### PR TITLE
feat(vald): new EVM config field

### DIFF
--- a/cmd/axelard/cmd/vald/evm/rpc/rpcClient.go
+++ b/cmd/axelard/cmd/vald/evm/rpc/rpcClient.go
@@ -69,10 +69,14 @@ func (c MoonbeamClientImpl) ChainGetHeader(ctx context.Context, hash common.Hash
 }
 
 // NewClient returns an EVM rpc client
-func NewClient(url string) (Client, error) {
+func NewClient(url string, rpcModuleSupport bool) (Client, error) {
 	evmClient, err := evmClient.Dial(url)
 	if err != nil {
 		return nil, err
+	}
+
+	if !rpcModuleSupport {
+		return evmClient, nil
 	}
 
 	moonbeamClient := MoonbeamClientImpl{

--- a/cmd/axelard/cmd/vald/evm/rpc/rpcClient.go
+++ b/cmd/axelard/cmd/vald/evm/rpc/rpcClient.go
@@ -69,7 +69,7 @@ func (c MoonbeamClientImpl) ChainGetHeader(ctx context.Context, hash common.Hash
 }
 
 // NewClient returns an EVM rpc client
-func NewClient(url string, rpcModuleSupport bool) (Client, error) {
+func NewClient(url string, enableRPCDetection bool) (Client, error) {
 	evmClient, err := evmClient.Dial(url)
 	if err != nil {
 		return nil, err

--- a/cmd/axelard/cmd/vald/evm/rpc/rpcClient.go
+++ b/cmd/axelard/cmd/vald/evm/rpc/rpcClient.go
@@ -75,7 +75,7 @@ func NewClient(url string, rpcModuleSupport bool) (Client, error) {
 		return nil, err
 	}
 
-	if !rpcModuleSupport {
+	if !enableRPCDetection {
 		return evmClient, nil
 	}
 

--- a/cmd/axelard/cmd/vald/start.go
+++ b/cmd/axelard/cmd/vald/start.go
@@ -362,7 +362,7 @@ func createEVMMgr(axelarCfg config.ValdConfig, cliCtx client.Context, b broadcas
 			panic(msg)
 		}
 
-		rpc, err := evmRPC.NewClient(evmChainConf.RPCAddr)
+		rpc, err := evmRPC.NewClient(evmChainConf.RPCAddr, evmChainConf.RPCModuleSupport)
 		if err != nil {
 			err = sdkerrors.Wrap(err, fmt.Sprintf("Failed to create an RPC connection for EVM chain %s. Verify your RPC config.", evmChainConf.Name))
 			logger.Error(err.Error())

--- a/cmd/axelard/cmd/vald/start.go
+++ b/cmd/axelard/cmd/vald/start.go
@@ -362,7 +362,7 @@ func createEVMMgr(axelarCfg config.ValdConfig, cliCtx client.Context, b broadcas
 			panic(msg)
 		}
 
-		rpc, err := evmRPC.NewClient(evmChainConf.RPCAddr, evmChainConf.RPCModuleSupport)
+		rpc, err := evmRPC.NewClient(evmChainConf.RPCAddr, evmChainConf.EnableRPCDetection)
 		if err != nil {
 			err = sdkerrors.Wrap(err, fmt.Sprintf("Failed to create an RPC connection for EVM chain %s. Verify your RPC config.", evmChainConf.Name))
 			logger.Error(err.Error())

--- a/x/evm/types/config.go
+++ b/x/evm/types/config.go
@@ -2,10 +2,10 @@ package types
 
 // EVMConfig contains all EVM module configuration values
 type EVMConfig struct {
-	Name             string `mapstructure:"name"`
-	RPCAddr          string `mapstructure:"rpc_addr"`
-	WithBridge       bool   `mapstructure:"start-with-bridge"`
-	RPCModuleSupport bool   `mapstructure:"rpc-module-support"`
+	Name               string `mapstructure:"name"`
+	RPCAddr            string `mapstructure:"rpc_addr"`
+	WithBridge         bool   `mapstructure:"start-with-bridge"`
+	EnableRPCDetection bool   `mapstructure:"enable-rpc-detection"`
 }
 
 // DefaultConfig returns a configuration populated with default values

--- a/x/evm/types/config.go
+++ b/x/evm/types/config.go
@@ -2,16 +2,18 @@ package types
 
 // EVMConfig contains all EVM module configuration values
 type EVMConfig struct {
-	Name       string `mapstructure:"name"`
-	RPCAddr    string `mapstructure:"rpc_addr"`
-	WithBridge bool   `mapstructure:"start-with-bridge"`
+	Name             string `mapstructure:"name"`
+	RPCAddr          string `mapstructure:"rpc_addr"`
+	WithBridge       bool   `mapstructure:"start-with-bridge"`
+	RPCModuleSupport bool   `mapstructure:"rpc-module-support"`
 }
 
 // DefaultConfig returns a configuration populated with default values
 func DefaultConfig() []EVMConfig {
 	return []EVMConfig{{
-		Name:       "Ethereum",
-		RPCAddr:    "http://127.0.0.1:7545",
-		WithBridge: true,
+		Name:             "Ethereum",
+		RPCAddr:          "http://127.0.0.1:7545",
+		WithBridge:       true,
+		RPCModuleSupport: true,
 	}}
 }

--- a/x/evm/types/config.go
+++ b/x/evm/types/config.go
@@ -11,9 +11,9 @@ type EVMConfig struct {
 // DefaultConfig returns a configuration populated with default values
 func DefaultConfig() []EVMConfig {
 	return []EVMConfig{{
-		Name:             "Ethereum",
-		RPCAddr:          "http://127.0.0.1:7545",
-		WithBridge:       true,
+		Name:               "Ethereum",
+		RPCAddr:            "http://127.0.0.1:7545",
+		WithBridge:         true,
 		EnableRPCDetection: true,
 	}}
 }

--- a/x/evm/types/config.go
+++ b/x/evm/types/config.go
@@ -14,6 +14,6 @@ func DefaultConfig() []EVMConfig {
 		Name:             "Ethereum",
 		RPCAddr:          "http://127.0.0.1:7545",
 		WithBridge:       true,
-		RPCModuleSupport: true,
+		EnableRPCDetection: true,
 	}}
 }


### PR DESCRIPTION
## Description

Upon testing non-standard rpc methods (e.g., Moonbeam's `chain_getFinalizedHead`), ganache returns error code -32000 (server error) instead of -32601 (method not found error). In order to be able to continue using ganache for local testing (as well as to account for other possible situations where we wouldn't want to support non-standard rpc functionality), this PR adds a new field in evm config params called `rpc-module-support`, which allows vald to skip detecting non-standard rpc functionality.

## Todos

- [ ] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [x] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
