### PR TITLE
fix(btc): prevent wrongful consolidation confirmation

### DIFF
--- a/x/bitcoin/handler_test.go
+++ b/x/bitcoin/handler_test.go
@@ -210,6 +210,7 @@ func TestHandleMsgVoteConfirmOutpoint(t *testing.T) {
 			DeletePendingOutPointInfoFunc: func(sdk.Context, vote.PollMeta) {},
 			CodecFunc:                     func() *codec.LegacyAmino { return types.ModuleCdc.LegacyAmino },
 			GetSignedTxFunc:               func(sdk.Context) (*wire.MsgTx, bool) { return nil, false },
+			GetMasterKeyVoutFunc:          func(sdk.Context) (uint32, bool) { return 0, false },
 		}
 		voter = &mock.VoterMock{
 			TallyVoteFunc:  func(sdk.Context, sdk.AccAddress, vote.PollMeta, vote.VotingData) error { return nil },
@@ -247,6 +248,9 @@ func TestHandleMsgVoteConfirmOutpoint(t *testing.T) {
 		msg.OutPoint = op.String()
 		btcKeeper.GetSignedTxFunc = func(sdk.Context) (*wire.MsgTx, bool) { return tx, true }
 		btcKeeper.DeleteSignedTxFunc = func(sdk.Context) {}
+		btcKeeper.GetMasterKeyVoutFunc = func(sdk.Context) (uint32, bool) {
+			return op.Index, true
+		}
 
 		_, err := HandleMsgVoteConfirmOutpoint(ctx, btcKeeper, voter, nexusKeeper, msg)
 		assert.NoError(t, err)
@@ -256,6 +260,31 @@ func TestHandleMsgVoteConfirmOutpoint(t *testing.T) {
 		assert.Equal(t, types.CONFIRMED, btcKeeper.SetOutpointInfoCalls()[0].State)
 		assert.Len(t, btcKeeper.DeleteSignedTxCalls(), 1)
 		assert.Len(t, nexusKeeper.EnqueueForTransferCalls(), 0)
+	}).Repeat(repeats))
+	t.Run("happy path confirm deposit in consolidation tx", testutils.Func(func(t *testing.T) {
+		setup()
+		tx := wire.NewMsgTx(wire.TxVersion)
+		hash := tx.TxHash()
+		op := wire.NewOutPoint(&hash, info.GetOutPoint().Index)
+		info.OutPoint = op.String()
+		msg.OutPoint = op.String()
+		btcKeeper.GetSignedTxFunc = func(sdk.Context) (*wire.MsgTx, bool) { return tx, true }
+		btcKeeper.DeleteSignedTxFunc = func(sdk.Context) {}
+		btcKeeper.GetMasterKeyVoutFunc = func(sdk.Context) (uint32, bool) {
+			return uint32(
+					rand.I64GenBetween(0, int64(^uint32(0))). // random uint32
+											Where(func(i int64) bool { return i != int64(op.Index) }).Next()),
+				true
+		}
+
+		_, err := HandleMsgVoteConfirmOutpoint(ctx, btcKeeper, voter, nexusKeeper, msg)
+		assert.NoError(t, err)
+		assert.Len(t, voter.DeletePollCalls(), 1)
+		assert.Len(t, btcKeeper.DeletePendingOutPointInfoCalls(), 1)
+		assert.Equal(t, info, btcKeeper.SetOutpointInfoCalls()[0].Info)
+		assert.Equal(t, types.CONFIRMED, btcKeeper.SetOutpointInfoCalls()[0].State)
+		assert.Len(t, btcKeeper.DeleteSignedTxCalls(), 0)
+		assert.Len(t, nexusKeeper.EnqueueForTransferCalls(), 1)
 	}).Repeat(repeats))
 
 	t.Run("happy path reject", testutils.Func(func(t *testing.T) {
@@ -414,15 +443,15 @@ func TestHandleMsgSignPendingTransfers(t *testing.T) {
 		secondaryKey := tss.Key{ID: rand.StrBetween(5, 20), Value: secondaryPrivateKey.PublicKey, Role: tss.SecondaryKey}
 
 		btcKeeper = &mock.BTCKeeperMock{
-			GetUnsignedTxFunc:              func(sdk.Context) (*wire.MsgTx, bool) { return nil, false },
-			GetSignedTxFunc:                func(sdk.Context) (*wire.MsgTx, bool) { return nil, false },
-			GetNetworkFunc:                 func(sdk.Context) types.Network { return types.Mainnet },
-			LoggerFunc:                     func(sdk.Context) log.Logger { return log.TestingLogger() },
-			GetConfirmedOutPointInfosFunc:  func(sdk.Context) []types.OutPointInfo { return deposits },
-			DeleteOutpointInfoFunc:         func(sdk.Context, wire.OutPoint) {},
-			SetOutpointInfoFunc:            func(sdk.Context, types.OutPointInfo, types.OutPointState) {},
-			DoesMasterKeyOutpointExistFunc: func(sdk.Context) bool { return false },
-			SetMasterKeyOutpointExistsFunc: func(sdk.Context) {},
+			GetUnsignedTxFunc:             func(sdk.Context) (*wire.MsgTx, bool) { return nil, false },
+			GetSignedTxFunc:               func(sdk.Context) (*wire.MsgTx, bool) { return nil, false },
+			GetNetworkFunc:                func(sdk.Context) types.Network { return types.Mainnet },
+			LoggerFunc:                    func(sdk.Context) log.Logger { return log.TestingLogger() },
+			GetConfirmedOutPointInfosFunc: func(sdk.Context) []types.OutPointInfo { return deposits },
+			DeleteOutpointInfoFunc:        func(sdk.Context, wire.OutPoint) {},
+			SetOutpointInfoFunc:           func(sdk.Context, types.OutPointInfo, types.OutPointState) {},
+			GetMasterKeyVoutFunc:          func(sdk.Context) (uint32, bool) { return 0, false },
+			SetMasterKeyVoutFunc:          func(sdk.Context, uint32) {},
 			GetAddressFunc: func(_ sdk.Context, encodedAddress string) (types.AddressInfo, bool) {
 				sk, _ := ecdsa.GenerateKey(btcec.S256(), cryptoRand.Reader)
 				return types.AddressInfo{
@@ -510,7 +539,7 @@ func TestHandleMsgSignPendingTransfers(t *testing.T) {
 		assert.Len(t, nexusKeeper.ArchivePendingTransferCalls(), len(transfers))
 		assert.Len(t, btcKeeper.DeleteOutpointInfoCalls(), len(deposits))
 		assert.Len(t, btcKeeper.SetOutpointInfoCalls(), len(deposits))
-		assert.Len(t, btcKeeper.SetMasterKeyOutpointExistsCalls(), 1)
+		assert.Len(t, btcKeeper.SetMasterKeyVoutCalls(), 1)
 		mapi(len(btcKeeper.SetOutpointInfoCalls()), func(i int) { assert.Equal(t, types.SPENT, btcKeeper.SetOutpointInfoCalls()[i].State) })
 		assert.Len(t, signer.StartSignCalls(), len(deposits))
 
@@ -528,7 +557,7 @@ func TestHandleMsgSignPendingTransfers(t *testing.T) {
 		assert.Len(t, nexusKeeper.ArchivePendingTransferCalls(), len(transfers))
 		assert.Len(t, btcKeeper.DeleteOutpointInfoCalls(), len(deposits))
 		assert.Len(t, btcKeeper.SetOutpointInfoCalls(), len(deposits))
-		assert.Len(t, btcKeeper.SetMasterKeyOutpointExistsCalls(), 1)
+		assert.Len(t, btcKeeper.SetMasterKeyVoutCalls(), 1)
 		mapi(len(btcKeeper.SetOutpointInfoCalls()), func(i int) { assert.Equal(t, types.SPENT, btcKeeper.SetOutpointInfoCalls()[i].State) })
 		assert.Len(t, signer.StartSignCalls(), len(deposits))
 
@@ -551,7 +580,7 @@ func TestHandleMsgSignPendingTransfers(t *testing.T) {
 		assert.Len(t, nexusKeeper.ArchivePendingTransferCalls(), len(transfers)-wrongAddressCount)
 		assert.Len(t, btcKeeper.DeleteOutpointInfoCalls(), len(deposits))
 		assert.Len(t, btcKeeper.SetOutpointInfoCalls(), len(deposits))
-		assert.Len(t, btcKeeper.SetMasterKeyOutpointExistsCalls(), 1)
+		assert.Len(t, btcKeeper.SetMasterKeyVoutCalls(), 1)
 		mapi(len(btcKeeper.SetOutpointInfoCalls()), func(i int) { assert.Equal(t, types.SPENT, btcKeeper.SetOutpointInfoCalls()[i].State) })
 		assert.Len(t, signer.StartSignCalls(), len(deposits))
 	}).Repeat(repeatCount))
@@ -581,7 +610,7 @@ func TestHandleMsgSignPendingTransfers(t *testing.T) {
 		assert.Len(t, nexusKeeper.ArchivePendingTransferCalls(), len(transfers))
 		assert.Len(t, btcKeeper.DeleteOutpointInfoCalls(), len(deposits))
 		assert.Len(t, btcKeeper.SetOutpointInfoCalls(), len(deposits))
-		assert.Len(t, btcKeeper.SetMasterKeyOutpointExistsCalls(), 1)
+		assert.Len(t, btcKeeper.SetMasterKeyVoutCalls(), 1)
 		mapi(len(btcKeeper.SetOutpointInfoCalls()), func(i int) { assert.Equal(t, types.SPENT, btcKeeper.SetOutpointInfoCalls()[i].State) })
 		assert.Len(t, signer.StartSignCalls(), len(deposits))
 	}).Repeat(repeatCount))
@@ -603,7 +632,7 @@ func TestHandleMsgSignPendingTransfers(t *testing.T) {
 		assert.Len(t, nexusKeeper.ArchivePendingTransferCalls(), len(transfers))
 		assert.Len(t, btcKeeper.DeleteOutpointInfoCalls(), len(deposits))
 		assert.Len(t, btcKeeper.SetOutpointInfoCalls(), len(deposits))
-		assert.Len(t, btcKeeper.SetMasterKeyOutpointExistsCalls(), 1)
+		assert.Len(t, btcKeeper.SetMasterKeyVoutCalls(), 1)
 		mapi(len(btcKeeper.SetOutpointInfoCalls()), func(i int) { assert.Equal(t, types.SPENT, btcKeeper.SetOutpointInfoCalls()[i].State) })
 		assert.Len(t, signer.StartSignCalls(), len(deposits))
 	}).Repeat(repeatCount))
@@ -626,7 +655,7 @@ func TestHandleMsgSignPendingTransfers(t *testing.T) {
 		assert.Len(t, nexusKeeper.ArchivePendingTransferCalls(), len(transfers))
 		assert.Len(t, btcKeeper.DeleteOutpointInfoCalls(), len(deposits))
 		assert.Len(t, btcKeeper.SetOutpointInfoCalls(), len(deposits))
-		assert.Len(t, btcKeeper.SetMasterKeyOutpointExistsCalls(), 1)
+		assert.Len(t, btcKeeper.SetMasterKeyVoutCalls(), 1)
 		mapi(len(btcKeeper.SetOutpointInfoCalls()), func(i int) { assert.Equal(t, types.SPENT, btcKeeper.SetOutpointInfoCalls()[i].State) })
 		assert.Len(t, signer.StartSignCalls(), len(deposits))
 

--- a/x/bitcoin/keeper/keeper.go
+++ b/x/bitcoin/keeper/keeper.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"encoding/binary"
 	"fmt"
 
 	"github.com/btcsuite/btcd/wire"
@@ -22,9 +23,9 @@ const (
 	addrPrefix              = "addr_"
 	dustAmtPrefix           = "dust_"
 
-	unsignedTxKey          = "unsignedTx"
-	signedTxKey            = "signedTx"
-	masterKeyUtxoExistsKey = "master_key_utxo_exists"
+	unsignedTxKey    = "unsignedTx"
+	signedTxKey      = "signedTx"
+	masterKeyVoutKey = "master_key_vout"
 )
 
 var _ types.BTCKeeper = Keeper{}
@@ -268,7 +269,6 @@ func (k Keeper) SetDustAmount(ctx sdk.Context, encodedAddress string, amount btc
 
 // GetDustAmount returns the dust amount for a destination bitcoin address
 func (k Keeper) GetDustAmount(ctx sdk.Context, encodedAddress string) btcutil.Amount {
-
 	bz := ctx.KVStore(k.storeKey).Get([]byte(dustAmtPrefix + encodedAddress))
 	if bz == nil {
 		return 0
@@ -283,12 +283,18 @@ func (k Keeper) DeleteDustAmount(ctx sdk.Context, encodedAddress string) {
 	ctx.KVStore(k.storeKey).Delete([]byte(dustAmtPrefix + encodedAddress))
 }
 
-// SetMasterKeyOutpointExists sets existence for UTXO controlled by the master key
-func (k Keeper) SetMasterKeyOutpointExists(ctx sdk.Context) {
-	ctx.KVStore(k.storeKey).Set([]byte(masterKeyUtxoExistsKey), []byte{})
+// SetMasterKeyVout sets the index of the consolidation outpoint
+func (k Keeper) SetMasterKeyVout(ctx sdk.Context, vout uint32) {
+	bz := make([]byte, 4)
+	binary.LittleEndian.PutUint32(bz, vout)
+	ctx.KVStore(k.storeKey).Set([]byte(masterKeyVoutKey), bz)
 }
 
-// DoesMasterKeyOutpointExist returns true if there is any UTXO controlled by the master key; otherwise, false
-func (k Keeper) DoesMasterKeyOutpointExist(ctx sdk.Context) bool {
-	return ctx.KVStore(k.storeKey).Has([]byte(masterKeyUtxoExistsKey))
+// GetMasterKeyVout returns the index of the consolidation outpoint if there is any UTXO controlled by the master key; otherwise, false
+func (k Keeper) GetMasterKeyVout(ctx sdk.Context) (uint32, bool) {
+	bz := ctx.KVStore(k.storeKey).Get([]byte(masterKeyVoutKey))
+	if bz == nil {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint32(bz), true
 }

--- a/x/bitcoin/types/expected_keepers.go
+++ b/x/bitcoin/types/expected_keepers.go
@@ -50,8 +50,8 @@ type BTCKeeper interface {
 	SetDustAmount(ctx sdk.Context, encodedAddress string, amount btcutil.Amount)
 	DeleteDustAmount(ctx sdk.Context, encodedAddress string)
 
-	SetMasterKeyOutpointExists(ctx sdk.Context)
-	DoesMasterKeyOutpointExist(ctx sdk.Context) bool
+	SetMasterKeyVout(ctx sdk.Context, vout uint32)
+	GetMasterKeyVout(ctx sdk.Context) (uint32, bool)
 }
 
 // Voter is the interface that provides voting functionality

--- a/x/bitcoin/types/mock/expected_keepers.go
+++ b/x/bitcoin/types/mock/expected_keepers.go
@@ -1203,9 +1203,6 @@ var _ types.BTCKeeper = &BTCKeeperMock{}
 // 			DeleteUnsignedTxFunc: func(ctx sdk.Context)  {
 // 				panic("mock out the DeleteUnsignedTx method")
 // 			},
-// 			DoesMasterKeyOutpointExistFunc: func(ctx sdk.Context) bool {
-// 				panic("mock out the DoesMasterKeyOutpointExist method")
-// 			},
 // 			GetAddressFunc: func(ctx sdk.Context, encodedAddress string) (types.AddressInfo, bool) {
 // 				panic("mock out the GetAddress method")
 // 			},
@@ -1214,6 +1211,9 @@ var _ types.BTCKeeper = &BTCKeeperMock{}
 // 			},
 // 			GetDustAmountFunc: func(ctx sdk.Context, encodedAddress string) github_com_btcsuite_btcutil.Amount {
 // 				panic("mock out the GetDustAmount method")
+// 			},
+// 			GetMasterKeyVoutFunc: func(ctx sdk.Context) (uint32, bool) {
+// 				panic("mock out the GetMasterKeyVout method")
 // 			},
 // 			GetMinimumWithdrawalAmountFunc: func(ctx sdk.Context) github_com_btcsuite_btcutil.Amount {
 // 				panic("mock out the GetMinimumWithdrawalAmount method")
@@ -1254,8 +1254,8 @@ var _ types.BTCKeeper = &BTCKeeperMock{}
 // 			SetDustAmountFunc: func(ctx sdk.Context, encodedAddress string, amount github_com_btcsuite_btcutil.Amount)  {
 // 				panic("mock out the SetDustAmount method")
 // 			},
-// 			SetMasterKeyOutpointExistsFunc: func(ctx sdk.Context)  {
-// 				panic("mock out the SetMasterKeyOutpointExists method")
+// 			SetMasterKeyVoutFunc: func(ctx sdk.Context, vout uint32)  {
+// 				panic("mock out the SetMasterKeyVout method")
 // 			},
 // 			SetOutpointInfoFunc: func(ctx sdk.Context, info types.OutPointInfo, state types.OutPointState)  {
 // 				panic("mock out the SetOutpointInfo method")
@@ -1297,9 +1297,6 @@ type BTCKeeperMock struct {
 	// DeleteUnsignedTxFunc mocks the DeleteUnsignedTx method.
 	DeleteUnsignedTxFunc func(ctx sdk.Context)
 
-	// DoesMasterKeyOutpointExistFunc mocks the DoesMasterKeyOutpointExist method.
-	DoesMasterKeyOutpointExistFunc func(ctx sdk.Context) bool
-
 	// GetAddressFunc mocks the GetAddress method.
 	GetAddressFunc func(ctx sdk.Context, encodedAddress string) (types.AddressInfo, bool)
 
@@ -1308,6 +1305,9 @@ type BTCKeeperMock struct {
 
 	// GetDustAmountFunc mocks the GetDustAmount method.
 	GetDustAmountFunc func(ctx sdk.Context, encodedAddress string) github_com_btcsuite_btcutil.Amount
+
+	// GetMasterKeyVoutFunc mocks the GetMasterKeyVout method.
+	GetMasterKeyVoutFunc func(ctx sdk.Context) (uint32, bool)
 
 	// GetMinimumWithdrawalAmountFunc mocks the GetMinimumWithdrawalAmount method.
 	GetMinimumWithdrawalAmountFunc func(ctx sdk.Context) github_com_btcsuite_btcutil.Amount
@@ -1348,8 +1348,8 @@ type BTCKeeperMock struct {
 	// SetDustAmountFunc mocks the SetDustAmount method.
 	SetDustAmountFunc func(ctx sdk.Context, encodedAddress string, amount github_com_btcsuite_btcutil.Amount)
 
-	// SetMasterKeyOutpointExistsFunc mocks the SetMasterKeyOutpointExists method.
-	SetMasterKeyOutpointExistsFunc func(ctx sdk.Context)
+	// SetMasterKeyVoutFunc mocks the SetMasterKeyVout method.
+	SetMasterKeyVoutFunc func(ctx sdk.Context, vout uint32)
 
 	// SetOutpointInfoFunc mocks the SetOutpointInfo method.
 	SetOutpointInfoFunc func(ctx sdk.Context, info types.OutPointInfo, state types.OutPointState)
@@ -1402,11 +1402,6 @@ type BTCKeeperMock struct {
 			// Ctx is the ctx argument value.
 			Ctx sdk.Context
 		}
-		// DoesMasterKeyOutpointExist holds details about calls to the DoesMasterKeyOutpointExist method.
-		DoesMasterKeyOutpointExist []struct {
-			// Ctx is the ctx argument value.
-			Ctx sdk.Context
-		}
 		// GetAddress holds details about calls to the GetAddress method.
 		GetAddress []struct {
 			// Ctx is the ctx argument value.
@@ -1425,6 +1420,11 @@ type BTCKeeperMock struct {
 			Ctx sdk.Context
 			// EncodedAddress is the encodedAddress argument value.
 			EncodedAddress string
+		}
+		// GetMasterKeyVout holds details about calls to the GetMasterKeyVout method.
+		GetMasterKeyVout []struct {
+			// Ctx is the ctx argument value.
+			Ctx sdk.Context
 		}
 		// GetMinimumWithdrawalAmount holds details about calls to the GetMinimumWithdrawalAmount method.
 		GetMinimumWithdrawalAmount []struct {
@@ -1501,10 +1501,12 @@ type BTCKeeperMock struct {
 			// Amount is the amount argument value.
 			Amount github_com_btcsuite_btcutil.Amount
 		}
-		// SetMasterKeyOutpointExists holds details about calls to the SetMasterKeyOutpointExists method.
-		SetMasterKeyOutpointExists []struct {
+		// SetMasterKeyVout holds details about calls to the SetMasterKeyVout method.
+		SetMasterKeyVout []struct {
 			// Ctx is the ctx argument value.
 			Ctx sdk.Context
+			// Vout is the vout argument value.
+			Vout uint32
 		}
 		// SetOutpointInfo holds details about calls to the SetOutpointInfo method.
 		SetOutpointInfo []struct {
@@ -1552,10 +1554,10 @@ type BTCKeeperMock struct {
 	lockDeletePendingOutPointInfo     sync.RWMutex
 	lockDeleteSignedTx                sync.RWMutex
 	lockDeleteUnsignedTx              sync.RWMutex
-	lockDoesMasterKeyOutpointExist    sync.RWMutex
 	lockGetAddress                    sync.RWMutex
 	lockGetConfirmedOutPointInfos     sync.RWMutex
 	lockGetDustAmount                 sync.RWMutex
+	lockGetMasterKeyVout              sync.RWMutex
 	lockGetMinimumWithdrawalAmount    sync.RWMutex
 	lockGetNetwork                    sync.RWMutex
 	lockGetOutPointInfo               sync.RWMutex
@@ -1569,7 +1571,7 @@ type BTCKeeperMock struct {
 	lockLogger                        sync.RWMutex
 	lockSetAddress                    sync.RWMutex
 	lockSetDustAmount                 sync.RWMutex
-	lockSetMasterKeyOutpointExists    sync.RWMutex
+	lockSetMasterKeyVout              sync.RWMutex
 	lockSetOutpointInfo               sync.RWMutex
 	lockSetParams                     sync.RWMutex
 	lockSetPendingOutpointInfo        sync.RWMutex
@@ -1770,37 +1772,6 @@ func (mock *BTCKeeperMock) DeleteUnsignedTxCalls() []struct {
 	return calls
 }
 
-// DoesMasterKeyOutpointExist calls DoesMasterKeyOutpointExistFunc.
-func (mock *BTCKeeperMock) DoesMasterKeyOutpointExist(ctx sdk.Context) bool {
-	if mock.DoesMasterKeyOutpointExistFunc == nil {
-		panic("BTCKeeperMock.DoesMasterKeyOutpointExistFunc: method is nil but BTCKeeper.DoesMasterKeyOutpointExist was just called")
-	}
-	callInfo := struct {
-		Ctx sdk.Context
-	}{
-		Ctx: ctx,
-	}
-	mock.lockDoesMasterKeyOutpointExist.Lock()
-	mock.calls.DoesMasterKeyOutpointExist = append(mock.calls.DoesMasterKeyOutpointExist, callInfo)
-	mock.lockDoesMasterKeyOutpointExist.Unlock()
-	return mock.DoesMasterKeyOutpointExistFunc(ctx)
-}
-
-// DoesMasterKeyOutpointExistCalls gets all the calls that were made to DoesMasterKeyOutpointExist.
-// Check the length with:
-//     len(mockedBTCKeeper.DoesMasterKeyOutpointExistCalls())
-func (mock *BTCKeeperMock) DoesMasterKeyOutpointExistCalls() []struct {
-	Ctx sdk.Context
-} {
-	var calls []struct {
-		Ctx sdk.Context
-	}
-	mock.lockDoesMasterKeyOutpointExist.RLock()
-	calls = mock.calls.DoesMasterKeyOutpointExist
-	mock.lockDoesMasterKeyOutpointExist.RUnlock()
-	return calls
-}
-
 // GetAddress calls GetAddressFunc.
 func (mock *BTCKeeperMock) GetAddress(ctx sdk.Context, encodedAddress string) (types.AddressInfo, bool) {
 	if mock.GetAddressFunc == nil {
@@ -1899,6 +1870,37 @@ func (mock *BTCKeeperMock) GetDustAmountCalls() []struct {
 	mock.lockGetDustAmount.RLock()
 	calls = mock.calls.GetDustAmount
 	mock.lockGetDustAmount.RUnlock()
+	return calls
+}
+
+// GetMasterKeyVout calls GetMasterKeyVoutFunc.
+func (mock *BTCKeeperMock) GetMasterKeyVout(ctx sdk.Context) (uint32, bool) {
+	if mock.GetMasterKeyVoutFunc == nil {
+		panic("BTCKeeperMock.GetMasterKeyVoutFunc: method is nil but BTCKeeper.GetMasterKeyVout was just called")
+	}
+	callInfo := struct {
+		Ctx sdk.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockGetMasterKeyVout.Lock()
+	mock.calls.GetMasterKeyVout = append(mock.calls.GetMasterKeyVout, callInfo)
+	mock.lockGetMasterKeyVout.Unlock()
+	return mock.GetMasterKeyVoutFunc(ctx)
+}
+
+// GetMasterKeyVoutCalls gets all the calls that were made to GetMasterKeyVout.
+// Check the length with:
+//     len(mockedBTCKeeper.GetMasterKeyVoutCalls())
+func (mock *BTCKeeperMock) GetMasterKeyVoutCalls() []struct {
+	Ctx sdk.Context
+} {
+	var calls []struct {
+		Ctx sdk.Context
+	}
+	mock.lockGetMasterKeyVout.RLock()
+	calls = mock.calls.GetMasterKeyVout
+	mock.lockGetMasterKeyVout.RUnlock()
 	return calls
 }
 
@@ -2325,34 +2327,38 @@ func (mock *BTCKeeperMock) SetDustAmountCalls() []struct {
 	return calls
 }
 
-// SetMasterKeyOutpointExists calls SetMasterKeyOutpointExistsFunc.
-func (mock *BTCKeeperMock) SetMasterKeyOutpointExists(ctx sdk.Context) {
-	if mock.SetMasterKeyOutpointExistsFunc == nil {
-		panic("BTCKeeperMock.SetMasterKeyOutpointExistsFunc: method is nil but BTCKeeper.SetMasterKeyOutpointExists was just called")
+// SetMasterKeyVout calls SetMasterKeyVoutFunc.
+func (mock *BTCKeeperMock) SetMasterKeyVout(ctx sdk.Context, vout uint32) {
+	if mock.SetMasterKeyVoutFunc == nil {
+		panic("BTCKeeperMock.SetMasterKeyVoutFunc: method is nil but BTCKeeper.SetMasterKeyVout was just called")
 	}
 	callInfo := struct {
-		Ctx sdk.Context
+		Ctx  sdk.Context
+		Vout uint32
 	}{
-		Ctx: ctx,
+		Ctx:  ctx,
+		Vout: vout,
 	}
-	mock.lockSetMasterKeyOutpointExists.Lock()
-	mock.calls.SetMasterKeyOutpointExists = append(mock.calls.SetMasterKeyOutpointExists, callInfo)
-	mock.lockSetMasterKeyOutpointExists.Unlock()
-	mock.SetMasterKeyOutpointExistsFunc(ctx)
+	mock.lockSetMasterKeyVout.Lock()
+	mock.calls.SetMasterKeyVout = append(mock.calls.SetMasterKeyVout, callInfo)
+	mock.lockSetMasterKeyVout.Unlock()
+	mock.SetMasterKeyVoutFunc(ctx, vout)
 }
 
-// SetMasterKeyOutpointExistsCalls gets all the calls that were made to SetMasterKeyOutpointExists.
+// SetMasterKeyVoutCalls gets all the calls that were made to SetMasterKeyVout.
 // Check the length with:
-//     len(mockedBTCKeeper.SetMasterKeyOutpointExistsCalls())
-func (mock *BTCKeeperMock) SetMasterKeyOutpointExistsCalls() []struct {
-	Ctx sdk.Context
+//     len(mockedBTCKeeper.SetMasterKeyVoutCalls())
+func (mock *BTCKeeperMock) SetMasterKeyVoutCalls() []struct {
+	Ctx  sdk.Context
+	Vout uint32
 } {
 	var calls []struct {
-		Ctx sdk.Context
+		Ctx  sdk.Context
+		Vout uint32
 	}
-	mock.lockSetMasterKeyOutpointExists.RLock()
-	calls = mock.calls.SetMasterKeyOutpointExists
-	mock.lockSetMasterKeyOutpointExists.RUnlock()
+	mock.lockSetMasterKeyVout.RLock()
+	calls = mock.calls.SetMasterKeyVout
+	mock.lockSetMasterKeyVout.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
It was possible that someone could withdraw to a deposit address. In that case, the confirmation of that outpoint would succeed, because it was a known address. Furthermore, it would confirm the consolidation tx, because it matched the tx ID. Yet, the actual consolidation outpoint would remain unconfirmed, preventing any subsequent consolidation.

This change adds a check (by index) to differentiate withdrawals to deposit addresses and withdrawals to the consolidation address.