### PR TITLE
fix(tss): use key in start sign

### DIFF
--- a/x/tss/keeper/keeperSign.go
+++ b/x/tss/keeper/keeperSign.go
@@ -30,9 +30,9 @@ func (k Keeper) StartSign(ctx sdk.Context, info exported.SignInfo, snapshotter t
 		return fmt.Errorf("sig ID '%s' has been used before", info.SigID)
 	}
 
-	keyInfo, ok := k.getKeyInfo(ctx, info.KeyID)
+	key, ok := k.GetKey(ctx, info.KeyID)
 	if !ok {
-		return fmt.Errorf("key info %s not found", info.KeyID)
+		return fmt.Errorf("key %s not found", info.KeyID)
 	}
 
 	snap, ok := snapshotter.GetSnapshot(ctx, info.SnapshotCounter)
@@ -40,7 +40,7 @@ func (k Keeper) StartSign(ctx sdk.Context, info exported.SignInfo, snapshotter t
 		return fmt.Errorf("could not find snapshot with sequence number #%d", info.SnapshotCounter)
 	}
 
-	participants, active, err := k.SelectSignParticipants(ctx, snapshotter, info, snap, keyInfo.KeyType)
+	participants, active, err := k.SelectSignParticipants(ctx, snapshotter, info, snap, key.Type)
 	if err != nil {
 		return err
 	}
@@ -63,12 +63,12 @@ func (k Keeper) StartSign(ctx sdk.Context, info exported.SignInfo, snapshotter t
 		))
 	}
 
-	keyRequirement, ok := k.GetKeyRequirement(ctx, keyInfo.KeyRole, keyInfo.KeyType)
+	keyRequirement, ok := k.GetKeyRequirement(ctx, key.Role, key.Type)
 	if !ok {
-		return fmt.Errorf("key requirement for key role %s type %s not found", keyInfo.KeyRole.SimpleString(), keyInfo.KeyType)
+		return fmt.Errorf("key requirement for %s and %s not found", key.Role, key.Type)
 	}
 
-	switch keyInfo.KeyType {
+	switch key.Type {
 	case exported.Threshold:
 		_, ok := k.GetKey(ctx, info.KeyID)
 		if !ok {
@@ -101,7 +101,7 @@ func (k Keeper) StartSign(ctx sdk.Context, info exported.SignInfo, snapshotter t
 			return err
 		}
 	default:
-		return fmt.Errorf("invalid key type %s", keyInfo.KeyType.SimpleString())
+		return fmt.Errorf("invalid key type %s", key.Type)
 	}
 
 	q := k.GetSignQueue(ctx)

--- a/x/tss/keeper/keeperSign_test.go
+++ b/x/tss/keeper/keeperSign_test.go
@@ -320,7 +320,7 @@ func TestMultisigSign(t *testing.T) {
 			}
 			s.Keeper.SubmitPubKeys(s.Ctx, keyID, v.GetSDKValidator().GetOperator(), pubKeys...)
 		}
-
+		s.Keeper.SetKey(s.Ctx, generateMultisigKey(keyID))
 		err = s.Keeper.StartSign(s.Ctx, signInfo, s.Snapshotter, s.Voter)
 		assert.NoError(t, err)
 		multisigSign, ok := s.Keeper.GetMultisigSignInfo(s.Ctx, sigID)
@@ -369,6 +369,7 @@ func TestMultisigSign(t *testing.T) {
 			}
 			s.Keeper.SubmitPubKeys(s.Ctx, keyID, v.GetSDKValidator().GetOperator(), pubKeys...)
 		}
+		s.Keeper.SetKey(s.Ctx, generateMultisigKey(keyID))
 
 		err = s.Keeper.StartSign(s.Ctx, signInfo, s.Snapshotter, s.Voter)
 		assert.NoError(t, err)


### PR DESCRIPTION
## Description
We use keyinfo to get key type and role. Key info is not exported, which is a wise choice.
Upon import the new genesis, we try to get key info, which leads to error

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
