### PR TITLE
fix: only restrict validator from unbonding when holding key shares

### DIFF
--- a/x/ante/ante.go
+++ b/x/ante/ante.go
@@ -89,6 +89,17 @@ func (d ValidateValidatorDeregisteredTssDecorator) AnteHandle(ctx sdk.Context, t
 			if err != nil {
 				return ctx, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, err.Error())
 			}
+
+			delegatorAddress, err := sdk.AccAddressFromBech32(msg.DelegatorAddress)
+			if err != nil {
+				return ctx, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, err.Error())
+			}
+
+			// only restrict a validator from unbonding it's self-delegation
+			if !delegatorAddress.Equals(valAddress) {
+				continue
+			}
+
 			chains := d.nexus.GetChains(ctx)
 
 			for _, chain := range chains {


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
