### PR TITLE
fix(evm): add chain command

### DIFF
--- a/x/evm/types/msg_add_chain.go
+++ b/x/evm/types/msg_add_chain.go
@@ -41,6 +41,7 @@ func (m AddChainRequest) ValidateBasic() error {
 		Name:                  m.Name,
 		NativeAsset:           m.NativeAsset,
 		SupportsForeignAssets: true,
+		KeyType:               m.KeyType,
 	}
 
 	if err := chain.Validate(); err != nil {


### PR DESCRIPTION
## Description

Adding a new EVM chain was failing because the validation of `AddChainRequest` messages were assuming `KEYTYPE_UNSPECIFIED` instead of the type defined by the command.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [x] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
