### PR TITLE
fix(vald): panic on start up

### DIFF
--- a/cmd/vald/main.go
+++ b/cmd/vald/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -8,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/tendermint/tendermint/libs/cli"
+	"github.com/tendermint/tendermint/libs/log"
 	tmos "github.com/tendermint/tendermint/libs/os"
 
 	"github.com/axelarnetwork/axelar-core/app"
@@ -23,7 +25,7 @@ func main() {
 		Short: "Validator Daemon ",
 	}
 
-	startCommand := getStartCommand()
+	startCommand := getStartCommand(log.NewTMLogger(os.Stdout).With("external", "main"))
 	rootCmd.AddCommand(flags.PostCommands(startCommand)...)
 
 	setPersistentFlags(rootCmd)
@@ -45,7 +47,7 @@ func configurate() {
 
 func setPersistentFlags(rootCmd *cobra.Command) {
 	rootCmd.PersistentFlags().String(cliHomeFlag, app.DefaultCLIHome, "directory for cli config and data")
-	_ = viper.BindPFlag(cliHomeFlag, rootCmd.Flags().Lookup(cliHomeFlag))
+	_ = viper.BindPFlag(cliHomeFlag, rootCmd.PersistentFlags().Lookup(cliHomeFlag))
 
 	rootCmd.PersistentFlags().String("tofnd-host", "", "host name for tss daemon")
 	_ = viper.BindPFlag("tofnd_host", rootCmd.PersistentFlags().Lookup("tofnd-host"))

--- a/cmd/vald/start.go
+++ b/cmd/vald/start.go
@@ -27,7 +27,7 @@ import (
 	tss "github.com/axelarnetwork/axelar-core/x/tss/types"
 )
 
-func getStartCommand() *cobra.Command {
+func getStartCommand(logger log.Logger) *cobra.Command {
 	return &cobra.Command{
 		Use: "start",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -40,8 +40,6 @@ func getStartCommand() *cobra.Command {
 			if valAddr == "" {
 				tmos.Exit("validator address not set")
 			}
-
-			logger := log.NewTMLogger(os.Stdout).With("external", "main")
 
 			logger.Info("Start listening to events")
 			err = listen(hub, axConf, valAddr, logger)


### PR DESCRIPTION
Fixed panic triggered by viper package by moving `loadConfig` back inside of `getStartCommand`