### PR TITLE
fix(vald): publish blocks starting at 1

### DIFF
--- a/cmd/axelard/cmd/vald/events/source.go
+++ b/cmd/axelard/cmd/vald/events/source.go
@@ -275,8 +275,8 @@ type blockNotifier struct {
 
 // NewBlockNotifier returns a new BlockNotifier instance
 func NewBlockNotifier(client BlockClient, startBlock int64, logger log.Logger, options ...DialOption) BlockNotifier {
-	if startBlock < 0 {
-		startBlock = 0
+	if startBlock <= 0 {
+		startBlock = 1
 	}
 	return &blockNotifier{
 		start:          startBlock,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/axelarnetwork/axelar-core
 go 1.16
 
 require (
-	github.com/axelarnetwork/tm-events v0.0.0-20210603164553-dc0202f4ebaf
+	github.com/axelarnetwork/tm-events v0.0.0-20210714065054-b010ab2580bd
 	github.com/btcsuite/btcd v0.22.0-beta
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/cosmos/cosmos-sdk v0.42.4

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxq
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
 github.com/axelarnetwork/tm-events v0.0.0-20210603164553-dc0202f4ebaf h1:S/p1Ec4aGxpjFG++Cn0mGzdVFSRFgQtc9IjxzDZhlJo=
 github.com/axelarnetwork/tm-events v0.0.0-20210603164553-dc0202f4ebaf/go.mod h1:IIG/UHjSISLaRS2JECy/KLY1xZruh7HL/sf0tiYKqh4=
+github.com/axelarnetwork/tm-events v0.0.0-20210714065054-b010ab2580bd h1:JJ0Cyu1WbKPzefB6a1FjzQVExnDAPvxJwefl227D9vI=
+github.com/axelarnetwork/tm-events v0.0.0-20210714065054-b010ab2580bd/go.mod h1:IIG/UHjSISLaRS2JECy/KLY1xZruh7HL/sf0tiYKqh4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
## Description
The `BlockResults` query of the Tendermint client expects given block heights to be >0. This PR ensures we call it this way
