### PR TITLE
feat(ci): sign released containers with sigstore

### DIFF
--- a/.github/workflows/build-docker-image-and-binaries.yaml
+++ b/.github/workflows/build-docker-image-and-binaries.yaml
@@ -16,6 +16,19 @@ jobs:
           - ubuntu-18.04
     runs-on: ${{ matrix.os }}
 
+    permissions:
+      actions: none
+      checks: none
+      contents: read
+      deployments: none
+      issues: none
+      packages: write
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
+      id-token: write # needed for signing the images with GitHub OIDC
+
     steps:
       - name: Validate tag
         env:
@@ -29,6 +42,9 @@ jobs:
           fetch-depth: '0'
           ref: ${{ github.event.inputs.tag }}
           submodules: recursive
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
 
       - name: Set up ssh agent
         uses: webfactory/ssh-agent@v0.5.2
@@ -55,6 +71,12 @@ jobs:
           make build-push-docker-images
         env:
           SEMVER: ${{ github.event.inputs.tag }}
+
+      - name: Sign the images with GitHub OIDC
+        run: cosign sign --oidc-issuer https://token.actions.githubusercontent.com ${TAGS}
+        env:
+          TAGS: axelar-core:${{ github.event.inputs.tag }}
+          COSIGN_EXPERIMENTAL: 1
 
       - name: Build Binaries for Linux/MacOS
         env:


### PR DESCRIPTION
## Description

- Context: sigstore is the latest tool from Linux Foundation for signing containers: https://www.sigstore.dev/
- Use `cosign` cmd from sigstore to perform signature using Github OIDC. More details:
  + https://github.com/sigstore/cosign/blob/main/KEYLESS.md
  + https://github.com/marketplace/actions/install-cosign
- The signed container can be verified later using `cosign` cmd.

## Todos

- [NA] Unit tests
- [] Manual tests
- [] Documentation
- [NA] Connect epics/issues
- [NA ] Tag type of change

## Steps to Test

A sample test can be found in https://github.com/erain9/container-playground/blob/main/.github/workflows/build-container.yaml

## Expected Behaviour

All released container will be signed and can be verified by `cosign` from [sigstore](https://www.sigstore.dev/).

## Other Notes

NA
