### PR TITLE
fix: binary versions for signing

### DIFF
--- a/.github/workflows/build-docker-image-and-binaries.yaml
+++ b/.github/workflows/build-docker-image-and-binaries.yaml
@@ -88,11 +88,11 @@ jobs:
         env:
           SEMVER: ${{ github.event.inputs.tag }}
         run: |
-          gpg --armor --detach-sign  axelard-darwin-amd64-v${SEMVER}
-          gpg --armor --detach-sign  axelard-darwin-arm64-v${SEMVER}
-          gpg --armor --detach-sign  axelard-linux-amd64-v${SEMVER}
-          gpg --armor --detach-sign  axelard-linux-arm-v${SEMVER}
-          gpg --armor --detach-sign  axelard-linux-arm64-v${SEMVER}
+          gpg --armor --detach-sign  axelard-darwin-amd64-${SEMVER}
+          gpg --armor --detach-sign  axelard-darwin-arm64-${SEMVER}
+          gpg --armor --detach-sign  axelard-linux-amd64-${SEMVER}
+          gpg --armor --detach-sign  axelard-linux-arm-${SEMVER}
+          gpg --armor --detach-sign  axelard-linux-arm64-${SEMVER}
 
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
## Description

- `v` is already part of ${SEMVER}

