### PR TITLE
feat(axelarnet): register asset on axelarnet

### DIFF
--- a/x/axelarnet/keeper/msg_server.go
+++ b/x/axelarnet/keeper/msg_server.go
@@ -242,6 +242,7 @@ func (s msgServer) RegisterAsset(c context.Context, req *types.RegisterAssetRequ
 	}
 
 	s.nexus.RegisterAsset(ctx, req.Chain, req.Denom)
+	s.nexus.RegisterAsset(ctx, exported.Axelarnet.Name, req.Denom)
 	s.BaseKeeper.RegisterAssetToCosmosChain(ctx, req.Denom, req.Chain)
 
 	return &types.RegisterAssetResponse{}, nil


### PR DESCRIPTION
## Description
When register an asset from a cosmos chain, we also register on the axelarnet. So we can do evm -> axelarnet on that asset

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
