### PR TITLE
feat(evm): include minHeight in VoteConfirmDeposit result event

### DIFF
--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -776,10 +776,13 @@ func (s msgServer) VoteConfirmDeposit(c context.Context, req *types.VoteConfirmD
 		return nil, fmt.Errorf("cross-chain sender has no recipient")
 	}
 
+	height, _ := keeper.GetRequiredConfirmationHeight(ctx)
+
 	// handle poll result
 	event := sdk.NewEvent(types.EventTypeDepositConfirmation,
 		sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
 		sdk.NewAttribute(types.AttributeKeyChain, chain.Name),
+		sdk.NewAttribute(types.AttributeKeyConfHeight, strconv.FormatUint(height, 10)),
 		sdk.NewAttribute(types.AttributeKeyDestinationChain, recipient.Chain.Name),
 		sdk.NewAttribute(types.AttributeKeyDestinationAddress, recipient.Address),
 		sdk.NewAttribute(types.AttributeKeyAmount, pendingDeposit.Amount.String()),


### PR DESCRIPTION
## Description

This PR allows the microservices to simply fetch the minimum confirmation height for a given `VoteConfirmDeposit` result event by reading the event attributes.

vald uses the same approach to get this value when responding to a start `ConfirmDeposit` request.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
