### PR TITLE
fix(axelarnet): panic in CLI command

### DIFF
--- a/x/axelarnet/client/cli/tx.go
+++ b/x/axelarnet/client/cli/tx.go
@@ -193,7 +193,7 @@ func GetCmdRegisterAsset() *cobra.Command {
 			chain := args[0]
 			denom := args[1]
 
-			minAmount, ok := sdk.NewIntFromString(args[3])
+			minAmount, ok := sdk.NewIntFromString(args[2])
 			if !ok {
 				return fmt.Errorf("could not convert string to integer")
 			}


### PR DESCRIPTION
## Description

There is an index-out-of-range error in the `register-asset` command of the axelarnet module.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
