### PR TITLE
feat(btc): add address roles (#465)

### DIFF
--- a/x/bitcoin/handler.go
+++ b/x/bitcoin/handler.go
@@ -195,32 +195,48 @@ func HandleMsgVoteConfirmOutpoint(ctx sdk.Context, k types.BTCKeeper, v types.Vo
 		event.AppendAttributes(sdk.NewAttribute(sdk.AttributeKeyAction, types.AttributeValueConfirm)))
 
 	k.SetOutpointInfo(ctx, pendingOutPointInfo, types.CONFIRMED)
+	addr, ok := k.GetAddress(ctx, pendingOutPointInfo.Address)
+	if !ok {
+		return nil, fmt.Errorf("cannot confirm outpoint of unknown address")
+	}
 
-	// TODO: handle withdrawals to deposit or consolidation addresses (this is currently undefined behaviour),
-	//  i.e. multiple outpoints in the SignedTx need to be confirmed
+	switch addr.Role {
+	case types.DEPOSIT:
+		// handle cross-chain transfer
+		depositAddr := nexus.CrossChainAddress{Address: pendingOutPointInfo.Address, Chain: exported.Bitcoin}
+		amount := sdk.NewInt64Coin(exported.Bitcoin.NativeAsset, int64(pendingOutPointInfo.Amount))
+		if err := n.EnqueueForTransfer(ctx, depositAddr, amount); err != nil {
+			return nil, sdkerrors.Wrap(err, "cross-chain transfer failed")
+		}
 
-	// if this is the consolidation outpoint it means the latest consolidation transaction is confirmed on Bitcoin
-	tx, txExist := k.GetSignedTx(ctx)
-	vout, voutExist := k.GetMasterKeyVout(ctx)
-	outPoint := pendingOutPointInfo.GetOutPoint()
-	if txExist && voutExist && tx.TxHash() == outPoint.Hash && vout == outPoint.Index {
-		k.DeleteSignedTx(ctx)
 		return &sdk.Result{
 			Events: ctx.EventManager().ABCIEvents(),
-			Log:    "confirmed consolidation transaction"}, nil
-	}
+			Log:    fmt.Sprintf("transfer of %s from {%s} successfully prepared", amount.Amount.String(), depositAddr.String()),
+		}, nil
+	case types.CONSOLIDATION:
+		tx, txExist := k.GetSignedTx(ctx)
+		vout, voutExist := k.GetMasterKeyVout(ctx)
+		// TODO: both booleans should always have the same value, we might be able to make use of cosmos invariant checks to enforce it
+		//  without the need to check it every call
+		if txExist && voutExist {
+			txHash := tx.TxHash()
 
-	// handle cross-chain transfer
-	depositAddr := nexus.CrossChainAddress{Address: pendingOutPointInfo.Address, Chain: exported.Bitcoin}
-	amount := sdk.NewInt64Coin(exported.Bitcoin.NativeAsset, int64(pendingOutPointInfo.Amount))
-	if err := n.EnqueueForTransfer(ctx, depositAddr, amount); err != nil {
-		return nil, sdkerrors.Wrap(err, "cross-chain transfer failed")
-	}
+			// if this is the consolidation outpoint it means the latest consolidation transaction is confirmed on Bitcoin
+			if wire.NewOutPoint(&txHash, vout).String() == pendingOutPointInfo.OutPoint {
+				k.DeleteSignedTx(ctx)
+				return &sdk.Result{
+					Events: ctx.EventManager().ABCIEvents(),
+					Log:    "confirmed consolidation transaction"}, nil
+			}
+		}
 
-	return &sdk.Result{
-		Events: ctx.EventManager().ABCIEvents(),
-		Log:    fmt.Sprintf("transfer of %s from {%s} successfully prepared", amount.Amount.String(), depositAddr.String()),
-	}, nil
+		// the outpoint simply deposits funds into a consolidation address. Simply confirm
+		return &sdk.Result{
+			Events: ctx.EventManager().ABCIEvents(),
+			Log:    "confirmed top up of consolidation balance"}, nil
+	default:
+		return nil, fmt.Errorf("outpoint sends funds to address with unrecognized role")
+	}
 }
 
 // HandleMsgSignPendingTransfers handles the signing of a consolidation transaction (consolidate confirmed outpoints and pay out transfers)

