### PR TITLE
chore: revert enable cgo for ledger support (#1160) [noci]

### DIFF
--- a/Dockerfile.binaries
+++ b/Dockerfile.binaries
@@ -4,8 +4,7 @@ RUN apt update && apt install \
   openssh-client \
   git \
   ca-certificates \
-  make \
-  build-essential
+  make
 
 WORKDIR $GOPATH/src/github.com/axelarnetwork/axelar-core
 ARG SEMVER
@@ -18,5 +17,5 @@ COPY ./go.sum .
 RUN --mount=type=ssh go mod download
 
 COPY . .
-ENV CGO_ENABLED=1
+ENV CGO_ENABLED=0
 RUN make build-binaries


### PR DESCRIPTION
This reverts commit d2e53233332fdcc4afcafc934d2404dfebae27bf.

## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
