### PR TITLE
fix: overwrite flag defaults correctly

### DIFF
--- a/cmd/axelard/cmd/root_test.go
+++ b/cmd/axelard/cmd/root_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,6 +15,24 @@ func TestNewRootCmd(t *testing.T) {
 		cmd := root
 		assert.True(t, testCmd(t, cmd), "no command with usage 'vald-start' found")
 	})
+
+	t.Run("keyring default set to file", func(t *testing.T) {
+		cmd := root
+		assert.True(t, keyringBackendSetToFile(t, cmd), "no keyring backend flag found")
+	})
+}
+
+func keyringBackendSetToFile(t *testing.T, cmd *cobra.Command) (foundKeyringBackend bool) {
+	if f := cmd.Flags().Lookup(flags.FlagKeyringBackend); f != nil {
+		assert.Equal(t, keyring.BackendFile, f.DefValue)
+		assert.Equal(t, keyring.BackendFile, f.Value)
+		assert.False(t, f.Changed)
+	}
+
+	for _, c := range cmd.Commands() {
+		foundKeyringBackend = foundKeyringBackend || testCmd(t, c)
+	}
+	return foundKeyringBackend
 }
 
 func testCmd(t *testing.T, cmd *cobra.Command) (foundVald bool) {

--- a/cmd/axelard/cmd/utils/utils.go
+++ b/cmd/axelard/cmd/utils/utils.go
@@ -14,6 +14,10 @@ func OverwriteFlagDefaults(c *cobra.Command, defaults map[string]string, updateV
 			if updateVal || !f.Changed {
 				_ = f.Value.Set(val)
 			}
+
+			if updateVal {
+				f.Changed = true
+			}
 		}
 	}
 	for key, val := range defaults {

--- a/cmd/axelard/cmd/utils/utils.go
+++ b/cmd/axelard/cmd/utils/utils.go
@@ -11,9 +11,8 @@ func OverwriteFlagDefaults(c *cobra.Command, defaults map[string]string, updateV
 	set := func(s *pflag.FlagSet, key, val string) {
 		if f := s.Lookup(key); f != nil {
 			f.DefValue = val
-			if updateVal {
-				_ = c.Flags().Set(key, val)
-				_ = c.PersistentFlags().Set(key, val)
+			if updateVal || !f.Changed {
+				_ = f.Value.Set(val)
 			}
 		}
 	}

--- a/cmd/axelard/cmd/utils/utils_test.go
+++ b/cmd/axelard/cmd/utils/utils_test.go
@@ -66,17 +66,12 @@ func TestOverwriteFlagDefaults(t *testing.T) {
 
 			assert.Equal(t, f1.DefValue, newDefaultString)
 			assert.Equal(t, f2.DefValue, strconv.FormatInt(newDefaultInt, 10))
+			assert.Equal(t, f1.Value.String(), newDefaultString)
+			assert.Equal(t, f2.Value.String(), strconv.FormatInt(newDefaultInt, 10))
 
 			if testCase.updateVal {
-				assert.Equal(t, f1.Value.String(), newDefaultString)
 				assert.True(t, f1.Changed)
-				assert.Equal(t, f2.Value.String(), strconv.FormatInt(newDefaultInt, 10))
 				assert.True(t, f2.Changed)
-			} else {
-				assert.Equal(t, f1.Value.String(), defaultString)
-				assert.False(t, f1.Changed)
-				assert.Equal(t, f2.Value.String(), strconv.FormatInt(defaultInt, 10))
-				assert.False(t, f2.Changed)
 			}
 
 		}).Repeat(repeats))


### PR DESCRIPTION
## Description
In case the flag value overwrite wasn't forced only the default value that's displayed to the user was overwritten, not the actual value that's used by the system.