### PR TITLE
fix(vald): bus panics when block channel closes

### DIFF
--- a/cmd/axelard/cmd/vald/events/bus.go
+++ b/cmd/axelard/cmd/vald/events/bus.go
@@ -116,11 +116,13 @@ func (m *EventBus) FetchEvents(ctx context.Context) <-chan error {
 			select {
 			case block, ok := <-blockResults:
 				if !ok {
-					return
+					m.shutdown()
+					continue
 				}
 				if err := m.publishEvents(block); err != nil {
 					errChan <- err
-					return
+					m.shutdown()
+					continue
 				}
 			case <-m.running.Done():
 				m.logger.Info("closing all subscriptions")


### PR DESCRIPTION
## Description
If a channel is closed one can still pull from it (data has default value). Here, the code didn't check if the channel was closed and just continued with whichever data it got from it, leading to a nil reference panic down the line

## Todos

- [x] Unit tests
- [x] Tag type of change
