### PR TITLE
fix: test breaking due to key collisions

### DIFF
--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -99,7 +99,7 @@ func TestCommands(t *testing.T) {
 		var commands []types.Command
 
 		for i := 0; i < numCmds; i++ {
-			tokenDetails := createDetails(randomNormalizedStr(10), randomNormalizedStr(3))
+			tokenDetails := createDetails(randomNormalizedStr(10), randomNormalizedStr(10))
 			cmd, err := types.CreateDeployTokenCommand(chainID, tss.KeyID(rand.HexStr(10)), tokenDetails, types.ZeroAddress)
 			assert.NoError(t, err)
 


### PR DESCRIPTION
## Description
a three-letter key doesn't have enough randomness to ensure up to 50 generated keys do not collide