### PR TITLE
fix: register faulters list for proto marshaler

### DIFF
--- a/x/tss/types/codec.go
+++ b/x/tss/types/codec.go
@@ -35,6 +35,7 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*codec.ProtoMarshaler)(nil),
 		&tofnd.MessageOut_SignResult{},
 		&tofnd.MessageOut_KeygenResult{},
+		&tofnd.MessageOut_CriminalList{},
 		&QueryRecoveryResponse{},
 		&gogoprototypes.BytesValue{},
 	)


### PR DESCRIPTION
## Description

If a tss session ends in sad path with faulters list then `vald` panics.  The panic is due to the fact that `tofnd.MessageOut_CriminalList` is not registered with `codec.ProtoMarshaler`.  The fix is one-line.  This fix is already included in main branch via #716 .  This PR back-ports that fix to `releases/0.7.x`

## Todos

- [x] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

Local cluster test.  Make docker images:

* axelar-core: check out this branch and run `make docker-image`
* tofnd: check out `v0.6.1` and run `make docker-image-all`

Set one of the nodes to use a malicious tofnd instance.  In axelarate repo change `docker-compose.local-cluster.yml` as follows.  Change `tofnd1` service to look like this:
```yml
  tofnd1:
    container_name: tofnd1
    hostname: tofnd1
    image: axelar/tofnd-malicious # NEW
    environment:
      - UNSAFE=true
      - MNEMONIC_CMD=create
    volumes:
      - type: volume
        source: tofnd1
        target: /.tofnd
    command:        # NEW
      - malicious   # NEW
      - Honest      # NEW
      - "1"         # NEW
```

Spin up the cluster and run keygen:  Run
```
docker-compose -f docker-compose.local-cluster.yml up
```
Then in a separate terminal do
```
./dev_tools/validator_setup.sh
./dev_tools/rotate_mk.sh -c bitcoin -k btc-key full
```

## Expected Behaviour

Prior to this PR the above test would cause `vald` to panic.  This can be observed in the logs via
```
docker logs -f validator1 2>&1 | grep -e "panic"
```
Under this PR `vald` no longer panics in the above test.

## Other Notes
