### PR TITLE
fix(evm):  do not return error when additional votes on a failed poll 

### DIFF
--- a/x/evm/keeper/msg_server_test.go
+++ b/x/evm/keeper/msg_server_test.go
@@ -1054,8 +1054,13 @@ func TestHandleMsgConfirmDeposit(t *testing.T) {
 					VoteFunc: func(sdk.ValAddress, codec.ProtoMarshaler) error {
 						return nil
 					},
-					IsFunc: func(vote.PollState) bool {
-						return true
+					IsFunc: func(state vote.PollState) bool {
+						switch state {
+						case vote.Pending:
+							return true
+						default:
+							return false
+						}
 					},
 				}
 			},


### PR DESCRIPTION
## Description
Current Behaviour
If validators vote false on a poll, the pending deposit is deleted after the poll completed.
For validators who vote slightly late, they will get error for no deposit found for poll.


If the voting threshold has been met and additional votes are received they should not return an error

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [x] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
