### PR TITLE
feat(axelarnet): continue execution on error

### DIFF
--- a/x/axelarnet/keeper/msg_server.go
+++ b/x/axelarnet/keeper/msg_server.go
@@ -187,21 +187,24 @@ func (s msgServer) ExecutePendingTransfers(c context.Context, req *types.Execute
 	for _, pendingTransfer := range pendingTransfers {
 		recipient, err := sdk.AccAddressFromBech32(pendingTransfer.Recipient.Address)
 		if err != nil {
-			ctx.Logger().Debug(fmt.Sprintf("Discard invalid recipient %s and continue", pendingTransfer.Recipient.Address))
+			ctx.Logger().Debug(fmt.Sprintf("discard invalid recipient %s and continue", pendingTransfer.Recipient.Address))
 			s.nexus.ArchivePendingTransfer(ctx, pendingTransfer)
 			continue
 		}
 
 		token, escrowAddress, err := prepareTransfer(ctx, s.BaseKeeper, s.nexus, s.bank, s.account, pendingTransfer)
 		if err != nil {
-			return nil, err
+			ctx.Logger().Error(fmt.Sprintf("failed to prepare transfer %s: %e", pendingTransfer.String(), err))
+			continue
 		}
 
 		if err = s.bank.SendCoins(
 			ctx, escrowAddress, recipient, sdk.NewCoins(token),
 		); err != nil {
-			return nil, err
+			ctx.Logger().Error(fmt.Sprintf("failed to send %s from %s to %s: %e", token, escrowAddress, recipient, err))
+			continue
 		}
+		ctx.Logger().Debug(fmt.Sprintf("successfully sent %s from %s to %s", token, escrowAddress, recipient))
 		s.nexus.ArchivePendingTransfer(ctx, pendingTransfer)
 	}
 
@@ -284,18 +287,23 @@ func (s msgServer) RouteIBCTransfers(c context.Context, req *types.RouteIBCTrans
 	for _, c := range s.BaseKeeper.GetCosmosChains(ctx) {
 		chain, ok := s.nexus.GetChain(ctx, c)
 		if !ok {
-			return &types.RouteIBCTransfersResponse{}, fmt.Errorf(fmt.Sprintf("%s is not a registered chain", chain.Name))
+			ctx.Logger().Error(fmt.Sprintf("%s is not a registered chain", chain.Name))
+			continue
 		}
+
 		// Get the channel id for the chain
 		path, ok := s.BaseKeeper.GetIBCPath(ctx, chain.Name)
 		if !ok {
-			return &types.RouteIBCTransfersResponse{}, fmt.Errorf(fmt.Sprintf("destination chain %s does not have a channel", chain.Name))
+			ctx.Logger().Error(fmt.Sprintf("%s is not a registered chain", chain.Name))
+			continue
 		}
+
 		pendingTransfers := s.nexus.GetTransfersForChain(ctx, chain, nexus.Pending)
 		for _, p := range pendingTransfers {
 			token, sender, err := prepareTransfer(ctx, s.BaseKeeper, s.nexus, s.bank, s.account, p)
 			if err != nil {
-				return nil, err
+				ctx.Logger().Error(fmt.Sprintf("failed to prepare transfer %s: %e", p.String(), err))
+				continue
 			}
 
 			err = IBCTransfer(ctx, s.BaseKeeper, s.ibcTransfer, s.ibcChannel, token, sender, p.Recipient.Address, path)
@@ -303,6 +311,7 @@ func (s msgServer) RouteIBCTransfers(c context.Context, req *types.RouteIBCTrans
 				ctx.Logger().Error(fmt.Sprintf("failed to send IBC transfer %s for %s:  %e", token, p.Recipient.Address, err))
 				continue
 			}
+			ctx.Logger().Debug(fmt.Sprintf("successfully sent IBC transfer %s from %s to %s", token, sender, p.Recipient.Address))
 			s.nexus.ArchivePendingTransfer(ctx, p)
 		}
 	}

--- a/x/axelarnet/keeper/msg_server_test.go
+++ b/x/axelarnet/keeper/msg_server_test.go
@@ -288,7 +288,8 @@ func TestHandleMsgExecutePendingTransfers(t *testing.T) {
 		ctx             sdk.Context
 		msg             *types.ExecutePendingTransfersRequest
 
-		transfers []nexus.CrossChainTransfer
+		transfers       []nexus.CrossChainTransfer
+		randTransferIdx int
 	)
 	setup := func() {
 		axelarnetKeeper = &mock.BaseKeeperMock{
@@ -306,6 +307,7 @@ func TestHandleMsgExecutePendingTransfers(t *testing.T) {
 					transfer := randomTransfer(testToken, testChain)
 					transfers = append(transfers, transfer)
 				}
+				randTransferIdx = mathRand.Intn(len(transfers))
 				return transfers
 			},
 			ArchivePendingTransferFunc: func(sdk.Context, nexus.CrossChainTransfer) {},
@@ -343,14 +345,18 @@ func TestHandleMsgExecutePendingTransfers(t *testing.T) {
 		assert.Len(t, nexusKeeper.ArchivePendingTransferCalls(), len(transfers))
 	}).Repeat(repeatCount))
 
-	t.Run("should return error when MintCoins in bank keeper failed", testutils.Func(func(t *testing.T) {
+	t.Run("should continue when MintCoins in bank keeper failed", testutils.Func(func(t *testing.T) {
 		setup()
 		bankKeeper.MintCoinsFunc = func(sdk.Context, string, sdk.Coins) error {
-			return fmt.Errorf("failed")
+			if len(bankKeeper.MintCoinsCalls()) == randTransferIdx+1 {
+				return fmt.Errorf("failed")
+			}
+			return nil
 		}
 		msg = types.NewExecutePendingTransfersRequest(rand.AccAddr())
 		_, err := server.ExecutePendingTransfers(sdk.WrapSDKContext(ctx), msg)
-		assert.Error(t, err)
+		assert.NoError(t, err)
+		assert.Len(t, nexusKeeper.ArchivePendingTransferCalls(), len(transfers)-1)
 	}).Repeat(repeatCount))
 
 	t.Run("should send ICS20 token from escrow account to recipients, and archive pending transfers \\"+
@@ -613,12 +619,12 @@ func TestHandleMsgRouteIBCTransfers(t *testing.T) {
 		assert.Len(t, axelarnetKeeper.SetPendingIBCTransferCalls(), len(transfers))
 	}).Repeat(repeatCount))
 
-	t.Run("should return error when no path registered for cosmos chain", testutils.Func(func(t *testing.T) {
+	t.Run("should continue when no path registered for cosmos chain", testutils.Func(func(t *testing.T) {
 		setup()
 		axelarnetKeeper.GetIBCPathFunc = func(sdk.Context, string) (string, bool) { return "", false }
 		msg = types.NewRouteIBCTransfersRequest(rand.AccAddr())
 		_, err := server.RouteIBCTransfers(sdk.WrapSDKContext(ctx), msg)
-		assert.Error(t, err)
+		assert.NoError(t, err)
 	}).Repeat(repeatCount))
 }
 


### PR DESCRIPTION
## Description
- continue the execution on error so the rest transfers are not blocked
- add more logging

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
