### PR TITLE
fix(tss): add separator in getSigs iterator

### DIFF
--- a/x/tss/keeper/keeperSign.go
+++ b/x/tss/keeper/keeperSign.go
@@ -123,9 +123,8 @@ func (k Keeper) StartSign(ctx sdk.Context, info exported.SignInfo, snapshotter t
 }
 
 func (k Keeper) getSignedSigs(ctx sdk.Context) (sigs []exported.Signature) {
-	iter := k.getStore(ctx).Iterator(sigPrefix)
+	iter := k.getStore(ctx).Iterator(sigPrefix.AppendStr("_"))
 	defer utils.CloseLogError(iter, k.Logger(ctx))
-
 	for ; iter.Valid(); iter.Next() {
 		var sig exported.Signature
 		iter.UnmarshalValue(&sig)


### PR DESCRIPTION
## Description
we have a common prefix for `sig` and `sign_queue`
I add this for now, we need an overhaul to solve this as we discussed before

## Todos

- [ ] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
