### PR TITLE
fix: confirm chain fail

### DIFF
--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -386,22 +386,13 @@ func (s msgServer) ConfirmChain(c context.Context, req *types.ConfirmChainReques
 		return nil, fmt.Errorf("unable to take snapshot: %v", err)
 	}
 
-	keeper := s.ForChain(req.Name)
-
-	period, ok := keeper.GetRevoteLockingPeriod(ctx)
-	if !ok {
-		return nil, fmt.Errorf("could not retrieve revote locking period for chain %s", req.Name)
+	if err := pendingChain.Params.Validate(); err != nil {
+		return nil, err
 	}
 
-	votingThreshold, ok := keeper.GetVotingThreshold(ctx)
-	if !ok {
-		return nil, fmt.Errorf("voting threshold for chain %s not found", req.Name)
-	}
-
-	minVoterCount, ok := keeper.GetMinVoterCount(ctx)
-	if !ok {
-		return nil, fmt.Errorf("min voter count for chain %s not found", req.Name)
-	}
+	period := pendingChain.Params.RevoteLockingPeriod
+	votingThreshold := pendingChain.Params.VotingThreshold
+	minVoterCount := pendingChain.Params.MinVoterCount
 
 	pollKey := vote.NewPollKey(types.ModuleName, req.Name)
 	if err := s.voter.InitializePollWithSnapshot(

--- a/x/evm/keeper/msg_server_test.go
+++ b/x/evm/keeper/msg_server_test.go
@@ -613,8 +613,21 @@ func TestHandleMsgConfirmChain(t *testing.T) {
 			GetPendingChainFunc: func(_ sdk.Context, chain string) (types.PendingChain, bool) {
 				if strings.EqualFold(chain, msg.Name) {
 					return types.PendingChain{
-						Chain:  nexus.Chain{Name: msg.Name, NativeAsset: rand.StrBetween(3, 5), SupportsForeignAssets: true,Module: rand.Str(10)},
-						Params: types.Params{},
+						Chain: nexus.Chain{Name: msg.Name, NativeAsset: rand.StrBetween(3, 5), SupportsForeignAssets: true, Module: rand.Str(10)},
+						Params: types.Params{
+							GatewayCode:         rand.Bytes(1024),
+							TokenCode:           rand.Bytes(1024),
+							Burnable:            rand.Bytes(1024),
+							Chain:               msg.Name,
+							ConfirmationHeight:  1,
+							Network:             "Fuji",
+							RevoteLockingPeriod: 50,
+							Networks:            []types.NetworkInfo{{Name: "Fuji", Id: sdk.NewInt(47)}},
+							VotingThreshold:     utils.NewThreshold(2, 5),
+							MinVoterCount:       2,
+							CommandsGasLimit:    1000,
+							TransactionFeeRate:  sdk.ZeroDec(),
+						},
 					}, true
 				}
 				return types.PendingChain{}, false

--- a/x/evm/keeper/msg_server_test.go
+++ b/x/evm/keeper/msg_server_test.go
@@ -573,7 +573,6 @@ func TestHandleMsgConfirmChain(t *testing.T) {
 	var (
 		ctx     sdk.Context
 		basek   *mock.BaseKeeperMock
-		chaink  *mock.ChainKeeperMock
 		v       *mock.VoterMock
 		n       *mock.NexusMock
 		s       *mock.SnapshotterMock
@@ -592,24 +591,7 @@ func TestHandleMsgConfirmChain(t *testing.T) {
 		}
 		voteReq = &types.VoteConfirmChainRequest{Name: chain}
 
-		chaink = &mock.ChainKeeperMock{
-			GetRevoteLockingPeriodFunc: func(ctx sdk.Context) (int64, bool) {
-				return rand.I64Between(50, 100), true
-			},
-			GetVotingThresholdFunc: func(sdk.Context) (utils.Threshold, bool) {
-				return utils.Threshold{Numerator: 15, Denominator: 100}, true
-			},
-			GetMinVoterCountFunc: func(sdk.Context) (int64, bool) { return 15, true },
-		}
-
 		basek = &mock.BaseKeeperMock{
-			ForChainFunc: func(chain string) types.ChainKeeper {
-				if strings.EqualFold(chain, msg.Name) {
-					return chaink
-				}
-				return nil
-			},
-
 			SetPendingChainFunc: func(sdk.Context, nexus.Chain, types.Params) {},
 			GetPendingChainFunc: func(_ sdk.Context, chain string) (types.PendingChain, bool) {
 				if strings.EqualFold(chain, msg.Name) {

--- a/x/evm/keeper/msg_server_test.go
+++ b/x/evm/keeper/msg_server_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 
+	evmTestUtils "github.com/axelarnetwork/axelar-core/x/evm/types/testutils"
 	tssTestUtils "github.com/axelarnetwork/axelar-core/x/tss/exported/testutils"
 	voteMock "github.com/axelarnetwork/axelar-core/x/vote/exported/mock"
 
@@ -613,21 +614,8 @@ func TestHandleMsgConfirmChain(t *testing.T) {
 			GetPendingChainFunc: func(_ sdk.Context, chain string) (types.PendingChain, bool) {
 				if strings.EqualFold(chain, msg.Name) {
 					return types.PendingChain{
-						Chain: nexus.Chain{Name: msg.Name, NativeAsset: rand.StrBetween(3, 5), SupportsForeignAssets: true, Module: rand.Str(10)},
-						Params: types.Params{
-							GatewayCode:         rand.Bytes(1024),
-							TokenCode:           rand.Bytes(1024),
-							Burnable:            rand.Bytes(1024),
-							Chain:               msg.Name,
-							ConfirmationHeight:  1,
-							Network:             "Fuji",
-							RevoteLockingPeriod: 50,
-							Networks:            []types.NetworkInfo{{Name: "Fuji", Id: sdk.NewInt(47)}},
-							VotingThreshold:     utils.NewThreshold(2, 5),
-							MinVoterCount:       2,
-							CommandsGasLimit:    1000,
-							TransactionFeeRate:  sdk.ZeroDec(),
-						},
+						Chain:  nexus.Chain{Name: msg.Name, NativeAsset: rand.StrBetween(3, 5), SupportsForeignAssets: true, Module: rand.Str(10)},
+						Params: evmTestUtils.RandomParams(),
 					}, true
 				}
 				return types.PendingChain{}, false


### PR DESCRIPTION
## Description

Can't confirm chain
```
$ axelard tx evm confirm-chain avalanche --from validator

{"height":"1612","txhash":"D343773D2ADB880A60B176F6F0BA7346E08E854ED1693ED6EB3BE63E0DF408AC","codespace":"evm","code":2,"data":"","raw_log":"failed to execute message; message index: 0: could not retrieve revote locking period for chain avalanche: bridge error","logs":[],"info":"","gas_wanted":"200000","gas_used":"186934","tx":null,"timestamp":""}
```

Thanks to @jcs47 for help.

## Todos

- [x] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
