### PR TITLE
refactor(tss): remove unnecessary handle-traffic methods and remove broadcaster as a dependency

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -286,7 +286,6 @@ func NewInitApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest b
 		app.cdc,
 		keys[tssTypes.StoreKey],
 		tssSubspace,
-		broadcastK,
 		slashingKCast,
 	)
 	snapK := snapKeeper.NewKeeper(
@@ -337,7 +336,7 @@ func NewInitApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest b
 		staking.NewAppModule(stakingK, accountK, supplyK),
 
 		snapshot.NewAppModule(snapK),
-		tss.NewAppModule(tssK, snapK, votingK, nexusK, stakingK),
+		tss.NewAppModule(tssK, snapK, votingK, nexusK, stakingK, broadcastK),
 		vote.NewAppModule(votingK),
 		broadcast.NewAppModule(broadcastK),
 		nexus.NewAppModule(nexusK),

--- a/x/tests/chainSetup.go
+++ b/x/tests/chainSetup.go
@@ -106,7 +106,6 @@ func newNode(moniker string, broadcaster fake.Broadcaster, mocks testMocks) *fak
 			sdk.NewKVStoreKey("tstorekey"),
 			tssTypes.DefaultParamspace,
 		),
-		broadcaster,
 		mocks.Slasher,
 	)
 	signer.SetParams(ctx, tssTypes.DefaultParams())
@@ -126,7 +125,7 @@ func newNode(moniker string, broadcaster fake.Broadcaster, mocks testMocks) *fak
 	snapHandler := snapshot.NewHandler(snapKeeper)
 	tssHandler := tss.NewHandler(signer, snapKeeper, nexusK, voter, &tssMock.StakingKeeperMock{
 		GetLastTotalPowerFunc: mocks.Staker.GetLastTotalPowerFunc,
-	})
+	}, broadcaster)
 	voteHandler := vote.NewHandler()
 
 	router = router.

--- a/x/tss/keeper/keeper.go
+++ b/x/tss/keeper/keeper.go
@@ -29,21 +29,19 @@ const (
 )
 
 type Keeper struct {
-	broadcaster types.Broadcaster
-	slasher     snapshot.Slasher
-	params      params.Subspace
-	storeKey    sdk.StoreKey
-	cdc         *codec.Codec
+	slasher  snapshot.Slasher
+	params   params.Subspace
+	storeKey sdk.StoreKey
+	cdc      *codec.Codec
 }
 
 // NewKeeper constructs a tss keeper
-func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey, paramSpace params.Subspace, broadcaster types.Broadcaster, slasher snapshot.Slasher) Keeper {
+func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey, paramSpace params.Subspace, slasher snapshot.Slasher) Keeper {
 	return Keeper{
-		broadcaster: broadcaster,
-		slasher:     slasher,
-		cdc:         cdc,
-		params:      paramSpace.WithKeyTable(types.KeyTable()),
-		storeKey:    storeKey,
+		slasher:  slasher,
+		cdc:      cdc,
+		params:   paramSpace.WithKeyTable(types.KeyTable()),
+		storeKey: storeKey,
 	}
 }
 

--- a/x/tss/keeper/keeperKeygen_test.go
+++ b/x/tss/keeper/keeperKeygen_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/axelarnetwork/axelar-core/x/tss/exported"
-	"github.com/axelarnetwork/axelar-core/x/tss/tofnd"
-	"github.com/axelarnetwork/axelar-core/x/tss/types"
 )
 
 func TestKeeper_StartKeygen_IdAlreadyInUse_ReturnError(t *testing.T) {
@@ -27,17 +25,6 @@ func TestKeeper_StartKeygen_IdAlreadyInUse_ReturnError(t *testing.T) {
 
 		err = s.Keeper.StartKeygen(s.Ctx, s.Voter, keyID, 1, snap)
 		assert.Error(t, err)
-	}
-}
-
-func TestKeeper_KeygenMsg_NoSessionWithGivenID_Error(t *testing.T) {
-	for _, keyID := range randDistinctStr.Take(100) {
-		s := setup(t)
-		assert.Error(t, s.Keeper.KeygenMsg(s.Ctx, types.MsgKeygenTraffic{
-			Sender:    s.Broadcaster.GetProxy(s.Ctx, s.Broadcaster.LocalPrincipal),
-			SessionID: keyID,
-			Payload:   &tofnd.TrafficOut{},
-		}))
 	}
 }
 

