### PR TITLE
fix(evm): rest queries for hex data returned as common.Hash type

### DIFF
--- a/x/evm/client/rest/query.go
+++ b/x/evm/client/rest/query.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"fmt"
 	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/ethereum/go-ethereum/common"


### PR DESCRIPTION
## Description
EVM queries for bytecode and tx data using the rest client were being returned as geth hashes, meaning the data was truncated into a fixed length array.

Also removes unused code.

## Todos

- [ ] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [x] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
