### PR TITLE
feat: adding matrix build

### DIFF
--- a/.github/workflows/build-docker-image-and-binaries.yaml
+++ b/.github/workflows/build-docker-image-and-binaries.yaml
@@ -10,11 +10,13 @@ on:
 
 jobs:
   release:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-18.04
-    runs-on: ${{ matrix.os }}
+        os: [ubuntu-18.04, macos-latest]
+        arch: [amd64, arm64, arm]
+        exclude:
+          - {os: "macos-latest", arch: "arm"}
 
     permissions:
       contents: write
@@ -36,7 +38,69 @@ jobs:
           submodules: recursive
 
       - name: Install Cosign
+        if: matrix.os == 'ubuntu-18.04' && matrix.arch == 'amd64'
         uses: sigstore/cosign-installer@main
+
+      - name: Set up ssh agent
+        if: matrix.os == 'ubuntu-18.04' && matrix.arch == 'amd64'
+        uses: webfactory/ssh-agent@v0.5.2
+        with:
+          ssh-private-key: ${{ secrets.CICD_RSA_KEY }}
+
+      - name: Set up QEMU
+        if: matrix.os == 'ubuntu-18.04' && matrix.arch == 'amd64'
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        if: matrix.os == 'ubuntu-18.04' && matrix.arch == 'amd64'
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          config: .github/buildkit-config.toml
+
+      - name: Login to DockerHub
+        if: matrix.os == 'ubuntu-18.04' && matrix.arch == 'amd64'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build and push docker image for all platforms
+        if: matrix.os == 'ubuntu-18.04' && matrix.arch == 'amd64'
+        run: |
+          make build-push-docker-images
+        env:
+          SEMVER: ${{ github.event.inputs.tag }}
+
+      - name: Sign the images with GitHub OIDC
+        if: matrix.os == 'ubuntu-18.04' && matrix.arch == 'amd64'
+        run: cosign sign --oidc-issuer https://token.actions.githubusercontent.com ${TAGS}
+        env:
+          TAGS: axelarnet/axelar-core:${{ github.event.inputs.tag }}
+          COSIGN_EXPERIMENTAL: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.5
+
+      - name: Build Binaries for Linux/MacOS
+        env:
+          SEMVER: ${{ github.event.inputs.tag }}
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]
+          then
+              OS="linux"
+          else
+              OS="darwin"
+          fi
+          ARCH="${{ matrix.arch }}"
+          make build
+          mv ./bin/axelard ./bin/axelard-"$OS"-"$ARCH"-"$SEMVER"
+
+      - name: Unit test (check ledger support)
+        run: |
+          ./bin/axelard-* version --long
 
       - name: Import GPG key
         id: import_gpg
@@ -45,49 +109,29 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          config: .github/buildkit-config.toml
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-      - name: Build and push docker image for all platforms
-        run: |
-          make build-push-docker-images
-        env:
-          SEMVER: ${{ github.event.inputs.tag }}
-
-      - name: Sign the images with GitHub OIDC
-        run: cosign sign --oidc-issuer https://token.actions.githubusercontent.com ${TAGS}
-        env:
-          TAGS: axelarnet/axelar-core:${{ github.event.inputs.tag }}
-          COSIGN_EXPERIMENTAL: 1
-
-      - name: Build Binaries for Linux/MacOS
-        env:
-          SEMVER: ${{ github.event.inputs.tag }}
-        run: |
-          make build-binaries-in-docker
-
       - name: Sign Binaries
         working-directory: ./bin
         env:
           SEMVER: ${{ github.event.inputs.tag }}
         run: |
-          gpg --armor --detach-sign  axelard-darwin-amd64-${SEMVER}
-          gpg --armor --detach-sign  axelard-darwin-arm64-${SEMVER}
-          gpg --armor --detach-sign  axelard-linux-amd64-${SEMVER}
-          gpg --armor --detach-sign  axelard-linux-arm-${SEMVER}
-          gpg --armor --detach-sign  axelard-linux-arm64-${SEMVER}
+          if [ "$RUNNER_OS" == "Linux" ]
+          then
+              OS="linux"
+          else
+              OS="darwin"
+          fi
+          ARCH="${{ matrix.arch }}"
+          gpg --armor --detach-sign  axelard-"$OS"-"$ARCH"-"$SEMVER"
+
+      - name: Create zip and sha256 files
+        working-directory: ./bin
+        run: |
+          for i in `ls`
+          do
+            zip $i.zip $i
+            shasum -a 256 $i.zip | awk '{print $1}' > $i.zip.sha256
+          done
+          ls
 
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
## Description

## Todos

- [x] Unit tests
- [ ] Manual tests
- [x] Documentation
- [x] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test
Run the https://github.com/axelarnetwork/axelar-core/blob/feat/build-matrix/.github/workflows/build-docker-image-and-binaries.yaml . It is a job triggered manually.
select branch feat/build-matrix.
ideally create a S3 and an ECR for testing purpose.
Enter a semantic tag, you should not use an existing tag (VERY IMPORTANT), if you do so you will overwrite the existing binaries/images. You can check the latest version in the S3 axelar-releases.

## Expected Behavior
The job will run on 5 os/architectures (3 Linux, 2 Darwin).
The build of container images will occur only on Ubuntu/amd64 that is the only job that will run all the steps
In the 4 remaining jobs, all container related steps will be skipped.

## Other Notes
To ensure that Ledger is supported, you can check in the test step of each job see https://github.com/axelarnetwork/axelar-core/runs/5248523237?check_suite_focus=true#step:13:10 for example.
you should see "build_tags: ledger"

