### PR TITLE
feat(evm): add query for burner info

### DIFF
--- a/x/evm/client/cli/query.go
+++ b/x/evm/client/cli/query.go
@@ -357,3 +357,26 @@ func GetCmdChains(queryRoute string) *cobra.Command {
 	flags.AddQueryFlagsToCmd(cmd)
 	return cmd
 }
+
+// GetCmdBurnerInfo returns the query to get burner info for the given address
+func GetCmdBurnerInfo(queryRoute string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "burner [chain] [address]",
+		Short: "Get burner info",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			res, err := evmclient.QueryBurnerInfo(clientCtx, args[0], common.HexToAddress(args[1]))
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintProto(&res)
+		},
+	}
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}

--- a/x/evm/client/query.go
+++ b/x/evm/client/query.go
@@ -59,12 +59,16 @@ func QueryCommand(clientCtx client.Context, chain, id string) (types.QueryComman
 	return res, nil
 }
 
-// QueryBurnerInfo returns the information for the given address
+// QueryBurnerInfo returns the burner information for the given address
 func QueryBurnerInfo(clientCtx client.Context, chain string, burnerAddress common.Address) (types.BurnerInfo, error) {
-	path := fmt.Sprintf("custom/%s/%s/%s/%s", types.QuerierRoute, keeper.QBurner, chain, burnerAddress.Hex())
+	path := fmt.Sprintf("custom/%s/%s/%s/%s", types.QuerierRoute, keeper.QBurnerInfo, chain, burnerAddress.Hex())
 	bz, _, err := clientCtx.Query(path)
 	if err != nil {
 		return types.BurnerInfo{}, sdkerrors.Wrapf(err, "could not get burner info for chain %s", chain)
+	}
+
+	if len(bz) == 0 {
+		return types.BurnerInfo{}, fmt.Errorf("burner info not found")
 	}
 
 	var res types.BurnerInfo
@@ -74,4 +78,25 @@ func QueryBurnerInfo(clientCtx client.Context, chain string, burnerAddress commo
 		return types.BurnerInfo{}, sdkerrors.Wrap(err, "could not get burner info")
 	}
 	return res, nil
+}
+
+// QueryBurnerExists returns whether or not the given address is a burner address
+func QueryBurnerExists(clientCtx client.Context, chain string, burnerAddress common.Address) (bool, error) {
+	path := fmt.Sprintf("custom/%s/%s/%s/%s", types.QuerierRoute, keeper.QBurnerInfo, chain, burnerAddress.Hex())
+	bz, _, err := clientCtx.Query(path)
+	if err != nil {
+		return false, sdkerrors.Wrapf(err, "could not get burner info for chain %s", chain)
+	}
+
+	if len(bz) == 0 {
+		return false, nil
+	}
+
+	var res types.BurnerInfo
+	err = res.Unmarshal(bz)
+	if err != nil {
+		return false, sdkerrors.Wrap(err, "could not get burner info")
+	}
+
+	return true, nil
 }

--- a/x/evm/client/query.go
+++ b/x/evm/client/query.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/axelarnetwork/axelar-core/x/evm/keeper"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
@@ -54,6 +55,23 @@ func QueryCommand(clientCtx client.Context, chain, id string) (types.QueryComman
 
 	if err != nil {
 		return types.QueryCommandResponse{}, sdkerrors.Wrap(err, "could not get pending commands")
+	}
+	return res, nil
+}
+
+// QueryBurnerInfo returns the information for the given address
+func QueryBurnerInfo(clientCtx client.Context, chain string, burnerAddress common.Address) (types.BurnerInfo, error) {
+	path := fmt.Sprintf("custom/%s/%s/%s/%s", types.QuerierRoute, keeper.QBurner, chain, burnerAddress.Hex())
+	bz, _, err := clientCtx.Query(path)
+	if err != nil {
+		return types.BurnerInfo{}, sdkerrors.Wrapf(err, "could not get burner info for chain %s", chain)
+	}
+
+	var res types.BurnerInfo
+	err = res.Unmarshal(bz)
+
+	if err != nil {
+		return types.BurnerInfo{}, sdkerrors.Wrap(err, "could not get burner info")
 	}
 	return res, nil
 }

