### PR TITLE
fix(ante): check potential nil validator (#947)

### DIFF
--- a/x/ante/check_refund.go
+++ b/x/ante/check_refund.go
@@ -69,7 +69,7 @@ func (d CheckRefundFeeDecorator) qualifyForRefund(ctx sdk.Context, msgs []sdk.Ms
 				return false
 			}
 			validator := d.staking.Validator(ctx, validatorAddr)
-			if !validator.IsBonded() {
+			if validator == nil || !validator.IsBonded() {
 				return false
 			}
 		}


### PR DESCRIPTION
## Description
Fix the case that when someone registers the broadcaster address but is not a validator yet

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
