### PR TITLE
feat(vald): add range check for key id length

### DIFF
--- a/x/tss/types/msg_keygen.go
+++ b/x/tss/types/msg_keygen.go
@@ -1,9 +1,17 @@
 package types
 
 import (
+	"fmt"
+
 	"github.com/axelarnetwork/axelar-core/x/tss/exported"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// key id length range bounds dictated by tofnd
+const (
+	keyIDLengthMin = 4
+	keyIDLengthMax = 256
 )
 
 // NewStartKeygenRequest constructor for StartKeygenRequest
@@ -32,11 +40,14 @@ func (m StartKeygenRequest) ValidateBasic() error {
 		return sdkerrors.Wrap(ErrTss, "key id must be set")
 	}
 
+	if len(m.KeyID) < keyIDLengthMin || len(m.KeyID) > keyIDLengthMax {
+		return sdkerrors.Wrap(ErrTss, fmt.Sprintf("key id length %d not in range [%d,%d]", len(m.KeyID), keyIDLengthMin, keyIDLengthMax))
+	}
+
 	if err := m.KeyRole.Validate(); err != nil {
 		return err
 	}
 
-	// TODO enforce a maximum length for m.KeyID?
 	return nil
 }
 


### PR DESCRIPTION
## Description

Add a check to ensure that length of key id is within a certain range, currently [4, 256].

### Why?

Because it's good practice to enforce reasonable key id lengths.  Also, `tofn` now has an active PR axelarnetwork/tofn#157 that enforces the same range bound on key id lengths.  That PR is blocked by this PR.

### Where to put the constants?

The specific choice of range (currently [4, 256]) is copied from `tofn`:
https://github.com/axelarnetwork/tofn/blob/2fa584658bfe8585e4a7a9387d4cf1caf213a559/src/gg20/keygen/rng.rs#L14-L15
This not ideal.  It is preferred to have these constants defined in only one place.  Unfortunately, `vald` talks to `tofn` via `tofnd`'s gRPC API.  [gRPC does not allow constants in protobuf files](https://stackoverflow.com/questions/35698849/can-i-define-a-constant-string-in-protobuf) and even if it did `tofn` as the upstream library should not have a dependence on that protobuf.  Anyone have a better idea?

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