--- a/x/evm/client/rest/query.go
+++ b/x/evm/client/rest/query.go
@@ -314,3 +314,24 @@ func GetHandlerQueryChains(cliCtx client.Context) http.HandlerFunc {
 		rest.PostProcessResponse(w, cliCtx, res)
 	}
 }
+
+// GetHandlerQueryBurnerInfo returns a handler to get burner info for the given address
+func GetHandlerQueryBurnerInfo(cliCtx client.Context) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+
+		chain := mux.Vars(r)[utils.PathVarChain]
+		burnerAddress := common.HexToAddress(mux.Vars(r)[utils.PathVarEthereumAddress])
+		res, err := evmclient.QueryBurnerInfo(cliCtx, chain, burnerAddress)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}

--- a/x/evm/client/rest/query.go
+++ b/x/evm/client/rest/query.go
@@ -335,3 +335,24 @@ func GetHandlerQueryBurnerInfo(cliCtx client.Context) http.HandlerFunc {
 		rest.PostProcessResponse(w, cliCtx, res)
 	}
 }
+
+// GetHandlerQueryBurnerExists returns a handler to check if the given address is a burner
+func GetHandlerQueryBurnerExists(cliCtx client.Context) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+
+		chain := mux.Vars(r)[utils.PathVarChain]
+		burnerAddress := common.HexToAddress(mux.Vars(r)[utils.PathVarEthereumAddress])
+		res, err := evmclient.QueryBurnerExists(cliCtx, chain, burnerAddress)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}

--- a/x/evm/client/rest/tx.go
+++ b/x/evm/client/rest/tx.go
@@ -46,6 +46,8 @@ const (
 	QueryBytecode             = keeper.QBytecode
 	QueryDepositState         = keeper.QDepositState
 	QueryChains               = keeper.QChains
+	QueryBurnerInfo           = keeper.QBurnerInfo
+	QueryBurnerExists         = "burner-exists"
 )
 
 // RegisterRoutes registers this module's REST routes with the given router
@@ -78,6 +80,8 @@ func RegisterRoutes(cliCtx client.Context, r *mux.Router) {
 	registerQuery(GetHandlerQueryBytecode(cliCtx), QueryBytecode, clientUtils.PathVarChain, clientUtils.PathVarContract)
 	registerQuery(GetHandlerQueryDepositState(cliCtx), QueryDepositState, clientUtils.PathVarChain, clientUtils.PathVarTxID, clientUtils.PathVarEthereumAddress, clientUtils.PathVarAmount)
 	registerQuery(GetHandlerQueryChains(cliCtx), QueryChains)
+	registerQuery(GetHandlerQueryBurnerInfo(cliCtx), QueryBurnerInfo, clientUtils.PathVarChain, clientUtils.PathVarEthereumAddress)
+	registerQuery(GetHandlerQueryBurnerExists(cliCtx), QueryBurnerExists, clientUtils.PathVarChain, clientUtils.PathVarEthereumAddress)
 }
 
 // ReqLink represents a request to link a cross-chain address to an EVM chain address

--- a/x/evm/keeper/querier.go
+++ b/x/evm/keeper/querier.go
@@ -33,7 +33,7 @@ const (
 	QPendingCommands       = "pending-commands"
 	QCommand               = "command"
 	QChains                = "chains"
-	QBurner                = "burner"
+	QBurnerInfo            = "burner"
 )
 
 //Bytecode labels
@@ -90,7 +90,7 @@ func NewQuerier(k types.BaseKeeper, s types.Signer, n types.Nexus) sdk.Querier {
 			return queryBytecode(ctx, chainKeeper, s, n, path[2])
 		case QChains:
 			return queryChains(ctx, n)
-		case QBurner:
+		case QBurnerInfo:
 			return QueryBurnerInfo(ctx, n, chainKeeper, common.HexToAddress(path[2]))
 		default:
 			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, fmt.Sprintf("unknown evm-bridge query endpoint: %s", path[0]))
@@ -590,5 +590,5 @@ func QueryBurnerInfo(ctx sdk.Context, n types.Nexus, k types.ChainKeeper, burner
 		return info.Marshal()
 	}
 
-	return nil, fmt.Errorf("burner info not found")
+	return nil, nil
 }


### PR DESCRIPTION
## Description

Adds a query to fetch burner information for a given address so that the microservices can validate whether a transfer event is a deposit before submitting a `ConfirmDeposit` request.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