--- a/x/bitcoin/handler_test.go
+++ b/x/bitcoin/handler_test.go
@@ -73,6 +73,7 @@ func TestHandleMsgLink(t *testing.T) {
 		assert.Equal(t, exported.Bitcoin, signer.GetCurrentKeyCalls()[0].Chain)
 		assert.Equal(t, msg.RecipientChain, nexusKeeper.GetChainCalls()[0].Chain)
 		assert.Equal(t, btcKeeper.SetAddressCalls()[0].Address.Address.EncodeAddress(), string(res.Data))
+		assert.Equal(t, types.DEPOSIT, btcKeeper.SetAddressCalls()[0].Address.Role)
 	}).Repeat(repeatCount))
 
 	t.Run("no master key", testutils.Func(func(t *testing.T) {
@@ -115,6 +116,7 @@ func TestHandleMsgConfirmOutpoint(t *testing.T) {
 				return types.AddressInfo{
 					Address:      address,
 					RedeemScript: rand.Bytes(200),
+					Role:         types.DEPOSIT,
 					Key: tss.Key{
 						ID:    rand.StrBetween(5, 20),
 						Value: ecdsa.PublicKey{},
@@ -146,7 +148,7 @@ func TestHandleMsgConfirmOutpoint(t *testing.T) {
 	}
 
 	repeatCount := 20
-	t.Run("happy path outpoint", testutils.Func(func(t *testing.T) {
+	t.Run("happy path deposit", testutils.Func(func(t *testing.T) {
 		setup()
 		res, err := HandleMsgConfirmOutpoint(ctx, btcKeeper, voter, signer, msg)
 		assert.NoError(t, err)
@@ -154,7 +156,20 @@ func TestHandleMsgConfirmOutpoint(t *testing.T) {
 		assert.Equal(t, msg.OutPointInfo, btcKeeper.SetPendingOutpointInfoCalls()[0].Info)
 		assert.Equal(t, voter.InitPollCalls()[0].Poll, btcKeeper.SetPendingOutpointInfoCalls()[0].Poll)
 	}).Repeat(repeatCount))
+	t.Run("happy path consolidation", testutils.Func(func(t *testing.T) {
+		setup()
+		addr, _ := btcKeeper.GetAddress(ctx, msg.OutPointInfo.Address)
+		addr.Role = types.CONSOLIDATION
+		btcKeeper.GetAddressFunc = func(sdk.Context, string) (types.AddressInfo, bool) {
+			return addr, true
+		}
 
+		res, err := HandleMsgConfirmOutpoint(ctx, btcKeeper, voter, signer, msg)
+		assert.NoError(t, err)
+		assert.Len(t, testutils.Events(res.Events).Filter(func(event abci.Event) bool { return event.Type == types.EventTypeOutpointConfirmation }), 1)
+		assert.Equal(t, msg.OutPointInfo, btcKeeper.SetPendingOutpointInfoCalls()[0].Info)
+		assert.Equal(t, voter.InitPollCalls()[0].Poll, btcKeeper.SetPendingOutpointInfoCalls()[0].Poll)
+	}).Repeat(repeatCount))
 	t.Run("already confirmed", testutils.Func(func(t *testing.T) {
 		setup()
 		btcKeeper.GetOutPointInfoFunc = func(sdk.Context, wire.OutPoint) (types.OutPointInfo, types.OutPointState, bool) {
@@ -198,6 +213,7 @@ func TestHandleMsgVoteConfirmOutpoint(t *testing.T) {
 		info        types.OutPointInfo
 	)
 	setup := func() {
+		address := randomAddress()
 		info = randomOutpointInfo()
 		msg = randomMsgVoteConfirmOutpoint()
 		msg.OutPoint = info.OutPoint
@@ -211,6 +227,18 @@ func TestHandleMsgVoteConfirmOutpoint(t *testing.T) {
 			CodecFunc:                     func() *codec.LegacyAmino { return types.ModuleCdc.LegacyAmino },
 			GetSignedTxFunc:               func(sdk.Context) (*wire.MsgTx, bool) { return nil, false },
 			GetMasterKeyVoutFunc:          func(sdk.Context) (uint32, bool) { return 0, false },
+			GetAddressFunc: func(sdk.Context, string) (types.AddressInfo, bool) {
+				return types.AddressInfo{
+					Address:      address,
+					RedeemScript: rand.Bytes(200),
+					Role:         types.DEPOSIT,
+					Key: tss.Key{
+						ID:    rand.StrBetween(5, 20),
+						Value: ecdsa.PublicKey{},
+						Role:  tss.SecondaryKey,
+					},
+				}, true
+			},
 		}
 		voter = &mock.VoterMock{
 			TallyVoteFunc:  func(sdk.Context, sdk.AccAddress, vote.PollMeta, vote.VotingData) error { return nil },
@@ -225,7 +253,7 @@ func TestHandleMsgVoteConfirmOutpoint(t *testing.T) {
 	}
 
 	repeats := 20
-	t.Run("happy path confirm deposit", testutils.Func(func(t *testing.T) {
+	t.Run("happy path confirm deposit to deposit address", testutils.Func(func(t *testing.T) {
 		setup()
 
 		_, err := HandleMsgVoteConfirmOutpoint(ctx, btcKeeper, voter, nexusKeeper, msg)
@@ -239,17 +267,82 @@ func TestHandleMsgVoteConfirmOutpoint(t *testing.T) {
 		assert.Equal(t, int64(info.Amount), nexusKeeper.EnqueueForTransferCalls()[0].Amount.Amount.Int64())
 	}).Repeat(repeats))
 
-	t.Run("happy path confirm consolidation", testutils.Func(func(t *testing.T) {
+	t.Run("happy path confirm deposit to consolidation address", testutils.Func(func(t *testing.T) {
+		setup()
+		addr, _ := btcKeeper.GetAddress(ctx, info.Address)
+		addr.Role = types.CONSOLIDATION
+		btcKeeper.GetAddressFunc = func(sdk.Context, string) (types.AddressInfo, bool) {
+			return addr, true
+		}
+
+		_, err := HandleMsgVoteConfirmOutpoint(ctx, btcKeeper, voter, nexusKeeper, msg)
+		assert.NoError(t, err)
+		assert.Len(t, voter.DeletePollCalls(), 1)
+		assert.Len(t, btcKeeper.DeletePendingOutPointInfoCalls(), 1)
+		assert.Equal(t, info, btcKeeper.SetOutpointInfoCalls()[0].Info)
+		assert.Equal(t, types.CONFIRMED, btcKeeper.SetOutpointInfoCalls()[0].State)
+		assert.Len(t, btcKeeper.DeleteSignedTxCalls(), 0)
+		assert.Len(t, nexusKeeper.EnqueueForTransferCalls(), 0)
+	}).Repeat(repeats))
+
+	t.Run("happy path confirm deposit to consolidation address in consolidation tx", testutils.Func(func(t *testing.T) {
 		setup()
 		tx := wire.NewMsgTx(wire.TxVersion)
 		hash := tx.TxHash()
 		op := wire.NewOutPoint(&hash, info.GetOutPoint().Index)
 		info.OutPoint = op.String()
 		msg.OutPoint = op.String()
+		addr, _ := btcKeeper.GetAddress(ctx, info.Address)
+		addr.Role = types.CONSOLIDATION
+		btcKeeper.GetAddressFunc = func(sdk.Context, string) (types.AddressInfo, bool) {
+			return addr, true
+		}
+
+		_, err := HandleMsgVoteConfirmOutpoint(ctx, btcKeeper, voter, nexusKeeper, msg)
+		assert.NoError(t, err)
+		assert.Len(t, voter.DeletePollCalls(), 1)
+		assert.Len(t, btcKeeper.DeletePendingOutPointInfoCalls(), 1)
+		assert.Equal(t, info, btcKeeper.SetOutpointInfoCalls()[0].Info)
+		assert.Equal(t, types.CONFIRMED, btcKeeper.SetOutpointInfoCalls()[0].State)
+		assert.Len(t, btcKeeper.DeleteSignedTxCalls(), 0)
+		assert.Len(t, nexusKeeper.EnqueueForTransferCalls(), 0)
+	}).Repeat(repeats))
+
+	t.Run("happy path confirm deposit to deposit address in consolidation tx", testutils.Func(func(t *testing.T) {
+		setup()
+		tx := wire.NewMsgTx(wire.TxVersion)
+		hash := tx.TxHash()
+		op := wire.NewOutPoint(&hash, info.GetOutPoint().Index)
+		info.OutPoint = op.String()
+		msg.OutPoint = op.String()
+
+		_, err := HandleMsgVoteConfirmOutpoint(ctx, btcKeeper, voter, nexusKeeper, msg)
+		assert.NoError(t, err)
+		assert.Len(t, voter.DeletePollCalls(), 1)
+		assert.Len(t, btcKeeper.DeletePendingOutPointInfoCalls(), 1)
+		assert.Equal(t, info, btcKeeper.SetOutpointInfoCalls()[0].Info)
+		assert.Equal(t, types.CONFIRMED, btcKeeper.SetOutpointInfoCalls()[0].State)
+		assert.Len(t, btcKeeper.DeleteSignedTxCalls(), 0)
+		assert.Len(t, nexusKeeper.EnqueueForTransferCalls(), 1)
+	}).Repeat(repeats))
+
+	t.Run("happy path confirm consolidation", testutils.Func(func(t *testing.T) {
+		setup()
+		tx := wire.NewMsgTx(wire.TxVersion)
+		hash := tx.TxHash()
+		vout, _ := btcKeeper.GetMasterKeyVoutFunc(ctx)
+		op := wire.NewOutPoint(&hash, vout)
+		info.OutPoint = op.String()
+		msg.OutPoint = op.String()
 		btcKeeper.GetSignedTxFunc = func(sdk.Context) (*wire.MsgTx, bool) { return tx, true }
 		btcKeeper.DeleteSignedTxFunc = func(sdk.Context) {}
 		btcKeeper.GetMasterKeyVoutFunc = func(sdk.Context) (uint32, bool) {
 			return op.Index, true
+		}
+		addr, _ := btcKeeper.GetAddress(ctx, "")
+		addr.Role = types.CONSOLIDATION
+		btcKeeper.GetAddressFunc = func(sdk.Context, string) (types.AddressInfo, bool) {
+			return addr, true
 		}
 
 		_, err := HandleMsgVoteConfirmOutpoint(ctx, btcKeeper, voter, nexusKeeper, msg)
@@ -262,7 +355,7 @@ func TestHandleMsgVoteConfirmOutpoint(t *testing.T) {
 		assert.Len(t, nexusKeeper.EnqueueForTransferCalls(), 0)
 	}).Repeat(repeats))
 
-	t.Run("happy path confirm deposit in consolidation tx", testutils.Func(func(t *testing.T) {
+	t.Run("happy path confirm deposit to deposit address in consolidation tx", testutils.Func(func(t *testing.T) {
 		setup()
 		tx := wire.NewMsgTx(wire.TxVersion)
 		hash := tx.TxHash()
@@ -681,8 +774,12 @@ func randomOutpointInfo() types.OutPointInfo {
 	if err != nil {
 		panic(err)
 	}
+	vout := mathRand.Uint32()
+	if vout == 0 {
+		vout++
+	}
 	return types.OutPointInfo{
-		OutPoint: wire.NewOutPoint(txHash, mathRand.Uint32()).String(),
+		OutPoint: wire.NewOutPoint(txHash, vout).String(),
 		Amount:   btcutil.Amount(rand.I64Between(1, 10000000000)),
 		Address:  randomAddress().EncodeAddress(),
 	}

--- a/x/bitcoin/keeper/keeper.go
+++ b/x/bitcoin/keeper/keeper.go
@@ -100,10 +100,12 @@ func (k Keeper) SetAddress(ctx sdk.Context, address types.AddressInfo) {
 	// so we use a helper struct to get around that problem
 	a := struct {
 		Addr   string
+		Role   types.AddressRole
 		Script types.RedeemScript
 		Key    tss.Key
 	}{
 		Addr:   address.EncodeAddress(),
+		Role:   address.Role,
 		Script: address.RedeemScript,
 		Key:    address.Key,
 	}
@@ -121,6 +123,7 @@ func (k Keeper) GetAddress(ctx sdk.Context, encodedAddress string) (types.Addres
 	// so we use a helper struct to get around that problem
 	var a struct {
 		Addr   string
+		Role   types.AddressRole
 		Script types.RedeemScript
 		Key    tss.Key
 	}
@@ -128,6 +131,7 @@ func (k Keeper) GetAddress(ctx sdk.Context, encodedAddress string) (types.Addres
 	addr, _ := btcutil.DecodeAddress(a.Addr, k.GetNetwork(ctx).Params())
 	return types.AddressInfo{
 		Address:      addr,
+		Role:         a.Role,
 		RedeemScript: a.Script,
 		Key:          a.Key,
 	}, true

--- a/x/bitcoin/types/types.go
+++ b/x/bitcoin/types/types.go
@@ -245,9 +245,20 @@ func createP2WSHAddress(script RedeemScript, network Network) *btcutil.AddressWi
 // AddressInfo is a wrapper containing the Bitcoin P2WSH address, it's corresponding script and the underlying key
 type AddressInfo struct {
 	btcutil.Address
+	Role         AddressRole
 	RedeemScript RedeemScript
 	Key          tss.Key
 }
+
+// AddressRole is an enum that specifies the allowed bitcoin address roles
+type AddressRole int
+
+// Roles of bitcoin addresses created by axelar
+const (
+	NONE AddressRole = iota
+	DEPOSIT
+	CONSOLIDATION
+)
 
 // NewConsolidationAddress creates a new address used to consolidate all unspent outpoints
 func NewConsolidationAddress(pk tss.Key, network Network) AddressInfo {
@@ -257,6 +268,7 @@ func NewConsolidationAddress(pk tss.Key, network Network) AddressInfo {
 	return AddressInfo{
 		RedeemScript: script,
 		Address:      addr,
+		Role:         CONSOLIDATION,
 		Key:          pk,
 	}
 }
@@ -273,6 +285,7 @@ func NewLinkedAddress(masterKey tss.Key, secondaryKey tss.Key, network Network, 
 	return AddressInfo{
 		RedeemScript: script,
 		Address:      addr,
+		Role:         DEPOSIT,
 		Key:          secondaryKey,
 	}
 }


### PR DESCRIPTION
There was some undefined behaviour for deposit confirmations because we implicitly have two different kinds of addresses: deposit addresses to transfer tokens to another chain and consolidation addresses to gather all funds into a single pot. It's possible that users can withdraw (accidentally or intentionally) to those addresses instead of addresses owned by themselves. This lead to bugs where the consolidation pipeline got stuck. This change adds explicit address roles and confirmations follow this behaviour:
- If a confirmation is done for a deposit address, try to transfer the funds to the target chain
- If a confirmation is done for a consolidation address check two cases:
    1. It's a user deposit: confirm and do nothing else
    2. It's the consolidation outpoint: free up the consolidation pipeline

(cherry picked from commit 898083e2891026e055485f158e452b3507d99e38)