### PR TITLE
fix(vald): gracefully stop on interrupt or termination (#566)

### DIFF
--- a/cmd/axelard/cmd/vald/start.go
+++ b/cmd/axelard/cmd/vald/start.go
@@ -226,7 +226,9 @@ func listen(ctx sdkClient.Context, appState map[string]json.RawMessage, hub *tmE
 
 	fetchEvents := func(errChan chan<- error) {
 		for err := range eventMgr.FetchEvents() {
-			errChan <- err
+			if err != nil {
+				errChan <- err
+			}
 		}
 	}
 	js := []jobs.Job{

--- a/entrypoint.debug.sh
+++ b/entrypoint.debug.sh
@@ -1,5 +1,14 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+trap stop_gracefully SIGTERM SIGINT
+
+stop_gracefully(){
+  echo "stopping all processes"
+  pkill "axelard"
+  sleep 10
+  echo "all processes stopped"
+}
 
 HOME_DIR=${HOME_DIR:?home directory not set}
 
@@ -45,7 +54,7 @@ startValProc() {
   fi
 
   dlv --listen=:2346 --headless=true ${VALD_CONTINUE:+--continue} --api-version=2 --accept-multiclient exec \
-    /usr/local/bin/axelard -- vald-start ${TOFND_HOST:+--tofnd-host "$TOFND_HOST"} --validator-addr "$(axelard keys show validator -a --bech val)"
+    /usr/local/bin/axelard -- vald-start ${TOFND_HOST:+--tofnd-host "$TOFND_HOST"} --validator-addr "$(axelard keys show validator -a --bech val)" &
 }
 
 D_HOME_DIR="$HOME_DIR/.axelar"
@@ -84,4 +93,6 @@ if [ "$CORE_CONTINUE" != true ]; then
 fi
 
 dlv --listen=:2345 --headless=true ${CORE_CONTINUE:+--continue} --api-version=2 --accept-multiclient exec \
-  /usr/local/bin/axelard -- start ${TOFND_HOST:+--tofnd-host "$TOFND_HOST"}
+  /usr/local/bin/axelard -- start ${TOFND_HOST:+--tofnd-host "$TOFND_HOST"} &
+
+wait

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,15 @@
 #!/bin/sh
 set -e
 
+trap stop_gracefully TERM INT
+
+stop_gracefully(){
+  echo "stopping all processes"
+  killall "axelard"
+  sleep 10
+  echo "all processes stopped"
+}
+
 HOME_DIR=${HOME_DIR:?home directory not set}
 
 fileCount() {
@@ -32,7 +41,7 @@ initGenesis() {
 startValProc() {
   sleep 10s
   axelard vald-start ${TOFND_HOST:+--tofnd-host "$TOFND_HOST"} \
-    --validator-addr "$(axelard keys show validator -a --bech val)"
+    --validator-addr "$(axelard keys show validator -a --bech val)" &
 }
 
 D_HOME_DIR="$HOME_DIR/.axelar"
@@ -62,4 +71,6 @@ fi
 
 startValProc &
 
-exec axelard start ${TOFND_HOST:+--tofnd-host "$TOFND_HOST"}
+axelard start ${TOFND_HOST:+--tofnd-host "$TOFND_HOST"} &
+
+wait


### PR DESCRIPTION
The docker containers now properly trap the SIGINT and SIGTERM signals and persist vald event state before shutting down

(cherry picked from commit 1c7f9749ea911e951d558372c8c173795154b7a5)