### PR TITLE
test(vald): fix test where missing events in a block lead to time out

### DIFF
--- a/cmd/axelard/cmd/vald/events/events_test.go
+++ b/cmd/axelard/cmd/vald/events/events_test.go
@@ -161,7 +161,7 @@ func TestMgr_Subscribe(t *testing.T) {
 			BlockResultsFunc: func(_ context.Context, height *int64) (*coretypes.ResultBlockResults, error) {
 				result := &coretypes.ResultBlockResults{
 					Height:     *height,
-					TxsResults: randomTxResults(rand.I64Between(0, 100)),
+					TxsResults: randomTxResults(rand.I64Between(1, 100)),
 				}
 
 				expectedEvents = nil


### PR DESCRIPTION
## Description

A test case only shut down after at least one event was processed, but the test setup allowed creation of blocks without any events. Now it is ensured that every block contains at least one event

## Todos

- [x] Unit tests
- [x] Tag type of change
