### PR TITLE
devops/build docker image with private module

### DIFF
--- a/.github/workflows/go-generate.yaml
+++ b/.github/workflows/go-generate.yaml
@@ -21,22 +21,25 @@ jobs:
       - name: Install moq
         run: go get github.com/matryer/moq
 
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.CICD_RSA_KEY }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS_GITHUB }}
+
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # This step will be removed once the tssd module is installed by go get
-      - name: Checkout tssd
-        uses: actions/checkout@v2
-        with:
-          repository: axelarnetwork/tssd
-          path: ./tssd
-          ssh-key: ${{ secrets.CICD_RSA_KEY }}
-
       - name: Check generated code up-to-date
         run: |
-          go generate ./...
+          git config --global url."git@github.com:axelarnetwork".insteadOf https://github.com/axelarnetwork
+
+          go generate -x ./...
 
           if [ -n "$(git status --porcelain)" ]; then
+            echo Following files are changed...
+            git status
+
             exit 1;
           else
             exit 0;

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,16 +19,17 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.CICD_RSA_KEY }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS_GITHUB }}
+
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # This step will be removed once the tssd module is installed by go get
-      - name: Checkout tssd
-        uses: actions/checkout@v2
-        with:
-          repository: axelarnetwork/tssd
-          path: ./tssd
-          ssh-key: ${{ secrets.CICD_RSA_KEY }}
-
       - name: Test
-        run: go test ./...
+        run: |
+          git config --global url."git@github.com:axelarnetwork".insteadOf https://github.com/axelarnetwork
+
+          go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,27 @@
-FROM golang:1.15 as build
+# syntax=docker/dockerfile:experimental
+
+FROM golang:1.15-alpine3.12 as build
+
+RUN apk add --no-cache --update \
+  openssh-client \
+  git \
+  ca-certificates \
+  make
+
 WORKDIR axelar
-COPY ./tssd ./tssd
+
+RUN git config --global url."git@github.com:axelarnetwork".insteadOf https://github.com/axelarnetwork
+RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+
 COPY ./go.mod .
 COPY ./go.sum .
-RUN go mod download
-COPY . .
+RUN --mount=type=ssh go mod download
 
+COPY . .
 ENV CGO_ENABLED=0
 RUN make build
 
 FROM alpine:3.12
+
 COPY --from=build /go/axelar/bin/axelar* /root/
 ENV PATH="/root:${PATH}"

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,12 +1,19 @@
+# syntax=docker/dockerfile:experimental
+
 FROM golang:1.15 as debug
+
 WORKDIR axelar
+
 RUN go get github.com/go-delve/delve/cmd/dlv
-COPY ./tssd ./tssd
+
+RUN git config --global url."git@github.com:axelarnetwork".insteadOf https://github.com/axelarnetwork
+RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+
 COPY ./go.mod .
 COPY ./go.sum .
-RUN go mod download
-COPY . .
+RUN --mount=type=ssh go mod download
 
+COPY . .
 RUN make debug
 RUN cp /go/axelar/bin/axelar* /root/
 ENV PATH="/root:${PATH}"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=axelar \
 	-X github.com/cosmos/cosmos-sdk/version.ServerName=axelard \
 	-X github.com/cosmos/cosmos-sdk/version.ClientName=axelarcli \
 	-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
-	-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) 
+	-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT)
 
 BUILD_FLAGS := -ldflags '$(ldflags)'
 
@@ -45,13 +45,8 @@ debug: go.sum
 
 .PHONY: docker-image
 docker-image:
-	@docker build -t axelar/core .
+	@DOCKER_BUILDKIT=1 docker build --ssh default -t axelar/core .
 
 .PHONY: docker-image-debug
 docker-image-debug:
-	@docker build -t axelar/core-debug -f ./Dockerfile.debug .
-
-.PHONY: copy-tssd
-copy-tssd:
-	@rsync -ru ../tssd ./
-
+	@DOCKER_BUILDKIT=1 docker build --ssh default -t axelar/core-debug -f ./Dockerfile.debug .

--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@
 
 The axelar-core app based on the Cosmos SDK is the main application of the axelar network.
 This repository is used to build the necessary binaries and docker image to run a core validator.
-See the axelarnetwork/axelarate repo for instructions to run a node. 
+See the axelarnetwork/axelarate repo for instructions to run a node.
+
+## Prerequisites for building binaries and docker images
+Since axelar-core requires tssd to build which is a private module, you will need to
+
+1. Have a SSH key on your machine
+2. Add your public key to your Github account for authentication
+3. Run `ssh-add ~/.ssh/{private key file name}` to add your private key to your ssh agent
+4. Run `git config --global url."git@github.com:axelarnetwork".insteadOf https://github.com/axelarnetwork` to force `go get` to authenticate via ssh
 
 ## Building binaries locally
 
-Execute `make build` to create local binaries for the validator node. 
+Execute `make build` to create local binaries for the validator node.
 They are created in the `./bin` folder.
 
 ## Creating docker images
@@ -23,8 +31,8 @@ Run `./bin/axelarcli --help` after building the binaries to get information abou
 ## Show API documentation
 Execute `GO111MODULE=off go get -u golang.org/x/tools/cmd/godoc` to ensure that `godoc` is installed on the host.
 
-After the installation, execute `godoc -http ":{port}" -index` to host a local godoc server. For example, with port `8080` the documentation is hosted at 
+After the installation, execute `godoc -http ":{port}" -index` to host a local godoc server. For example, with port `8080` the documentation is hosted at
 http://localhost:8080/pkg/github.com/axelarnetwork/axelar-core. The index flag makes the documentation searchable.
 
-Comments at the beginning of packages, before types and before functions are automatically taken from the source files to populate the documentation. 
+Comments at the beginning of packages, before types and before functions are automatically taken from the source files to populate the documentation.
 See https://blog.golang.org/godoc for more information.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/axelarnetwork/axelar-core
 go 1.13
 
 require (
-	github.com/axelarnetwork/tssd v0.0.0-00010101000000-000000000000
+	github.com/axelarnetwork/tssd v0.0.0-20210107210332-7e3f2d78ef7e
 	github.com/binance-chain/tss-lib v1.3.2 // for tests only
 	github.com/btcsuite/btcd v0.21.0-beta
 	github.com/btcsuite/btcutil v1.0.2
@@ -20,5 +20,3 @@ require (
 )
 
 replace github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // https://github.com/axelarnetwork/axelar-core/issues/36
-
-replace github.com/axelarnetwork/tssd => ./tssd

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6l
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
+github.com/axelarnetwork/tssd v0.0.0-20210107210332-7e3f2d78ef7e h1:aMNGe6kkidEkTQEbxnTkJx+pARhn1XtKysB0DqY6GNk=
+github.com/axelarnetwork/tssd v0.0.0-20210107210332-7e3f2d78ef7e/go.mod h1:mcE7nB9jwd8jwmO8kVkVxpPdwgThZ5bjvMNNM/C7Ztg=
 github.com/bartekn/go-bip39 v0.0.0-20171116152956-a05967ea095d h1:1aAija9gr0Hyv4KfQcRcwlmFIrhkDmIj2dz5bkg/s/8=
 github.com/bartekn/go-bip39 v0.0.0-20171116152956-a05967ea095d/go.mod h1:icNx/6QdFblhsEjZehARqbNumymUT/ydwlLojFdv7Sk=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
Fixed downloading private axelarnetwork module in the Dockerfile with ssh agent forwarding so that you don't need to copy your local tssd anymore to build the docker image. You may have run `ssh-add ~/.ssh/id_rsa` to let your ssh agent to know your key.