### PR TITLE
fix: short term fee granter type replace (AccAddress -> string)

### DIFF
--- a/cmd/axelard/cmd/vald/config/config.go
+++ b/cmd/axelard/cmd/vald/config/config.go
@@ -5,7 +5,6 @@ import (
 
 	evm "github.com/axelarnetwork/axelar-core/x/evm/types"
 	tss "github.com/axelarnetwork/axelar-core/x/tss/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // ValdConfig contains all necessary vald configurations
@@ -27,9 +26,9 @@ func DefaultValdConfig() ValdConfig {
 
 // BroadcastConfig is the configuration for transaction broadcasting
 type BroadcastConfig struct {
-	MaxRetries int            `mapstructure:"max-retries"`
-	MinTimeout time.Duration  `mapstructure:"min-timeout"`
-	FeeGranter sdk.AccAddress `mapstructure:"fee_granter"`
+	MaxRetries int           `mapstructure:"max-retries"`
+	MinTimeout time.Duration `mapstructure:"min-timeout"`
+	FeeGranter string        `mapstructure:"fee_granter"`
 }
 
 // DefaultBroadcastConfig returns a configurations populated with default values


### PR DESCRIPTION
## Description
The automatic conversion of `string` in the `config.toml` to `AccAddress` doesn't work properly at the moment, so in the short term change the config to accept a `string` until this can be fixed.