### PR TITLE
fix(ante): check potential nil validator

### DIFF
--- a/x/ante/check_refund.go
+++ b/x/ante/check_refund.go
@@ -69,7 +69,7 @@ func (d CheckRefundFeeDecorator) qualifyForRefund(ctx sdk.Context, msgs []sdk.Ms
 				return false
 			}
 			validator := d.staking.Validator(ctx, validatorAddr)
-			if !validator.IsBonded() {
+			if validator == nil || !validator.IsBonded() {
 				return false
 			}
 		}


### PR DESCRIPTION
## Description
This pr solves second issue on #946, after you create proxy, but before you send a "create validator" TX, vald segfaults and then recovers.

## Todos

- [ ] Unit tests
- [x] Manual tests
- [ ] Documentation
- [x] Connect epics/issues
- [x] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
