### PR TITLE
fix: make Link events consistent on axelarnet and evm

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -670,7 +670,6 @@ github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPK
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
-github.com/matryer/moq v0.2.3 h1:Q06vEqnBYjjfx5KKgHfYRKE/lvlRu+Nj+xodG4YdHnU=
 github.com/matryer/moq v0.2.3/go.mod h1:9RtPYjTnH1bSBIkpvtHkFN7nbWAnO7oRpdJkEIn6UtE=
 github.com/matryer/moq v0.2.4 h1:QqYZmY9MZgmqH/7903x7Vk7ul69yF8e6zTS5kRV7W4k=
 github.com/matryer/moq v0.2.4/go.mod h1:9RtPYjTnH1bSBIkpvtHkFN7nbWAnO7oRpdJkEIn6UtE=

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -278,10 +278,10 @@ func (s msgServer) Link(c context.Context, req *types.LinkRequest) (*types.LinkR
 		sdk.NewEvent(
 			types.EventTypeLink,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-			sdk.NewAttribute(types.AttributeKeyChain, req.Chain),
+			sdk.NewAttribute(types.AttributeKeyChain, senderChain.Name),
 			sdk.NewAttribute(types.AttributeKeyBurnAddress, burnerAddr.Hex()),
 			sdk.NewAttribute(types.AttributeKeyAddress, req.RecipientAddr),
-			sdk.NewAttribute(types.AttributeKeyDestinationChain, req.RecipientChain),
+			sdk.NewAttribute(types.AttributeKeyDestinationChain, recipientChain.Name),
 			sdk.NewAttribute(types.AttributeKeyTokenAddress, tokenAddr.Hex()),
 		),
 	)


### PR DESCRIPTION
## Description
Making the spelling of the chains consistent across modules