### PR TITLE
fix(evm): distinct command IDs by chain

### DIFF
--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -49,6 +49,7 @@ type Keeper struct {
 	storeKey     sdk.StoreKey
 	cdc          codec.BinaryMarshaler
 	paramsKeeper types.ParamsKeeper
+	subspaces    map[string]params.Subspace
 }
 
 // NewKeeper returns a new EVM keeper
@@ -57,6 +58,7 @@ func NewKeeper(cdc codec.BinaryMarshaler, storeKey sdk.StoreKey, paramsKeeper ty
 		cdc:          cdc,
 		storeKey:     storeKey,
 		paramsKeeper: paramsKeeper,
+		subspaces:    make(map[string]params.Subspace),
 	}
 }
 
@@ -528,16 +530,18 @@ func (k Keeper) getStore(ctx sdk.Context, chain string) prefix.Store {
 func (k Keeper) getSubspace(ctx sdk.Context, chain string) (params.Subspace, bool) {
 	chainLower := strings.ToLower(chain)
 
-	subspace, subspaceExists := k.paramsKeeper.GetSubspace(types.ModuleName + "_" + chainLower)
-
-	// The && operator in Golang does short-circuiting, i.e. the second condition will not be checked if the first one is already false.
-	// Subspaces need to be recreated if a node restarts, so it is possible that the subspace check returns different values for different nodes.
-	// Therefore we need to make the following call to the kvstore before the if statement, otherwise we would run the risk of differing gas consumption
-	// and hence a block hash conflict.
-	chainExists := ctx.KVStore(k.storeKey).Has([]byte(subspacePrefix + chainLower))
-	if !subspaceExists && chainExists {
-		subspace = k.paramsKeeper.Subspace(types.ModuleName + "_" + chainLower)
-		subspace = subspace.WithKeyTable(types.KeyTable())
+	// When a node restarts or joins the network after genesis, it might not have all EVM subspaces initialized.
+	// The following checks has to be done regardless, if we would only do it dependent on the existence of a subspace
+	// different nodes would consume different amounts of gas and it would result in a consensus failure
+	if !ctx.KVStore(k.storeKey).Has([]byte(subspacePrefix + chainLower)) {
+		return params.Subspace{}, false
 	}
-	return subspace, subspaceExists
+
+	chainKey := types.ModuleName + "_" + chainLower
+	subspace, ok := k.subspaces[chainKey]
+	if !ok {
+		subspace = k.paramsKeeper.Subspace(chainKey).WithKeyTable(types.KeyTable())
+		k.subspaces[chainKey] = subspace
+	}
+	return subspace, true
 }


### PR DESCRIPTION
This PR enforces distinct command IDs for each EVM chain, hence fixing the conflicting signature IDs problem.