### PR TITLE
chore: change keyring default to "file"

### DIFF
--- a/cmd/axelard/cmd/root.go
+++ b/cmd/axelard/cmd/root.go
@@ -181,7 +181,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	rootCmd.AddCommand(server.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Codec))
 
 	defaults := map[string]string{
-		flags.FlagKeyringBackend:   "test",
+		flags.FlagKeyringBackend:   "file",
 		flags.FlagBroadcastMode:    flags.BroadcastBlock,
 		flags.FlagSkipConfirmation: "true",
 		flags.FlagGasPrices:        "0.05uaxl",

--- a/docs/cli/axelard_add-genesis-account.md
+++ b/docs/cli/axelard_add-genesis-account.md
@@ -18,7 +18,7 @@ axelard add-genesis-account [address_or_key_name] [coin][,[coin]] [flags]
 ```
       --height int               Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help                     help for add-genesis-account
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test) (default "file")
       --node string              <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --vesting-amount string    amount of coins for vesting accounts
       --vesting-end-time int     schedule end time (unix epoch) for vesting accounts

--- a/docs/cli/axelard_gentx.md
+++ b/docs/cli/axelard_gentx.md
@@ -53,7 +53,7 @@ axelard gentx [key_name] [amount] [flags]
   -h, --help                                help for gentx
       --identity string                     The (optional) identity signature (ex. UPort or Keybase)
       --ip string                           The node's public IP (default "127.0.0.1")
-      --keyring-backend string              Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string              Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string                  The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                              Use a connected Ledger device
       --min-self-delegation string          The minimum self delegation required on the validator

--- a/docs/cli/axelard_keys.md
+++ b/docs/cli/axelard_keys.md
@@ -32,7 +32,7 @@ The pass backend requires GnuPG: https://gnupg.org/
 
 ```
   -h, --help                     help for keys
-      --keyring-backend string   Select keyring's backend (os|file|test) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|test) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
 ```
 

--- a/docs/cli/axelard_keys_add.md
+++ b/docs/cli/axelard_keys_add.md
@@ -53,7 +53,7 @@ axelard keys add <name> [flags]
 
 ```
       --home string              The application home directory (default "$HOME/.axelar")
-      --keyring-backend string   Select keyring's backend (os|file|test) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|test) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --log_format string        The logging format (json|plain) (default "plain")
       --log_level string         The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")

--- a/docs/cli/axelard_keys_delete.md
+++ b/docs/cli/axelard_keys_delete.md
@@ -26,7 +26,7 @@ axelard keys delete <name>... [flags]
 
 ```
       --home string              The application home directory (default "$HOME/.axelar")
-      --keyring-backend string   Select keyring's backend (os|file|test) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|test) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --log_format string        The logging format (json|plain) (default "plain")
       --log_level string         The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")

--- a/docs/cli/axelard_keys_export.md
+++ b/docs/cli/axelard_keys_export.md
@@ -29,7 +29,7 @@ axelard keys export <name> [flags]
 
 ```
       --home string              The application home directory (default "$HOME/.axelar")
-      --keyring-backend string   Select keyring's backend (os|file|test) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|test) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --log_format string        The logging format (json|plain) (default "plain")
       --log_level string         The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")

--- a/docs/cli/axelard_keys_import.md
+++ b/docs/cli/axelard_keys_import.md
@@ -20,7 +20,7 @@ axelard keys import <name> <keyfile> [flags]
 
 ```
       --home string              The application home directory (default "$HOME/.axelar")
-      --keyring-backend string   Select keyring's backend (os|file|test) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|test) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --log_format string        The logging format (json|plain) (default "plain")
       --log_level string         The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")

--- a/docs/cli/axelard_keys_list.md
+++ b/docs/cli/axelard_keys_list.md
@@ -22,7 +22,7 @@ axelard keys list [flags]
 
 ```
       --home string              The application home directory (default "$HOME/.axelar")
-      --keyring-backend string   Select keyring's backend (os|file|test) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|test) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --log_format string        The logging format (json|plain) (default "plain")
       --log_level string         The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")

--- a/docs/cli/axelard_keys_migrate.md
+++ b/docs/cli/axelard_keys_migrate.md
@@ -28,7 +28,7 @@ axelard keys migrate <old_home_dir> [flags]
 
 ```
       --home string              The application home directory (default "$HOME/.axelar")
-      --keyring-backend string   Select keyring's backend (os|file|test) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|test) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --log_format string        The logging format (json|plain) (default "plain")
       --log_level string         The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")

--- a/docs/cli/axelard_keys_mnemonic.md
+++ b/docs/cli/axelard_keys_mnemonic.md
@@ -21,7 +21,7 @@ axelard keys mnemonic [flags]
 
 ```
       --home string              The application home directory (default "$HOME/.axelar")
-      --keyring-backend string   Select keyring's backend (os|file|test) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|test) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --log_format string        The logging format (json|plain) (default "plain")
       --log_level string         The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")

--- a/docs/cli/axelard_keys_parse.md
+++ b/docs/cli/axelard_keys_parse.md
@@ -21,7 +21,7 @@ axelard keys parse <hex-or-bech32-address> [flags]
 
 ```
       --home string              The application home directory (default "$HOME/.axelar")
-      --keyring-backend string   Select keyring's backend (os|file|test) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|test) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --log_format string        The logging format (json|plain) (default "plain")
       --log_level string         The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")

--- a/docs/cli/axelard_keys_show.md
+++ b/docs/cli/axelard_keys_show.md
@@ -27,7 +27,7 @@ axelard keys show [name_or_address [name_or_address...]] [flags]
 
 ```
       --home string              The application home directory (default "$HOME/.axelar")
-      --keyring-backend string   Select keyring's backend (os|file|test) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|test) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --log_format string        The logging format (json|plain) (default "plain")
       --log_level string         The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")

--- a/docs/cli/axelard_query_tendermint-validator-set.md
+++ b/docs/cli/axelard_query_tendermint-validator-set.md
@@ -10,7 +10,7 @@ axelard query tendermint-validator-set [height] [flags]
 
 ```
   -h, --help                     help for tendermint-validator-set
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test) (default "file")
       --limit int                Query number of results returned per page (default 100)
   -n, --node string              Node to connect to (default "tcp://localhost:26657")
       --page int                 Query a specific page of paginated results (default 1)

--- a/docs/cli/axelard_tx_axelarnet_add-cosmos-based-chain.md
+++ b/docs/cli/axelard_tx_axelarnet_add-cosmos-based-chain.md
@@ -20,7 +20,7 @@ axelard tx axelarnet add-cosmos-based-chain [name] [native asset] [min amount] [
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for add-cosmos-based-chain
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_axelarnet_confirm-deposit.md
+++ b/docs/cli/axelard_tx_axelarnet_confirm-deposit.md
@@ -20,7 +20,7 @@ axelard tx axelarnet confirm-deposit [txID] [amount] [burnerAddr] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-deposit
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_axelarnet_execute-pending-transfers.md
+++ b/docs/cli/axelard_tx_axelarnet_execute-pending-transfers.md
@@ -20,7 +20,7 @@ axelard tx axelarnet execute-pending-transfers [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for execute-pending-transfers
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_axelarnet_link.md
+++ b/docs/cli/axelard_tx_axelarnet_link.md
@@ -20,7 +20,7 @@ axelard tx axelarnet link [recipient chain] [recipient address] [asset] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for link
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_axelarnet_register-asset.md
+++ b/docs/cli/axelard_tx_axelarnet_register-asset.md
@@ -20,7 +20,7 @@ axelard tx axelarnet register-asset [chain] [denom] [min amount] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-asset
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_axelarnet_register-fee-collector.md
+++ b/docs/cli/axelard_tx_axelarnet_register-fee-collector.md
@@ -20,7 +20,7 @@ axelard tx axelarnet register-fee-collector [fee collector] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-fee-collector
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_axelarnet_register-path.md
+++ b/docs/cli/axelard_tx_axelarnet_register-path.md
@@ -20,7 +20,7 @@ axelard tx axelarnet register-path [chain] [path] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-path
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_axelarnet_route-ibc-transfers.md
+++ b/docs/cli/axelard_tx_axelarnet_route-ibc-transfers.md
@@ -20,7 +20,7 @@ axelard tx axelarnet route-ibc-transfers [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for route-ibc-transfers
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_bank_send.md
+++ b/docs/cli/axelard_tx_bank_send.md
@@ -21,7 +21,7 @@ axelard tx bank send [from_key_or_address] [to_address] [amount] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for send
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_broadcast.md
+++ b/docs/cli/axelard_tx_broadcast.md
@@ -29,7 +29,7 @@ axelard tx broadcast [file_path] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for broadcast
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_crisis_invariant-broken.md
+++ b/docs/cli/axelard_tx_crisis_invariant-broken.md
@@ -20,7 +20,7 @@ axelard tx crisis invariant-broken [module-name] [invariant-route] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for invariant-broken
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_decode.md
+++ b/docs/cli/axelard_tx_decode.md
@@ -21,7 +21,7 @@ axelard tx decode [amino-byte-string] [flags]
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for decode
   -x, --hex                      Treat input as hexadecimal instead of base64
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_distribution_fund-community-pool.md
+++ b/docs/cli/axelard_tx_distribution_fund-community-pool.md
@@ -27,7 +27,7 @@ axelard tx distribution fund-community-pool [amount] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for fund-community-pool
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_distribution_set-withdraw-addr.md
+++ b/docs/cli/axelard_tx_distribution_set-withdraw-addr.md
@@ -27,7 +27,7 @@ axelard tx distribution set-withdraw-addr [withdraw-addr] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for set-withdraw-addr
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_distribution_withdraw-all-rewards.md
+++ b/docs/cli/axelard_tx_distribution_withdraw-all-rewards.md
@@ -28,7 +28,7 @@ axelard tx distribution withdraw-all-rewards [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for withdraw-all-rewards
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --max-msgs int             Limit the number of messages per tx (0 for unlimited)

--- a/docs/cli/axelard_tx_distribution_withdraw-rewards.md
+++ b/docs/cli/axelard_tx_distribution_withdraw-rewards.md
@@ -30,7 +30,7 @@ axelard tx distribution withdraw-rewards [validator-addr] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for withdraw-rewards
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_encode.md
+++ b/docs/cli/axelard_tx_encode.md
@@ -26,7 +26,7 @@ axelard tx encode [file] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for encode
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_add-chain.md
+++ b/docs/cli/axelard_tx_evm_add-chain.md
@@ -24,7 +24,7 @@ axelard tx evm add-chain [name] [native asset] [key type] [chain config] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for add-chain
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_confirm-chain.md
+++ b/docs/cli/axelard_tx_evm_confirm-chain.md
@@ -20,7 +20,7 @@ axelard tx evm confirm-chain [chain] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-chain
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_confirm-erc20-deposit.md
+++ b/docs/cli/axelard_tx_evm_confirm-erc20-deposit.md
@@ -20,7 +20,7 @@ axelard tx evm confirm-erc20-deposit [chain] [txID] [amount] [burnerAddr] [flags
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-erc20-deposit
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_confirm-erc20-token.md
+++ b/docs/cli/axelard_tx_evm_confirm-erc20-token.md
@@ -20,7 +20,7 @@ axelard tx evm confirm-erc20-token [chain] [origin chain] [origin asset] [txID] 
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-erc20-token
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_confirm-gateway-deployment.md
+++ b/docs/cli/axelard_tx_evm_confirm-gateway-deployment.md
@@ -20,7 +20,7 @@ axelard tx evm confirm-gateway-deployment [chain] [txID] [address] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-gateway-deployment
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_confirm-transfer-operatorship.md
+++ b/docs/cli/axelard_tx_evm_confirm-transfer-operatorship.md
@@ -20,7 +20,7 @@ axelard tx evm confirm-transfer-operatorship [chain] [txID] [keyID] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-transfer-operatorship
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_confirm-transfer-ownership.md
+++ b/docs/cli/axelard_tx_evm_confirm-transfer-ownership.md
@@ -20,7 +20,7 @@ axelard tx evm confirm-transfer-ownership [chain] [txID] [keyID] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-transfer-ownership
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_create-burn-tokens.md
+++ b/docs/cli/axelard_tx_evm_create-burn-tokens.md
@@ -20,7 +20,7 @@ axelard tx evm create-burn-tokens [chain] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for create-burn-tokens
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_create-deploy-token.md
+++ b/docs/cli/axelard_tx_evm_create-deploy-token.md
@@ -20,7 +20,7 @@ axelard tx evm create-deploy-token [evm chain] [origin chain] [origin asset] [to
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for create-deploy-token
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_create-pending-transfers.md
+++ b/docs/cli/axelard_tx_evm_create-pending-transfers.md
@@ -20,7 +20,7 @@ axelard tx evm create-pending-transfers [chain] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for create-pending-transfers
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_link.md
+++ b/docs/cli/axelard_tx_evm_link.md
@@ -20,7 +20,7 @@ axelard tx evm link [chain] [recipient chain] [recipient address] [asset name] [
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for link
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_sign-commands.md
+++ b/docs/cli/axelard_tx_evm_sign-commands.md
@@ -20,7 +20,7 @@ axelard tx evm sign-commands [chain] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for sign-commands
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_transfer-operatorship.md
+++ b/docs/cli/axelard_tx_evm_transfer-operatorship.md
@@ -20,7 +20,7 @@ axelard tx evm transfer-operatorship [chain] [keyID] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for transfer-operatorship
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_evm_transfer-ownership.md
+++ b/docs/cli/axelard_tx_evm_transfer-ownership.md
@@ -20,7 +20,7 @@ axelard tx evm transfer-ownership [chain] [keyID] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for transfer-ownership
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_feegrant_grant.md
+++ b/docs/cli/axelard_tx_feegrant_grant.md
@@ -33,7 +33,7 @@ axelard tx feegrant grant [granter_key_or_address] [grantee] [flags]
       --gas-prices string          Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only              Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                       help for grant
-      --keyring-backend string     Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string     Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string         The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                     Use a connected Ledger device
       --node string                <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_feegrant_revoke.md
+++ b/docs/cli/axelard_tx_feegrant_revoke.md
@@ -28,7 +28,7 @@ axelard tx feegrant revoke [granter] [grantee] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for revoke
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_gov_deposit.md
+++ b/docs/cli/axelard_tx_gov_deposit.md
@@ -28,7 +28,7 @@ axelard tx gov deposit [proposal-id] [deposit] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for deposit
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_gov_submit-proposal.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal.md
@@ -43,7 +43,7 @@ axelard tx gov submit-proposal [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for submit-proposal
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_gov_submit-proposal_cancel-software-upgrade.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal_cancel-software-upgrade.md
@@ -26,7 +26,7 @@ axelard tx gov submit-proposal cancel-software-upgrade [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for cancel-software-upgrade
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_gov_submit-proposal_community-pool-spend.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal_community-pool-spend.md
@@ -38,7 +38,7 @@ axelard tx gov submit-proposal community-pool-spend [proposal-file] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for community-pool-spend
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_gov_submit-proposal_ibc-upgrade.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal_ibc-upgrade.md
@@ -36,7 +36,7 @@ axelard tx gov submit-proposal ibc-upgrade [name] [height] [path/to/upgraded_cli
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for ibc-upgrade
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_gov_submit-proposal_param-change.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal_param-change.md
@@ -52,7 +52,7 @@ axelard tx gov submit-proposal param-change [proposal-file] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for param-change
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_gov_submit-proposal_software-upgrade.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal_software-upgrade.md
@@ -28,7 +28,7 @@ axelard tx gov submit-proposal software-upgrade [name] (--upgrade-height [height
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for software-upgrade
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_gov_submit-proposal_update-client.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal_update-client.md
@@ -28,7 +28,7 @@ axelard tx gov submit-proposal update-client [subject-client-id] [substitute-cli
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for update-client
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_gov_vote.md
+++ b/docs/cli/axelard_tx_gov_vote.md
@@ -28,7 +28,7 @@ axelard tx gov vote [proposal-id] [option] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for vote
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_gov_weighted-vote.md
+++ b/docs/cli/axelard_tx_gov_weighted-vote.md
@@ -28,7 +28,7 @@ axelard tx gov weighted-vote [proposal-id] [weighted-options] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for weighted-vote
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_ibc-transfer_transfer.md
+++ b/docs/cli/axelard_tx_ibc-transfer_transfer.md
@@ -35,7 +35,7 @@ axelard tx ibc-transfer transfer [src-port] [src-channel] [receiver] [amount] [f
       --gas-prices string               Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only                   Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                            help for transfer
-      --keyring-backend string          Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string          Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string              The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                          Use a connected Ledger device
       --node string                     <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_ibc_client_create.md
+++ b/docs/cli/axelard_tx_ibc_client_create.md
@@ -32,7 +32,7 @@ axelard tx ibc client create [path/to/client_state.json] [path/to/consensus_stat
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for create
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_ibc_client_upgrade.md
+++ b/docs/cli/axelard_tx_ibc_client_upgrade.md
@@ -32,7 +32,7 @@ axelard tx ibc client upgrade [client-identifier] [path/to/client_state.json] [p
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for upgrade
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_multisign-batch.md
+++ b/docs/cli/axelard_tx_multisign-batch.md
@@ -33,7 +33,7 @@ axelard tx multisign-batch [file] [name] [[signature-file]...] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for multisign-batch
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --multisig string          Address of the multisig account that the transaction signs on behalf of

--- a/docs/cli/axelard_tx_multisign.md
+++ b/docs/cli/axelard_tx_multisign.md
@@ -41,7 +41,7 @@ axelard tx multisign [file] [name] [[signature]...] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for multisign
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_nexus_deregister-chain-maintainer.md
+++ b/docs/cli/axelard_tx_nexus_deregister-chain-maintainer.md
@@ -20,7 +20,7 @@ axelard tx nexus deregister-chain-maintainer [chains] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for deregister-chain-maintainer
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_nexus_register-chain-maintainer.md
+++ b/docs/cli/axelard_tx_nexus_register-chain-maintainer.md
@@ -20,7 +20,7 @@ axelard tx nexus register-chain-maintainer [chains] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-chain-maintainer
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_permission_deregister-controller.md
+++ b/docs/cli/axelard_tx_permission_deregister-controller.md
@@ -20,7 +20,7 @@ axelard tx permission deregister-controller [controller] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for deregister-controller
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_permission_register-controller.md
+++ b/docs/cli/axelard_tx_permission_register-controller.md
@@ -20,7 +20,7 @@ axelard tx permission register-controller [controller] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-controller
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_permission_update-governance-key.md
+++ b/docs/cli/axelard_tx_permission_update-governance-key.md
@@ -20,7 +20,7 @@ axelard tx permission update-governance-key [threshold] [[pubKey]...] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for update-governance-key
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_sign-batch.md
+++ b/docs/cli/axelard_tx_sign-batch.md
@@ -38,7 +38,7 @@ axelard tx sign-batch [file] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for sign-batch
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --multisig string          Address or key name of the multisig account on behalf of which the transaction shall be signed

--- a/docs/cli/axelard_tx_sign.md
+++ b/docs/cli/axelard_tx_sign.md
@@ -37,7 +37,7 @@ axelard tx sign [file] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for sign
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --multisig string          Address or key name of the multisig account on behalf of which the transaction shall be signed

--- a/docs/cli/axelard_tx_slashing_unjail.md
+++ b/docs/cli/axelard_tx_slashing_unjail.md
@@ -26,7 +26,7 @@ axelard tx slashing unjail [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for unjail
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_snapshot_deactivate-proxy.md
+++ b/docs/cli/axelard_tx_snapshot_deactivate-proxy.md
@@ -20,7 +20,7 @@ axelard tx snapshot deactivate-proxy [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for deactivate-proxy
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_snapshot_register-proxy.md
+++ b/docs/cli/axelard_tx_snapshot_register-proxy.md
@@ -20,7 +20,7 @@ axelard tx snapshot register-proxy [proxy address] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-proxy
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_snapshot_send-tokens.md
+++ b/docs/cli/axelard_tx_snapshot_send-tokens.md
@@ -20,7 +20,7 @@ axelard tx snapshot send-tokens [amount] [address 1] ... [address n] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for send-tokens
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_staking_create-validator.md
+++ b/docs/cli/axelard_tx_staking_create-validator.md
@@ -27,7 +27,7 @@ axelard tx staking create-validator [flags]
   -h, --help                                help for create-validator
       --identity string                     The optional identity signature (ex. UPort or Keybase)
       --ip string                           The node's public IP. It takes effect only when used in combination with --generate-only (default "127.0.0.1")
-      --keyring-backend string              Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string              Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string                  The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                              Use a connected Ledger device
       --min-self-delegation string          The minimum self delegation required on the validator

--- a/docs/cli/axelard_tx_staking_delegate.md
+++ b/docs/cli/axelard_tx_staking_delegate.md
@@ -27,7 +27,7 @@ axelard tx staking delegate [validator-addr] [amount] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for delegate
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_staking_edit-validator.md
+++ b/docs/cli/axelard_tx_staking_edit-validator.md
@@ -23,7 +23,7 @@ axelard tx staking edit-validator [flags]
       --generate-only                Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                         help for edit-validator
       --identity string              The (optional) identity signature (ex. UPort or Keybase) (default "[do-not-modify]")
-      --keyring-backend string       Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string       Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string           The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                       Use a connected Ledger device
       --min-self-delegation string   The minimum self delegation required on the validator

--- a/docs/cli/axelard_tx_staking_redelegate.md
+++ b/docs/cli/axelard_tx_staking_redelegate.md
@@ -27,7 +27,7 @@ axelard tx staking redelegate [src-validator-addr] [dst-validator-addr] [amount]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for redelegate
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_staking_unbond.md
+++ b/docs/cli/axelard_tx_staking_unbond.md
@@ -27,7 +27,7 @@ axelard tx staking unbond [validator-addr] [amount] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for unbond
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_tss_register-external-keys.md
+++ b/docs/cli/axelard_tx_tss_register-external-keys.md
@@ -21,7 +21,7 @@ axelard tx tss register-external-keys [chain] [flags]
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-external-keys
       --key strings              key ID and public key in the hex format, e.g. [keyID:keyHex]
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_tss_rotate.md
+++ b/docs/cli/axelard_tx_tss_rotate.md
@@ -20,7 +20,7 @@ axelard tx tss rotate [chain] [role] [keyID] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for rotate
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_tss_start-keygen.md
+++ b/docs/cli/axelard_tx_tss_start-keygen.md
@@ -23,7 +23,7 @@ axelard tx tss start-keygen [flags]
       --id string                unique ID for new key (required)
       --key-role string          role of the key to be generated (default "master")
       --key-type string          type of the key to be generated (default "multisig")
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_validate-signatures.md
+++ b/docs/cli/axelard_tx_validate-signatures.md
@@ -30,7 +30,7 @@ axelard tx validate-signatures [file] [flags]
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for validate-signatures
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")

--- a/docs/cli/axelard_tx_vesting_create-vesting-account.md
+++ b/docs/cli/axelard_tx_vesting_create-vesting-account.md
@@ -29,7 +29,7 @@ axelard tx vesting create-vesting-account [to_address] [amount] [end_time] [flag
       --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for create-vesting-account
-      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
+      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")


### PR DESCRIPTION
## Description
In preparation to the launch we change the default keyring type from "test" to "file"
