### PR TITLE
feat(tss): introduce type for safe key ID validation

### DIFF
--- a/x/tss/exported/testutils/rand.go
+++ b/x/tss/exported/testutils/rand.go
@@ -1,0 +1,15 @@
+package testutils
+
+import (
+	"github.com/axelarnetwork/axelar-core/testutils/rand"
+	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
+)
+
+// RandKeyID creates a random valid key ID
+func RandKeyID() tss.KeyID {
+	keyID := tss.KeyID(rand.StrBetween(tss.KeyIDLengthMin, tss.KeyIDLengthMax))
+	if err := keyID.Validate(); err != nil {
+		panic(err)
+	}
+	return keyID
+}

--- a/x/tss/exported/types.go
+++ b/x/tss/exported/types.go
@@ -26,6 +26,36 @@ type Key struct {
 	RotatedAt *time.Time
 }
 
+// key id length range bounds dictated by tofnd
+const (
+	KeyIDLengthMin = 4
+	KeyIDLengthMax = 256
+)
+
+// KeyID ensures a correctly formatted tss key ID
+type KeyID string
+
+// Validate returns an error, if the key ID is too short or too long
+func (id KeyID) Validate() error {
+	if len(id) < KeyIDLengthMin || len(id) > KeyIDLengthMax {
+		return fmt.Errorf("key id length %d not in range [%d,%d]", len(id), KeyIDLengthMin, KeyIDLengthMax)
+	}
+
+	return nil
+}
+
+// KeyIDsToStrings converts a slice of type KeyID to a slice of strings
+func KeyIDsToStrings(keyIDs []KeyID) []string {
+	if keyIDs == nil {
+		return nil
+	}
+	strs := make([]string, 0, len(keyIDs))
+	for _, id := range keyIDs {
+		strs = append(strs, string(id))
+	}
+	return strs
+}
+
 // GetKeyRoles returns an array of all types of key role
 func GetKeyRoles() []KeyRole {
 	return []KeyRole{MasterKey, SecondaryKey, ExternalKey}

--- a/x/tss/exported/types_test.go
+++ b/x/tss/exported/types_test.go
@@ -1,0 +1,58 @@
+package exported_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/axelarnetwork/axelar-core/testutils"
+	"github.com/axelarnetwork/axelar-core/testutils/rand"
+	"github.com/axelarnetwork/axelar-core/x/tss/exported"
+	tssTestUtils "github.com/axelarnetwork/axelar-core/x/tss/exported/testutils"
+)
+
+func TestKeyID_Validate(t *testing.T) {
+	repeats := 20
+	t.Run("GIVEN a valid key ID WHEN validating THEN return no error", testutils.Func(func(t *testing.T) {
+		keyID := exported.KeyID(rand.StrBetween(exported.KeyIDLengthMin, exported.KeyIDLengthMax))
+		assert.NoError(t, keyID.Validate())
+	}).Repeat(repeats))
+
+	t.Run("GIVEN a short key ID WHEN validating THEN return error", testutils.Func(func(t *testing.T) {
+		keyID := exported.KeyID(rand.StrBetween(1, exported.KeyIDLengthMin-1))
+		assert.Error(t, keyID.Validate())
+	}).Repeat(repeats))
+
+	t.Run("GIVEN a long key ID WHEN validating THEN return error", testutils.Func(func(t *testing.T) {
+		keyID := exported.KeyID(rand.StrBetween(exported.KeyIDLengthMax+1, 2*exported.KeyIDLengthMax))
+		assert.Error(t, keyID.Validate())
+	}).Repeat(repeats))
+}
+
+func TestKeyIDsToStrings(t *testing.T) {
+	repeats := 5
+	t.Run("GIVEN a slice of key IDs WHEN converting THEN return equivalent slice of strings", testutils.Func(func(t *testing.T) {
+		keyIDs := make([]exported.KeyID, 0, rand.I64Between(1, 20))
+		for i := 0; i < cap(keyIDs); i++ {
+			keyIDs = append(keyIDs, tssTestUtils.RandKeyID())
+		}
+
+		strs := exported.KeyIDsToStrings(keyIDs)
+
+		for i := range keyIDs {
+			assert.Equal(t, string(keyIDs[i]), strs[i])
+		}
+	}).Repeat(repeats))
+
+	t.Run("GIVEN an empty slice of key IDs WHEN converting THEN return an empty slice of strings", func(t *testing.T) {
+		keyIDs := make([]exported.KeyID, 0)
+		strs := exported.KeyIDsToStrings(keyIDs)
+		assert.Equal(t, []string{}, strs)
+	})
+
+	t.Run("GIVEN a nil slice of key IDs WHEN converting THEN return a nil slice of strings", func(t *testing.T) {
+		var keyIDs []exported.KeyID
+		strs := exported.KeyIDsToStrings(keyIDs)
+		assert.Nil(t, strs)
+	})
+}


### PR DESCRIPTION
## Description
tofnd has requirements on the key ID length for keygen. This PR introduces a new type to ensure these constraints. A follow-up PR will replace all instances of `keyID string` with this new type throughout the code base.

## Todos

- [x] Unit tests
- [x] Documentation
- [x] Tag type of change
