### PR TITLE
refactor(dockerimage): entrypoint with command

### DIFF
--- a/entrypoint.debug.sh
+++ b/entrypoint.debug.sh
@@ -47,7 +47,7 @@ cont(){
 }
 
 startValdProc() {
-  DURATION=${SLEEP_TIME:+"1s"}
+  DURATION=${SLEEP_TIME:-"10s"}
   sleep $DURATION
   
   if [ "$VALD_CONTINUE" != true ]; then
@@ -55,7 +55,7 @@ startValdProc() {
   fi
 
   dlv --listen=:2346 --headless=true ${VALD_CONTINUE:+--continue} --api-version=2 --accept-multiclient exec \
-    /usr/local/bin/axelard -- vald-start ${TOFND_HOST:+--tofnd-host "$TOFND_HOST"} --validator-addr "$(axelard keys show validator -a --bech val)" --node "$VALIDATOR_HOST" &
+    /usr/local/bin/axelard -- vald-start ${TOFND_HOST:+--tofnd-host "$TOFND_HOST"} ${VALIDATOR_HOST:+--node "$VALIDATOR_HOST"} --validator-addr "$(axelard keys show validator -a --bech val)"
 }
 
 startNodeProc() {
@@ -96,6 +96,18 @@ if [ "$REST_CONTINUE" != true ]; then
   unset REST_CONTINUE
 fi
 
-$@ &
+if [ -z "$1" ]; then
 
-wait
+  startValdProc &
+
+  startNodeProc &
+
+  wait
+
+else
+
+  $@ &
+
+  wait
+
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,11 +39,10 @@ initGenesis() {
 }
 
 startValdProc() {
-  DURATION=${SLEEP_TIME:+"1s"}
+  DURATION=${SLEEP_TIME:-"10s"}
   sleep $DURATION
-  axelard vald-start ${TOFND_HOST:+--tofnd-host "$TOFND_HOST"} \
-    --validator-addr "$(axelard keys show validator -a --bech val)" \
-    --node "$VALIDATOR_HOST"
+  axelard vald-start ${TOFND_HOST:+--tofnd-host "$TOFND_HOST"} ${VALIDATOR_HOST:+--node "$VALIDATOR_HOST"} \
+    --validator-addr "$(axelard keys show validator -a --bech val)"
 }
 
 startNodeProc() {
@@ -75,6 +74,18 @@ if [ -n "$PEERS_FILE" ]; then
   addPeers "$PEERS"
 fi
 
-$@ &
+if [ -z "$1" ]; then
 
-wait
+  startValdProc &
+
+  startNodeProc &
+
+  wait
+
+else
+
+  $@ &
+
+  wait
+
+fi


### PR DESCRIPTION
This PR updates the entrypoint scripts so that a command can be passed (either to start the node or a vald process) If no command is given, both node and vald are stated within the same container as before.

## Description

## Todos

- [x] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

Just a usual ceremony. Must be done using the updated docker-compose files

## Expected Behaviour

The docker image should now only launch either a node process or a vald process

## Other Notes
