### PR TITLE
fix: replace OS time by block time

### DIFF
--- a/x/bitcoin/keeper/msg_server.go
+++ b/x/bitcoin/keeper/msg_server.go
@@ -698,7 +698,7 @@ func (s msgServer) CreateMasterTx(c context.Context, req *types.CreateMasterTxRe
 		[]string{types.ModuleName, "secondary", "address", "balance"},
 		float32(change.Int64()),
 		[]metrics.Label{
-			telemetry.NewLabel("timestamp", strconv.FormatInt(time.Now().Unix(), 10)),
+			telemetry.NewLabel("timestamp", strconv.FormatInt(ctx.BlockTime().Unix(), 10)),
 			telemetry.NewLabel("address", consolidationAddress.Address),
 		})
 
@@ -829,7 +829,7 @@ func (s msgServer) CreatePendingTransfersTx(c context.Context, req *types.Create
 		[]string{types.ModuleName, "secondary", "address", "balance"},
 		float32(change.Int64()),
 		[]metrics.Label{
-			telemetry.NewLabel("timestamp", strconv.FormatInt(time.Now().Unix(), 10)),
+			telemetry.NewLabel("timestamp", strconv.FormatInt(ctx.BlockTime().Unix(), 10)),
 			telemetry.NewLabel("address", consolidationAddress.Address),
 		})
 

--- a/x/snapshot/keeper/msg_server.go
+++ b/x/snapshot/keeper/msg_server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/telemetry"
@@ -56,7 +55,7 @@ func (s msgServer) RegisterProxy(c context.Context, req *types.RegisterProxyRequ
 		[]string{types.ModuleName, "register", "proxy"},
 		0,
 		[]metrics.Label{
-			telemetry.NewLabel("timestamp", strconv.FormatInt(time.Now().Unix(), 10)),
+			telemetry.NewLabel("timestamp", strconv.FormatInt(ctx.BlockTime().Unix(), 10)),
 			telemetry.NewLabel("principal_address", req.Sender.String()),
 			telemetry.NewLabel("proxy_address", req.ProxyAddr.String()),
 		})
@@ -87,7 +86,7 @@ func (s msgServer) DeactivateProxy(c context.Context, req *types.DeactivateProxy
 		[]string{types.ModuleName, "deactivate", "proxy"},
 		0,
 		[]metrics.Label{
-			telemetry.NewLabel("timestamp", strconv.FormatInt(time.Now().Unix(), 10)),
+			telemetry.NewLabel("timestamp", strconv.FormatInt(ctx.BlockTime().Unix(), 10)),
 			telemetry.NewLabel("principal_address", req.Sender.String()),
 			telemetry.NewLabel("proxy_address", proxy.String()),
 		})

--- a/x/tss/abci.go
+++ b/x/tss/abci.go
@@ -3,7 +3,6 @@ package tss
 import (
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/telemetry"
@@ -124,7 +123,7 @@ func startKeygen(
 	telemetry.SetGauge(float32(minKeygenThreshold.Numerator*100/minKeygenThreshold.Denominator), types.ModuleName, "minimum", "keygen", "threshold")
 
 	// metrics for keygen participation
-	ts := time.Now().Unix()
+	ts := ctx.BlockTime().Unix()
 	for _, validator := range snapshot.Validators {
 		telemetry.SetGaugeWithLabels(
 			[]string{types.ModuleName, "keygen", "participation"},
@@ -259,7 +258,7 @@ func startSign(
 	k.Logger(ctx).Info(fmt.Sprintf("new Sign: sig_id [%s] key_id [%s] message [%s]", info.SigID, info.KeyID, string(info.Msg)))
 
 	// metrics for sign participation
-	ts := time.Now().Unix()
+	ts := ctx.BlockTime().Unix()
 	for _, validator := range snap.Validators {
 		if !k.DoesValidatorParticipateInSign(ctx, info.SigID, validator.GetSDKValidator().GetOperator()) {
 			continue

--- a/x/tss/keeper/msg_server.go
+++ b/x/tss/keeper/msg_server.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/armon/go-metrics"
 	"github.com/btcsuite/btcd/btcec"
@@ -147,7 +146,7 @@ func (s msgServer) StartKeygen(c context.Context, req *types.StartKeygenRequest)
 	telemetry.SetGauge(float32(minKeygenThreshold.Numerator*100/minKeygenThreshold.Denominator), types.ModuleName, "minimum", "keygen", "threshold")
 
 	// metrics for keygen participation
-	ts := time.Now().Unix()
+	ts := ctx.BlockTime().Unix()
 	for _, validator := range snapshot.Validators {
 		telemetry.SetGaugeWithLabels(
 			[]string{types.ModuleName, "keygen", "participation"},
@@ -221,7 +220,7 @@ func (s msgServer) RotateKey(c context.Context, req *types.RotateKeyRequest) (*t
 		[]string{types.ModuleName, strings.ToLower(chain.Name), req.KeyRole.SimpleString(), "key", "id"},
 		0,
 		[]metrics.Label{
-			telemetry.NewLabel("timestamp", strconv.FormatInt(time.Now().Unix(), 10)),
+			telemetry.NewLabel("timestamp", strconv.FormatInt(ctx.BlockTime().Unix(), 10)),
 			telemetry.NewLabel("keyID", string(req.KeyID)),
 		})
 


### PR DESCRIPTION
## Description

using OS time is a non-deterministic operation. Even though it is only used to take metrics, it is still dangerous. This PR replaces all ocurrences of `time.Now()` with `ctx.BlockTime()`

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
