### PR TITLE
fix(axelarnet): collector address validation

### DIFF
--- a/x/axelarnet/types/genesis.go
+++ b/x/axelarnet/types/genesis.go
@@ -42,7 +42,7 @@ func (m GenesisState) Validate() error {
 		return sdkerrors.Wrapf(err, "genesis state for module %s is invalid", ModuleName)
 	}
 
-	if m.CollectorAddress != nil {
+	if len(m.CollectorAddress) > 0 {
 		if err := sdk.VerifyAddressFormat(m.CollectorAddress); err != nil {
 			return getValidateError(err)
 		}


### PR DESCRIPTION
## Description

After generating a new genesis file, `axelard gentx` would fail because the validation of the collectors address at the axelarnet module was buggy

## Todos

- [ ] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [x] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
