### PR TITLE
fix(vald): no bitcoin bridge

### DIFF
--- a/cmd/axelard/cmd/vald/btc/btc.go
+++ b/cmd/axelard/cmd/vald/btc/btc.go
@@ -43,6 +43,11 @@ func NewMgr(rpc rpc3.Client, cliCtx sdkClient.Context, broadcaster types.Broadca
 
 // ProcessConfirmation votes on the correctness of a Bitcoin deposit
 func (mgr *Mgr) ProcessConfirmation(e tmEvents.Event) error {
+	if mgr.rpc == nil {
+		mgr.logger.Error("no bitcoin rpc endpoint was provided during start-up, ignoring confirmation event")
+		return nil
+	}
+
 	outPointInfo, confHeight, pollKey, err := parseConfirmationParams(mgr.cdc, e.Attributes)
 	if err != nil {
 		return sdkerrors.Wrap(err, "Bitcoin transaction confirmation failed")

--- a/cmd/axelard/cmd/vald/start.go
+++ b/cmd/axelard/cmd/vald/start.go
@@ -323,15 +323,20 @@ func createTSSMgr(broadcaster broadcasterTypes.Broadcaster, cliCtx client.Contex
 }
 
 func createBTCMgr(axelarCfg config.ValdConfig, cliCtx client.Context, b broadcasterTypes.Broadcaster, logger log.Logger, cdc *codec.LegacyAmino) *btc.Mgr {
-	rpc, err := btcRPC.NewRPCClient(axelarCfg.BtcConfig, logger)
-	if err != nil {
-		logger.Error(err.Error())
-		panic(err)
-	}
-	// clean up btcRPC connection on process shutdown
-	cleanupCommands = append(cleanupCommands, rpc.Shutdown)
+	var rpc *btcRPC.ClientImpl
+	var err error
 
-	logger.Info("Successfully connected to Bitcoin bridge ")
+	if axelarCfg.BtcConfig.RPCAddr != "" {
+		rpc, err = btcRPC.NewRPCClient(axelarCfg.BtcConfig, logger)
+		if err != nil {
+			logger.Error(err.Error())
+			panic(err)
+		}
+
+		// clean up btcRPC connection on process shutdown
+		cleanupCommands = append(cleanupCommands, rpc.Shutdown)
+		logger.Info("Successfully connected to Bitcoin bridge ")
+	}
 
 	btcMgr := btc.NewMgr(rpc, cliCtx, b, logger, cdc)
 	return btcMgr


### PR DESCRIPTION
## Description

 if no bitcoin bridge was provided, vald will now create a bitcoin manager without any rpc and skip the confirmation event

## Todos

- [ ] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
