### PR TITLE
fix: set keyring backend flag, so it can still be overwritten

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV HOME_DIR /home/axelard
 # Host name for tss daemon (only necessary for validator nodes)
 ENV TOFND_HOST ""
 # The keyring backend type https://docs.cosmos.network/master/run-node/keyring.html
-ENV KEYRING_BACKEND test
+ENV AXELARD_KEYRING_BACKEND file
 # The chain ID
 ENV AXELARD_CHAIN_ID axelar-testnet-toronto
 # The file with the peer list to connect to the network

--- a/cmd/axelard/cmd/root.go
+++ b/cmd/axelard/cmd/root.go
@@ -181,14 +181,18 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	rootCmd.AddCommand(server.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Codec))
 
 	defaults := map[string]string{
-		flags.FlagKeyringBackend:   "file",
 		flags.FlagBroadcastMode:    flags.BroadcastBlock,
 		flags.FlagSkipConfirmation: "true",
 		flags.FlagGasPrices:        "0.05uaxl",
 	}
+	// overwrite default and set as current value
 	utils.OverwriteFlagDefaults(rootCmd, defaults, true)
-	// Only set default, not actual value of chain ID, so it can be overwritten by env variable
-	utils.OverwriteFlagDefaults(rootCmd, map[string]string{flags.FlagChainID: app.Name}, false)
+
+	// Only set default, not actual value, so it can be overwritten by env variable
+	utils.OverwriteFlagDefaults(rootCmd, map[string]string{
+		flags.FlagChainID:        app.Name,
+		flags.FlagKeyringBackend: "file",
+	}, false)
 
 	rootCmd.PersistentFlags().String(tmcli.OutputFlag, "text", "Output format (text|json)")
 


### PR DESCRIPTION
## Description
For testing, we still want to be able to overwrite the keyring backend type with env variables. Because viper prioritizes flags over env variables, the backend flag mustn't be set with the value in order for the env variable to apply.
