### PR TITLE
fix(axelarnet): cobra command to confirm deposits

### DIFF
--- a/x/axelarnet/client/cli/tx.go
+++ b/x/axelarnet/client/cli/tx.go
@@ -74,12 +74,12 @@ func GetCmdConfirmDeposit() *cobra.Command {
 				return err
 			}
 
-			burnerAddr, err := sdk.AccAddressFromBech32(args[2])
+			burnerAddr, err := sdk.AccAddressFromBech32(args[1])
 			if err != nil {
 				return err
 			}
 
-			msg := types.NewConfirmDepositRequest(cliCtx.GetFromAddress(), args[1], burnerAddr)
+			msg := types.NewConfirmDepositRequest(cliCtx.GetFromAddress(), args[0], burnerAddr)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/axelarnet/client/cli/tx.go
+++ b/x/axelarnet/client/cli/tx.go
@@ -67,7 +67,7 @@ func GetCmdConfirmDeposit() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "confirm-deposit [denom] [burnerAddr]",
 		Short: "Confirm a deposit to Axelar chain that sent given the asset denomination and the burner address",
-		Args:  cobra.ExactArgs(3),
+		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {


### PR DESCRIPTION
## Description

CLI command `confirm-deposit` at axelarnet did not match documention, thus still requiring 3 parameters

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
