### PR TITLE
test: adjust tests to changed start block behaviour

### DIFF
--- a/cmd/axelard/cmd/vald/events/features/blockheights.feature
+++ b/cmd/axelard/cmd/vald/events/features/blockheights.feature
@@ -13,8 +13,8 @@ Feature: provide a robust source for existing blocks
 
     Examples:
       | start  | latest |
-      | 0      | 0      |
-      | 0      | 1      |
+      | 1      | 1      |
+      | 1      | 2      |
       | 100000 | 100018 |
 
   Scenario Outline: stale block queries
@@ -26,8 +26,8 @@ Feature: provide a robust source for existing blocks
 
     Examples:
       | start  | latest |
-      | 0      | 0      |
-      | 0      | 1      |
+      | 1      | 1      |
+      | 1      | 2      |
       | 100000 | 100018 |
 
   Scenario Outline: canceled context
@@ -39,9 +39,9 @@ Feature: provide a robust source for existing blocks
 
     Examples:
       | start | latest |
-      | 0     | 0      |
-      | 0     | 1      |
-      | 0     | 10000  |
+      | 1     | 1      |
+      | 1     | 2      |
+      | 1     | 10000  |
 
   Scenario Outline: subscription fails
     Given a block notifier starting at block <start>
@@ -52,8 +52,8 @@ Feature: provide a robust source for existing blocks
 
     Examples:
       | start  | latest |
-      | 0      | 0      |
-      | 0      | 1      |
+      | 1      | 1      |
+      | 1      | 2      |
       | 100000 | 100018 |
 
   Scenario Outline: block query fails
@@ -65,18 +65,18 @@ Feature: provide a robust source for existing blocks
 
     Examples:
       | start  | latest |
-      | 0      | 0      |
-      | 0      | 1      |
+      | 1      | 1      |
+      | 1      | 2      |
       | 100000 | 100018 |
 
   Scenario Outline: negative start block
     Given a block notifier starting at block <start>
     And block <latest> is available
     When I try to receive block heights
-    Then I receive all blocks from 0 to <latest>
+    Then I receive all blocks from 1 to <latest>
 
     Examples:
       | start  | latest |
-      | -1     | 0      |
+      | -1     | 1      |
       | -10000 | 1      |
       | -10000 | 10     |

--- a/cmd/axelard/cmd/vald/events/features/blockresults.feature
+++ b/cmd/axelard/cmd/vald/events/features/blockresults.feature
@@ -12,8 +12,8 @@ Feature: provide a robust source for block results
     Then I receive all results from <start> to <latest>
     Examples:
       | start  | latest |
-      | 0      | 0      |
-      | 0      | 1      |
+      | 1      | 1      |
+      | 1      | 2      |
       | 100000 | 100018 |
 
   Scenario: block notifier fails
@@ -36,6 +36,6 @@ Feature: provide a robust source for block results
     Then the result channel gets closed
     Examples:
       | start  | latest |
-      | 0      | 0      |
-      | 0      | 1      |
+      | 1      | 1      |
+      | 1      | 2      |
       | 100000 | 100018 |

--- a/cmd/axelard/cmd/vald/events/features/events.feature
+++ b/cmd/axelard/cmd/vald/events/features/events.feature
@@ -1,1 +1,0 @@
-Feature

--- a/cmd/axelard/cmd/vald/events/source_test.go
+++ b/cmd/axelard/cmd/vald/events/source_test.go
@@ -193,7 +193,7 @@ func TestBlockNotifier_BlockHeights(t *testing.T) {
 		}
 	}).Repeat(repeats))
 
-	t.Run("GIVEN start < 0 THEN start at block 0", testutils.Func(func(t *testing.T) {
+	t.Run("GIVEN start < 0 THEN start at block 1", testutils.Func(func(t *testing.T) {
 		client := NewClientMock()
 		client.NextBlock(rand.PosI64())
 
@@ -210,7 +210,7 @@ func TestBlockNotifier_BlockHeights(t *testing.T) {
 			return
 		case b, ok := <-blocks:
 			assert.True(t, ok)
-			assert.Equal(t, int64(0), b)
+			assert.Equal(t, int64(1), b)
 		case <-timeout.Done():
 			assert.FailNow(t, "test timed out")
 		}


### PR DESCRIPTION
## Description
There was an issue with our main branch and PR #686 went through even though tests were wrong. This is the followup to fix the tests.

## Todos

- [x] Unit tests
- [x] Tag type of change
