### PR TITLE
fix(keeper): append the delimiter to the iterator key

### DIFF
--- a/utils/store.go
+++ b/utils/store.go
@@ -80,7 +80,7 @@ func (store KVStore) Delete(key Key) {
 
 // Iterator returns an Iterator that can handle a structured Key
 func (store KVStore) Iterator(prefix Key) Iterator {
-	iter := sdk.KVStorePrefixIterator(store.KVStore, prefix.AsKey())
+	iter := sdk.KVStorePrefixIterator(store.KVStore, append(prefix.AsKey(), []byte(DefaultDelimiter)...))
 	return iterator{Iterator: iter, cdc: store.cdc}
 }
 

--- a/x/tss/keeper/keeperSign.go
+++ b/x/tss/keeper/keeperSign.go
@@ -123,7 +123,7 @@ func (k Keeper) StartSign(ctx sdk.Context, info exported.SignInfo, snapshotter t
 }
 
 func (k Keeper) getSignedSigs(ctx sdk.Context) (sigs []exported.Signature) {
-	iter := k.getStore(ctx).Iterator(sigPrefix.AppendStr("_"))
+	iter := k.getStore(ctx).Iterator(sigPrefix)
 	defer utils.CloseLogError(iter, k.Logger(ctx))
 	for ; iter.Valid(); iter.Next() {
 		var sig exported.Signature


### PR DESCRIPTION
## Description

Fixes Issue 1 from the Internal Audit report.
When iterating over a prefix, we don't require `_` to be present right after the prefix in the key. This can lead to an overlap in two keys. For e.g. when iterating with a prefix `state_key123`, both keys `state_key123_value` and `state_key1234_value` will be iterated over.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
