### PR TITLE
bug:concurrent setup

### DIFF
--- a/cmd/axelarcli/docs/axelarcli_tx_broadcast.md
+++ b/cmd/axelarcli/docs/axelarcli_tx_broadcast.md
@@ -26,3 +26,4 @@ axelarcli tx broadcast [flags]
 
 - [axelarcli tx](axelarcli_tx.md)	 - Transactions subcommands
 - [axelarcli tx broadcast registerProxy](axelarcli_tx_broadcast_registerProxy.md)	 - Register a proxy account for a specific validator principal to broadcast transactions in its stead
+- [axelarcli tx broadcast sendStake](axelarcli_tx_broadcast_sendStake.md)	 - Sends the specified amount of stake to the designated addresses

--- a/cmd/axelarcli/docs/axelarcli_tx_broadcast_sendStake.md
+++ b/cmd/axelarcli/docs/axelarcli_tx_broadcast_sendStake.md
@@ -1,0 +1,44 @@
+## axelarcli tx broadcast sendStake
+
+Sends the specified amount of stake to the designated addresses
+
+### Synopsis
+
+Sends the specified amount of stake to the designated addresses
+
+```
+axelarcli tx broadcast sendStake [amount] [address 1] ... [address n] [flags]
+```
+
+### Options
+
+```
+  -a, --account-number uint      The account number of the signing account (offline mode only)
+  -b, --broadcast-mode string    Transaction broadcasting mode (sync|async|block) (default "sync")
+      --dry-run                  ignore the --gas flag and perform a simulation of a transaction, but don't broadcast it
+      --fees string              Fees to pay along with transaction; eg: 10uatom
+      --from string              Name or address of private key with which to sign
+      --gas string               gas limit to set per-transaction; set to "auto" to calculate required gas automatically (default 200000) (default "200000")
+      --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
+      --gas-prices string        Gas prices to determine the transaction fee (e.g. 10uatom)
+      --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible and the node operates offline)
+  -h, --help                     help for sendStake
+      --indent                   Add indent to JSON response
+      --keyring-backend string   Select keyring's backend (os|file|test) (default "os")
+      --ledger                   Use a connected Ledger device
+      --memo string              Memo to send along with transaction
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+  -s, --sequence uint            The sequence number of the signing account (offline mode only)
+      --trust-node               Trust connected full node (don't verify proofs for responses) (default true)
+  -y, --yes                      Skip tx broadcasting prompt confirmation
+```
+
+### Options inherited from parent commands
+
+```
+      --chain-id string   Network ID of tendermint node
+```
+
+### SEE ALSO
+
+- [axelarcli tx broadcast](axelarcli_tx_broadcast.md)	 - broadcast transactions subcommands

--- a/cmd/axelarcli/docs/toc.md
+++ b/cmd/axelarcli/docs/toc.md
@@ -69,6 +69,7 @@
       - [verifyTx \[txInfo json\]](axelarcli_tx_bitcoin_verifyTx.md)	 - Verify a Bitcoin transaction
     - [broadcast](axelarcli_tx_broadcast.md)	 - broadcast transactions subcommands
       - [registerProxy \[proxy\] ](axelarcli_tx_broadcast_registerProxy.md)	 - Register a proxy account for a specific validator principal to broadcast transactions in its stead
+      - [sendStake \[amount\] \[address 1\] ... \[address n\]](axelarcli_tx_broadcast_sendStake.md)	 - Sends the specified amount of stake to the designated addresses
     - [decode \[amino-byte-string\]](axelarcli_tx_decode.md)	 - Decode an amino-encoded transaction string.
     - [distribution](axelarcli_tx_distribution.md)	 - Distribution transactions subcommands
       - [fund-community-pool \[amount\]](axelarcli_tx_distribution_fund-community-pool.md)	 - Funds the community pool with the specified amount


### PR DESCRIPTION
This pull request introduces a new command into the broadcast module, that receives multiple addresses and the amount of stake to be transferred to them. It is intended to enable validator setup to be done concurrently across validators.