### PR TITLE
fix: unmarshal heartbeat responses

### DIFF
--- a/cmd/axelard/cmd/vald/tss/tss.go
+++ b/cmd/axelard/cmd/vald/tss/tss.go
@@ -362,7 +362,7 @@ func (mgr *Mgr) abortKeygen(keyID string) (err error) {
 
 func (mgr *Mgr) extractRefundMsgResponses(res *sdk.TxResponse) ([]rewardtypes.RefundMsgResponse, error) {
 	var txMsg sdk.TxMsgData
-	var refundReply []rewardtypes.RefundMsgResponse
+	var refundResponses []rewardtypes.RefundMsgResponse
 
 	bz, err := hex.DecodeString(res.Data)
 	if err != nil {
@@ -381,10 +381,10 @@ func (mgr *Mgr) extractRefundMsgResponses(res *sdk.TxResponse) ([]rewardtypes.Re
 			mgr.Logger.Debug(fmt.Sprintf("not a refund response: %v", err))
 			continue
 		}
-		refundReply = append(refundReply, refund)
+		refundResponses = append(refundResponses, refund)
 	}
 
-	return refundReply, nil
+	return refundResponses, nil
 }
 
 func abort(stream Stream) error {

--- a/cmd/axelard/cmd/vald/tss/tss_test.go
+++ b/cmd/axelard/cmd/vald/tss/tss_test.go
@@ -2,11 +2,22 @@ package tss
 
 import (
 	"context"
+	"encoding/hex"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/axelarnetwork/axelar-core/app"
+	types2 "github.com/axelarnetwork/axelar-core/x/reward/types"
+	"github.com/axelarnetwork/axelar-core/x/tss/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+	coretypes "github.com/tendermint/tendermint/rpc/core/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 )
@@ -39,4 +50,43 @@ func TestGRPCTimeout(t *testing.T) {
 		_, err := grpc.DialContext(ctx, "", grpc.WithInsecure(), grpc.WithBlock())
 		assert.Equal(t, context.DeadlineExceeded, err)
 	})
+}
+
+func TestHeartBeatResponseMarshaling(t *testing.T) {
+	res, _ := sdk.WrapServiceResult(sdk.Context{}, &types.HeartBeatResponse{
+		KeygenIllegibility:  7,
+		SigningIllegibility: 49,
+	}, nil)
+
+	res1, _ := sdk.WrapServiceResult(sdk.Context{}, &types2.RefundMsgResponse{Data: res.Data}, nil)
+
+	res, _ = sdk.WrapServiceResult(sdk.Context{}, &types.HeartBeatResponse{
+		KeygenIllegibility:  8,
+		SigningIllegibility: 50,
+	}, nil)
+
+	res2, _ := sdk.WrapServiceResult(sdk.Context{}, &types2.RefundMsgResponse{Data: res.Data}, nil)
+
+	// this is what cosmos-sdk does in the background
+	txMsgData := &sdk.TxMsgData{Data: []*sdk.MsgData{
+		{MsgType: sdk.MsgTypeURL(&types2.RefundMsgRequest{}), Data: res1.Data},
+		{MsgType: sdk.MsgTypeURL(&types2.RefundMsgRequest{}), Data: res2.Data},
+	}}
+	data, _ := proto.Marshal(txMsgData)
+
+	resCommit := coretypes.ResultBroadcastTxCommit{DeliverTx: abci.ResponseDeliverTx{
+		Data: data,
+	}}
+
+	resp := &sdk.TxResponse{Data: strings.ToUpper(hex.EncodeToString(resCommit.DeliverTx.Data))}
+	// -------------------------------
+
+	cfg := app.MakeEncodingConfig()
+	mgr := NewMgr(nil, nil, client.Context{Codec: cfg.Codec}, 0, "", nil, log.TestingLogger(), cfg.Amino)
+	heartbeats, err := mgr.extractHeartBeatResponses(resp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 7, heartbeats[0].KeygenIllegibility)
+	assert.EqualValues(t, 49, heartbeats[0].SigningIllegibility)
+	assert.EqualValues(t, 8, heartbeats[1].KeygenIllegibility)
+	assert.EqualValues(t, 50, heartbeats[1].SigningIllegibility)
 }

