### PR TITLE
fix(ethereum): retrieving the snapshot for specific keyid before signing

### DIFF
--- a/x/ethereum/handler.go
+++ b/x/ethereum/handler.go
@@ -169,9 +169,13 @@ func handleMsgSignPendingTransfersTx(ctx sdk.Context, k keeper.Keeper, signer ty
 		return nil, sdkerrors.Wrapf(types.ErrEthereum, "no master key for chain %s found", exported.Ethereum.Name)
 	}
 
-	s, ok := snap.GetLatestSnapshot(ctx)
+	counter, ok := signer.GetSnapshotCounterForKeyID(ctx, keyID)
 	if !ok {
-		return nil, sdkerrors.Wrap(types.ErrEthereum, "no snapshot found")
+		return nil, sdkerrors.Wrapf(types.ErrEthereum, "no snapshot counter for key ID %s registered", keyID)
+	}
+	s, ok := snap.GetSnapshot(ctx, counter)
+	if !ok {
+		return nil, sdkerrors.Wrapf(types.ErrEthereum, "no snapshot found")
 	}
 
 	commandIDHex := hex.EncodeToString(commandID[:])
@@ -311,9 +315,13 @@ func handleMsgSignDeployToken(ctx sdk.Context, k keeper.Keeper, signer types.Sig
 		return nil, sdkerrors.Wrapf(types.ErrEthereum, "no master key for chain %s found", exported.Ethereum.Name)
 	}
 
-	s, ok := snap.GetLatestSnapshot(ctx)
+	counter, ok := signer.GetSnapshotCounterForKeyID(ctx, keyID)
 	if !ok {
-		return nil, sdkerrors.Wrap(types.ErrEthereum, "no snapshot found")
+		return nil, sdkerrors.Wrapf(types.ErrEthereum, "no snapshot counter for key ID %s registered", keyID)
+	}
+	s, ok := snap.GetSnapshot(ctx, counter)
+	if !ok {
+		return nil, sdkerrors.Wrapf(types.ErrEthereum, "no snapshot found")
 	}
 
 	commandIDHex := hex.EncodeToString(commandID[:])
@@ -370,10 +378,15 @@ func handleMsgSignTx(ctx sdk.Context, k keeper.Keeper, signer types.Signer, snap
 		return nil, sdkerrors.Wrapf(types.ErrEthereum, "no master key for chain %s found", exported.Ethereum.Name)
 	}
 
-	s, ok := snap.GetLatestSnapshot(ctx)
+	counter, ok := signer.GetSnapshotCounterForKeyID(ctx, keyID)
 	if !ok {
-		return nil, sdkerrors.Wrap(types.ErrEthereum, "no snapshot found")
+		return nil, sdkerrors.Wrapf(types.ErrEthereum, "no snapshot counter for key ID %s registered", keyID)
 	}