--- a/x/tss/keeper/keeperSign_test.go
+++ b/x/tss/keeper/keeperSign_test.go
@@ -11,9 +11,6 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/snapshot/exported"
 	snapshot "github.com/axelarnetwork/axelar-core/x/snapshot/exported"
 	snapMock "github.com/axelarnetwork/axelar-core/x/snapshot/exported/mock"
-	"github.com/axelarnetwork/axelar-core/x/tss/tofnd"
-
-	"github.com/axelarnetwork/axelar-core/x/tss/types"
 )
 
 func TestStartSign_NoEnoughActiveValidators(t *testing.T) {
@@ -69,14 +66,4 @@ func TestKeeper_StartSign_IdAlreadyInUse_ReturnError(t *testing.T) {
 	assert.NoError(t, err)
 	err = s.Keeper.StartSign(s.Ctx, s.Voter, keyID, sigID, msgToSign, exported.Snapshot{})
 	assert.Error(t, err)
-}
-
-func TestKeeper_SignMsg_NoSessionWithGivenID_Error(t *testing.T) {
-	s := setup(t)
-
-	assert.Error(t, s.Keeper.SignMsg(s.Ctx, types.MsgSignTraffic{
-		Sender:    s.Broadcaster.GetProxy(s.Ctx, s.Broadcaster.LocalPrincipal),
-		SessionID: "sigID",
-		Payload:   &tofnd.TrafficOut{},
-	}))
 }

--- a/x/tss/keeper/keeper_test.go
+++ b/x/tss/keeper/keeper_test.go
@@ -85,7 +85,7 @@ func setup(t *testing.T) *testSetup {
 		},
 	}
 
-	k := NewKeeper(testutils.Codec(), sdk.NewKVStoreKey("tss"), subspace, broadcaster, slasher)
+	k := NewKeeper(testutils.Codec(), sdk.NewKVStoreKey("tss"), subspace, slasher)
 	k.SetParams(ctx, types.DefaultParams())
 
 	setup.Keeper = k

--- a/x/tss/module.go
+++ b/x/tss/module.go
@@ -75,10 +75,11 @@ type AppModule struct {
 	voter       types.Voter
 	nexus       types.Nexus
 	staker      types.StakingKeeper
+	broadcaster types.Broadcaster
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(k keeper.Keeper, s types.Snapshotter, v types.Voter, n types.Nexus, sk types.StakingKeeper) AppModule {
+func NewAppModule(k keeper.Keeper, s types.Snapshotter, v types.Voter, n types.Nexus, sk types.StakingKeeper, broadcaster types.Broadcaster) AppModule {
 	return AppModule{
 		AppModuleBasic: AppModuleBasic{},
 		keeper:         k,
@@ -86,6 +87,7 @@ func NewAppModule(k keeper.Keeper, s types.Snapshotter, v types.Voter, n types.N
 		voter:          v,
 		nexus:          n,
 		staker:         sk,
+		broadcaster:    broadcaster,
 	}
 }
 
@@ -115,7 +117,7 @@ func (AppModule) Route() string {
 
 // NewHandler returns a new handler for this module
 func (am AppModule) NewHandler() sdk.Handler {
-	return NewHandler(am.keeper, am.snapshotter, am.nexus, am.voter, am.staker)
+	return NewHandler(am.keeper, am.snapshotter, am.nexus, am.voter, am.staker, am.broadcaster)
 }
 
 // QuerierRoute returns this module's query route


### PR DESCRIPTION
The reason for doing this PR is that I don't like doing logging and emitting events in keepers, but IMO those should be done in handlers. However, I left those `StartSign` because that function is used everywhere and I don't have a good solution to avoid duplicates. I also removed methods `SignMsg` and `KeygenMsg` since they are basically doing nothing related to the db but just performing some validations. 