--- a/cmd/axelard/cmd/vald/tss/tss_test.go
+++ b/cmd/axelard/cmd/vald/tss/tss_test.go
@@ -53,24 +53,26 @@ func TestGRPCTimeout(t *testing.T) {
 }
 
 func TestHeartBeatResponseMarshaling(t *testing.T) {
-	res, _ := sdk.WrapServiceResult(sdk.Context{}, &types.HeartBeatResponse{
+	heartbeat1 := types.HeartBeatResponse{
 		KeygenIllegibility:  7,
 		SigningIllegibility: 49,
-	}, nil)
+	}
+	wrappedHeartbeat, _ := sdk.WrapServiceResult(sdk.Context{}, &heartbeat1, nil)
 
-	res1, _ := sdk.WrapServiceResult(sdk.Context{}, &types2.RefundMsgResponse{Data: res.Data}, nil)
+	wrappedRefundResponse1, _ := sdk.WrapServiceResult(sdk.Context{}, &types2.RefundMsgResponse{Data: wrappedHeartbeat.Data}, nil)
 
-	res, _ = sdk.WrapServiceResult(sdk.Context{}, &types.HeartBeatResponse{
+	heartbeat2 := types.HeartBeatResponse{
 		KeygenIllegibility:  8,
 		SigningIllegibility: 50,
-	}, nil)
+	}
+	wrappedHeartbeat, _ = sdk.WrapServiceResult(sdk.Context{}, &heartbeat2, nil)
 
-	res2, _ := sdk.WrapServiceResult(sdk.Context{}, &types2.RefundMsgResponse{Data: res.Data}, nil)
+	wrappedRefundReponse2, _ := sdk.WrapServiceResult(sdk.Context{}, &types2.RefundMsgResponse{Data: wrappedHeartbeat.Data}, nil)
 
 	// this is what cosmos-sdk does in the background
 	txMsgData := &sdk.TxMsgData{Data: []*sdk.MsgData{
-		{MsgType: sdk.MsgTypeURL(&types2.RefundMsgRequest{}), Data: res1.Data},
-		{MsgType: sdk.MsgTypeURL(&types2.RefundMsgRequest{}), Data: res2.Data},
+		{MsgType: sdk.MsgTypeURL(&types2.RefundMsgRequest{}), Data: wrappedRefundResponse1.Data},
+		{MsgType: sdk.MsgTypeURL(&types2.RefundMsgRequest{}), Data: wrappedRefundReponse2.Data},
 	}}
 	data, _ := proto.Marshal(txMsgData)
 
@@ -78,15 +80,13 @@ func TestHeartBeatResponseMarshaling(t *testing.T) {
 		Data: data,
 	}}
 
-	resp := &sdk.TxResponse{Data: strings.ToUpper(hex.EncodeToString(resCommit.DeliverTx.Data))}
+	txResp := &sdk.TxResponse{Data: strings.ToUpper(hex.EncodeToString(resCommit.DeliverTx.Data))}
 	// -------------------------------
 
 	cfg := app.MakeEncodingConfig()
 	mgr := NewMgr(nil, nil, client.Context{Codec: cfg.Codec}, 0, "", nil, log.TestingLogger(), cfg.Amino)
-	heartbeats, err := mgr.extractHeartBeatResponses(resp)
+	heartbeats, err := mgr.extractHeartBeatResponses(txResp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, 7, heartbeats[0].KeygenIllegibility)
-	assert.EqualValues(t, 49, heartbeats[0].SigningIllegibility)
-	assert.EqualValues(t, 8, heartbeats[1].KeygenIllegibility)
-	assert.EqualValues(t, 50, heartbeats[1].SigningIllegibility)
+	assert.Equal(t, heartbeat1, heartbeats[0])
+	assert.Equal(t, heartbeat2, heartbeats[1])
 }


### PR DESCRIPTION
## Description
The broadcaster can now send multiple messages per tx, and the heart beat code assumed there was always exactly one msg per tx. This fixes the heart beat code so any number of msgs can be sent, in particular multiple heart beats per tx.