### PR TITLE
fix(tss): suspend non-malicious faulters, too

### DIFF
--- a/x/tss/keeper/keeperSign.go
+++ b/x/tss/keeper/keeperSign.go
@@ -266,7 +266,8 @@ func (k Keeper) DoesValidatorParticipateInSign(ctx sdk.Context, sigID string, va
 // PenalizeCriminal penalizes the criminal caught during tss protocol according to the given crime type
 func (k Keeper) PenalizeCriminal(ctx sdk.Context, criminal sdk.ValAddress, crimeType tofnd.MessageOut_CriminalList_Criminal_CrimeType) {
 	switch crimeType {
-	case tofnd.CRIME_TYPE_MALICIOUS:
+	// currently we do not distinguish between malicious and non-malicious faults
+	case tofnd.CRIME_TYPE_MALICIOUS, tofnd.CRIME_TYPE_NON_MALICIOUS:
 		k.setTssSuspendedUntil(ctx, criminal, ctx.BlockHeight()+k.GetParams(ctx).SuspendDurationInBlocks)
 	default:
 		k.Logger(ctx).Info(fmt.Sprintf("no policy is set to penalize validator %s for crime type %s", criminal.String(), crimeType.String()))


### PR DESCRIPTION
## Description

We currently penalize only "malicious" tss faulters.  As per offline discussion, our current policy is to penalize both "malicious" and "non-malicious" faulters equally.  This PR implements that policy.

An example of a non-malicious fault is timeout or serialization failure.  Here is how tofnd currently classifies faults:
https://github.com/axelarnetwork/tofnd/blob/44fdc900d3a5ee1742ec311fc958632c6d1e2d40/src/gg20/proto_helpers.rs#L80-L85

## Question

I see that code for `PenalizeCriminal` appears in `keeperSign.go` even though this method is used in both keygen and sign.  Should this method's code be moved elsewhere?

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
