### PR TITLE
refactor: use rand.ValAddr and rand AccAddr everywhere

### DIFF
--- a/cmd/axelard/cmd/vald/broadcaster/broadcast_test.go
+++ b/cmd/axelard/cmd/vald/broadcaster/broadcast_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/address"
 	txsigning "github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	"github.com/spf13/pflag"
@@ -229,7 +228,7 @@ func setup() (*Broadcaster, client.Context) {
 
 func createMsgsWithRandomSigner() []sdk.Msg {
 	var msgs []sdk.Msg
-	signer := rand.Bytes(address.Len)
+	signer := rand.AccAddr()
 	for i := int64(0); i < rand.I64Between(1, 20); i++ {
 		txHash, err := chainhash.NewHash(rand.Bytes(chainhash.HashSize))
 		if err != nil {

--- a/x/evm/keeper/msg_server_test.go
+++ b/x/evm/keeper/msg_server_test.go
@@ -581,7 +581,7 @@ func TestHandleMsgConfirmChain(t *testing.T) {
 		ctx = sdk.NewContext(nil, tmproto.Header{}, false, log.TestingLogger())
 		chain := rand.StrBetween(5, 20)
 		msg = &types.ConfirmChainRequest{
-			Sender: rand.Bytes(20),
+			Sender: rand.AccAddr(),
 			Name:   chain,
 		}
 		voteReq = &types.VoteConfirmChainRequest{Name: chain}
@@ -819,7 +819,7 @@ func TestHandleMsgConfirmTokenDeploy(t *testing.T) {
 
 		token = createMockERC20Token(btc.Bitcoin.NativeAsset, createDetails())
 		msg = &types.ConfirmTokenRequest{
-			Sender: rand.Bytes(20),
+			Sender: rand.AccAddr(),
 			Chain:  evmChain,
 			TxID:   types.Hash(common.BytesToHash(rand.Bytes(common.HashLength))),
 			Asset:  types.NewAsset(btc.Bitcoin.Name, btc.Bitcoin.NativeAsset),
@@ -959,7 +959,7 @@ func TestAddChain(t *testing.T) {
 		params := types.DefaultParams()[0]
 		params.Chain = name
 		msg = &types.AddChainRequest{
-			Sender:      rand.Bytes(20),
+			Sender:      rand.AccAddr(),
 			Name:        name,
 			NativeAsset: nativeAsset,
 			Params:      params,
@@ -1080,7 +1080,7 @@ func TestHandleMsgConfirmDeposit(t *testing.T) {
 		}
 
 		msg = &types.ConfirmDepositRequest{
-			Sender:        rand.Bytes(20),
+			Sender:        rand.AccAddr(),
 			Chain:         evmChain,
 			TxID:          types.Hash(common.BytesToHash(rand.Bytes(common.HashLength))),
 			Amount:        sdk.NewUint(mathRand.Uint64()),

--- a/x/vote/types/types_test.go
+++ b/x/vote/types/types_test.go
@@ -392,7 +392,7 @@ func randomEvenVotingPowers() map[string]int64 {
 
 	total := sdk.ZeroInt()
 	for i := 0; i < int(rand.I64Between(1, 20)); i++ {
-		addr := sdk.ValAddress(rand.Bytes(20))
+		addr := rand.ValAddr()
 		votingPower := rand.I64Between(1, 100)
 		votingPowers[addr.String()] = votingPower
 		total = total.AddRaw(votingPower)


### PR DESCRIPTION
## Description
Instead of manually creating test addresses, rely on the rand package