### PR TITLE
fix network mismatch and wait for warmup

### DIFF
--- a/x/bitcoin/handler_test.go
+++ b/x/bitcoin/handler_test.go
@@ -496,9 +496,7 @@ func TestSignTx(t *testing.T) {
 			hash := tx.TxHash()
 			return &hash, nil
 		},
-		NetworkFunc: func() types.Network {
-			return types.Network(chaincfg.MainNetParams.Name)
-		}}
+		NetworkFunc: func() types.Network { return types.Mainnet }}
 	b := &btcMock.BalancerMock{}
 	snap := &btcMock.SnapshotterMock{GetSnapshotFunc: func(ctx sdk.Context, round int64) (snapshot.Snapshot, bool) {
 		return snapshot.Snapshot{}, true

--- a/x/bitcoin/keeper/keeper.go
+++ b/x/bitcoin/keeper/keeper.go
@@ -171,7 +171,7 @@ func (k Keeper) GenerateDepositAddressAndRedeemScript(ctx sdk.Context, pk btcec.
 		return nil, nil, err
 	}
 	hash := sha256.Sum256(redeemScript)
-	addr, err := btcutil.NewAddressWitnessScriptHash(hash[:], k.getNetwork(ctx).Params())
+	addr, err := btcutil.NewAddressWitnessScriptHash(hash[:], k.getNetwork(ctx).Params)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -231,7 +231,7 @@ func (k Keeper) getDepositAddress(ctx sdk.Context, outpoint *wire.OutPoint) (btc
 	if !ok {
 		return nil, fmt.Errorf("transaction ID is not known")
 	}
-	addr, err := btcutil.DecodeAddress(out.DepositAddr, k.getNetwork(ctx).Params())
+	addr, err := btcutil.DecodeAddress(out.DepositAddr, k.getNetwork(ctx).Params)
 	if err != nil {
 		return nil, err
 	}

--- a/x/bitcoin/keeper/querier.go
+++ b/x/bitcoin/keeper/querier.go
@@ -106,7 +106,7 @@ func createRawTx(ctx sdk.Context, k Keeper, data []byte) ([]byte, error) {
 		return nil, sdkerrors.Wrap(types.ErrBitcoin, err.Error())
 	}
 
-	recipient, err := btcutil.DecodeAddress(params.DepositAddr, k.getNetwork(ctx).Params())
+	recipient, err := btcutil.DecodeAddress(params.DepositAddr, k.getNetwork(ctx).Params)
 	if err != nil {
 		return nil, sdkerrors.Wrap(types.ErrBitcoin, err.Error())
 	}

--- a/x/bitcoin/module.go
+++ b/x/bitcoin/module.go
@@ -89,11 +89,11 @@ func (am AppModule) InitGenesis(ctx sdk.Context, message json.RawMessage) []abci
 	var genesisState types.GenesisState
 	types.ModuleCdc.MustUnmarshalJSON(message, &genesisState)
 	actualNetwork := am.rpc.Network()
-	if genesisState.Params.Network != actualNetwork {
+	if genesisState.Params.Network.Params.Name != actualNetwork.Params.Name {
 		panic(fmt.Sprintf(
 			"local bitcoin client not configured correctly: expected network %s, got %s",
-			genesisState.Params.Network,
-			actualNetwork,
+			genesisState.Params.Network.Params.Name,
+			actualNetwork.Params.Name,
 		))
 	}
 	InitGenesis(ctx, am.keeper, genesisState)

--- a/x/bitcoin/types/rpcClient.go
+++ b/x/bitcoin/types/rpcClient.go
@@ -104,10 +104,10 @@ func (r *RPCClientImpl) setNetwork(logger log.Logger) error {
 	var retries int
 
 	// Ensure the loop is run at least once
-	var err error = btcjson.RPCError{Code: errRpcInWarmup}
+	var err error = &btcjson.RPCError{Code: errRpcInWarmup}
 	for retries = 0; err != nil && retries < maxRetries; retries++ {
 		switch err := err.(type) {
-		case btcjson.RPCError:
+		case *btcjson.RPCError:
 			if err.Code == errRpcInWarmup {
 				logger.Debug("waiting for bitcoin rpc server to start")
 				time.Sleep(sleep)
@@ -125,8 +125,8 @@ func (r *RPCClientImpl) setNetwork(logger log.Logger) error {
 		if info == nil {
 			return fmt.Errorf("bitcoin blockchain info is nil")
 		}
-		r.network = Network(info.Chain)
-		return nil
+		r.network, err = NetworkFromStr(info.Chain)
+		return err
 	} else {
 		return sdkerrors.Wrap(ErrTimeOut, "could not establish a connection to the bitcoin node")
 	}

--- a/x/bitcoin/types/types.go
+++ b/x/bitcoin/types/types.go
@@ -15,12 +15,10 @@ import (
 )
 
 var (
-	Mainnet  = Network(chaincfg.MainNetParams.Name)
-	Testnet3 = Network(chaincfg.TestNet3Params.Name)
-	Regtest  = Network(chaincfg.RegressionNetParams.Name)
+	Mainnet  = Network{&chaincfg.MainNetParams}
+	Testnet3 = Network{&chaincfg.TestNet3Params}
+	Regtest  = Network{&chaincfg.RegressionNetParams}
 )
-
-type Mode int
 
 // OutPointInfo describes all the necessary information to verify the outPoint of a transaction
 type OutPointInfo struct {
@@ -53,29 +51,30 @@ func (i OutPointInfo) Equals(other OutPointInfo) bool {
 }
 
 // Network provides additional functionality based on the bitcoin network name
-type Network string
+type Network struct {
+	// Params returns the configuration parameters associated with the chain
+	Params *chaincfg.Params
+}
+
+func NetworkFromStr(net string) (Network, error) {
+	switch net {
+	case "main":
+		return Network{&chaincfg.MainNetParams}, nil
+	case "test":
+		return Network{&chaincfg.TestNet3Params}, nil
+	case "regtest":
+		return Network{&chaincfg.RegressionNetParams}, nil
+	default:
+		return Network{}, fmt.Errorf("unknown network: %s", net)
+	}
+}
 
 // Validate checks if the object is a valid chain
 func (n Network) Validate() error {
-	if n.Params() == nil {
-		return fmt.Errorf("network could not be parsed, choose %s, %s, or %s",
-			Mainnet, Testnet3, Regtest)
+	if n.Params == nil {
+		return fmt.Errorf("network could not be parsed, choose main, test, or regtest")
 	}
 	return nil
-}
-
-// Params returns the configuration parameters associated with the chain
-func (n Network) Params() *chaincfg.Params {
-	switch n {
-	case Mainnet:
-		return &chaincfg.MainNetParams
-	case Testnet3:
-		return &chaincfg.TestNet3Params
-	case Regtest:
-		return &chaincfg.RegressionNetParams
-	default:
-		return nil
-	}
 }
 
 type RawTxParams struct {

--- a/x/tests/keyRotation_test.go
+++ b/x/tests/keyRotation_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/axelarnetwork/tssd/convert"
 	tssd "github.com/axelarnetwork/tssd/pb"
 	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -484,9 +483,7 @@ func createMocks() testMocks {
 			hash := tx.TxHash()
 			return &hash, nil
 		},
-		NetworkFunc: func() btcTypes.Network {
-			return btcTypes.Network(chaincfg.MainNetParams.Name)
-		}}
+		NetworkFunc: func() btcTypes.Network { return btcTypes.Mainnet }}
 
 	keygen := &tssdMock.TSSDKeyGenClientMock{}
 	sign := &tssdMock.TSSDSignClientMock{}


### PR DESCRIPTION
1. axelar wasn't waiting for the btc bridge because it was listening for the wrong error type (value instead of pointer...)
2. bitcoins chain naming scheme is "main", "test", "regtest", while btcd uses "mainnet", "testnet3" and "regtest". Introduced a mapping between the two