+	s, ok := snap.GetSnapshot(ctx, counter)
+	if !ok {
+		return nil, sdkerrors.Wrapf(types.ErrEthereum, "no snapshot found")
+	}
+
 	err = signer.StartSign(ctx, keyID, txID, hash.Bytes(), s.Validators)
 	if err != nil {
 		return nil, sdkerrors.Wrap(types.ErrEthereum, err.Error())

--- a/x/ethereum/types/expected_keepers.go
+++ b/x/ethereum/types/expected_keepers.go
@@ -39,6 +39,7 @@ type Signer interface {
 	GetCurrentMasterKey(ctx sdk.Context, chain exported.Chain) (ecdsa.PublicKey, bool)
 	GetNextMasterKey(ctx sdk.Context, chain exported.Chain) (ecdsa.PublicKey, bool)
 	GetKeyForSigID(ctx sdk.Context, sigID string) (ecdsa.PublicKey, bool)
+	GetSnapshotCounterForKeyID(ctx sdk.Context, keyID string) (int64, bool)
 }
 
 // Snapshotter provides snapshot functionality

--- a/x/ethereum/types/mock/expected_keepers.go
+++ b/x/ethereum/types/mock/expected_keepers.go
@@ -303,6 +303,9 @@ var _ types.Signer = &SignerMock{}
 // 			GetSigFunc: func(ctx sdk.Context, sigID string) (tss.Signature, bool) {
 // 				panic("mock out the GetSig method")
 // 			},
+// 			GetSnapshotCounterForKeyIDFunc: func(ctx sdk.Context, keyID string) (int64, bool) {
+// 				panic("mock out the GetSnapshotCounterForKeyID method")
+// 			},
 // 			StartSignFunc: func(ctx sdk.Context, keyID string, sigID string, msg []byte, validators []snapshot.Validator) error {
 // 				panic("mock out the StartSign method")
 // 			},
@@ -330,6 +333,9 @@ type SignerMock struct {
 
 	// GetSigFunc mocks the GetSig method.
 	GetSigFunc func(ctx sdk.Context, sigID string) (tss.Signature, bool)
+
+	// GetSnapshotCounterForKeyIDFunc mocks the GetSnapshotCounterForKeyID method.
+	GetSnapshotCounterForKeyIDFunc func(ctx sdk.Context, keyID string) (int64, bool)
 
 	// StartSignFunc mocks the StartSign method.
 	StartSignFunc func(ctx sdk.Context, keyID string, sigID string, msg []byte, validators []snapshot.Validator) error
@@ -378,6 +384,13 @@ type SignerMock struct {
 			// SigID is the sigID argument value.
 			SigID string
 		}
+		// GetSnapshotCounterForKeyID holds details about calls to the GetSnapshotCounterForKeyID method.
+		GetSnapshotCounterForKeyID []struct {
+			// Ctx is the ctx argument value.
+			Ctx sdk.Context
+			// KeyID is the keyID argument value.
+			KeyID string
+		}
 		// StartSign holds details about calls to the StartSign method.
 		StartSign []struct {
 			// Ctx is the ctx argument value.
@@ -392,13 +405,14 @@ type SignerMock struct {
 			Validators []snapshot.Validator
 		}
 	}
-	lockGetCurrentMasterKey   sync.RWMutex
-	lockGetCurrentMasterKeyID sync.RWMutex
-	lockGetKey                sync.RWMutex
-	lockGetKeyForSigID        sync.RWMutex
-	lockGetNextMasterKey      sync.RWMutex
-	lockGetSig                sync.RWMutex
-	lockStartSign             sync.RWMutex
+	lockGetCurrentMasterKey        sync.RWMutex
+	lockGetCurrentMasterKeyID      sync.RWMutex
+	lockGetKey                     sync.RWMutex
+	lockGetKeyForSigID             sync.RWMutex
+	lockGetNextMasterKey           sync.RWMutex
+	lockGetSig                     sync.RWMutex
+	lockGetSnapshotCounterForKeyID sync.RWMutex
+	lockStartSign                  sync.RWMutex
 }
 
 // GetCurrentMasterKey calls GetCurrentMasterKeyFunc.
@@ -608,6 +622,41 @@ func (mock *SignerMock) GetSigCalls() []struct {
 	mock.lockGetSig.RLock()
 	calls = mock.calls.GetSig
 	mock.lockGetSig.RUnlock()
+	return calls
+}
+
+// GetSnapshotCounterForKeyID calls GetSnapshotCounterForKeyIDFunc.
+func (mock *SignerMock) GetSnapshotCounterForKeyID(ctx sdk.Context, keyID string) (int64, bool) {
+	if mock.GetSnapshotCounterForKeyIDFunc == nil {
+		panic("SignerMock.GetSnapshotCounterForKeyIDFunc: method is nil but Signer.GetSnapshotCounterForKeyID was just called")
+	}
+	callInfo := struct {
+		Ctx   sdk.Context
+		KeyID string
+	}{
+		Ctx:   ctx,
+		KeyID: keyID,
+	}
+	mock.lockGetSnapshotCounterForKeyID.Lock()
+	mock.calls.GetSnapshotCounterForKeyID = append(mock.calls.GetSnapshotCounterForKeyID, callInfo)
+	mock.lockGetSnapshotCounterForKeyID.Unlock()
+	return mock.GetSnapshotCounterForKeyIDFunc(ctx, keyID)
+}
+
+// GetSnapshotCounterForKeyIDCalls gets all the calls that were made to GetSnapshotCounterForKeyID.
+// Check the length with:
+//     len(mockedSigner.GetSnapshotCounterForKeyIDCalls())
+func (mock *SignerMock) GetSnapshotCounterForKeyIDCalls() []struct {
+	Ctx   sdk.Context
+	KeyID string
+} {
+	var calls []struct {
+		Ctx   sdk.Context
+		KeyID string
+	}
+	mock.lockGetSnapshotCounterForKeyID.RLock()
+	calls = mock.calls.GetSnapshotCounterForKeyID
+	mock.lockGetSnapshotCounterForKeyID.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
- instead of retrieving the latest snapshot for Ethereum, we retrieve the specific snapshot for the given keyID prior to calling the signing functions. 