### PR TITLE
refactor: consolidate refund usage

### DIFF
--- a/cmd/axelard/cmd/vald/broadcaster/refundable.go
+++ b/cmd/axelard/cmd/vald/broadcaster/refundable.go
@@ -7,10 +7,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// RefundableBroadcaster only sends RefundMsgRequest msgs
 type RefundableBroadcaster struct {
 	broadcaster *Broadcaster
 }
 
+// Broadcast wraps all given msgs into RefundMsgRequest msgs before broadcasting them
 func (b *RefundableBroadcaster) Broadcast(ctx context.Context, msgs ...sdk.Msg) (*sdk.TxResponse, error) {
 	var refundables []sdk.Msg
 	for _, msg := range msgs {
@@ -19,6 +21,7 @@ func (b *RefundableBroadcaster) Broadcast(ctx context.Context, msgs ...sdk.Msg) 
 	return b.Broadcast(ctx, refundables...)
 }
 
+// WithRefund wraps a broadcaster into a RefundableBroadcaster
 func WithRefund(b *Broadcaster) *RefundableBroadcaster {
 	return &RefundableBroadcaster{broadcaster: b}
 }

--- a/cmd/axelard/cmd/vald/broadcaster/refundable.go
+++ b/cmd/axelard/cmd/vald/broadcaster/refundable.go
@@ -18,7 +18,7 @@ func (b *RefundableBroadcaster) Broadcast(ctx context.Context, msgs ...sdk.Msg) 
 	for _, msg := range msgs {
 		refundables = append(refundables, types.NewRefundMsgRequest(b.broadcaster.clientCtx.FromAddress, msg))
 	}
-	return b.Broadcast(ctx, refundables...)
+	return b.broadcaster.Broadcast(ctx, refundables...)
 }
 
 // WithRefund wraps a broadcaster into a RefundableBroadcaster

--- a/cmd/axelard/cmd/vald/broadcaster/refundable.go
+++ b/cmd/axelard/cmd/vald/broadcaster/refundable.go
@@ -1,0 +1,24 @@
+package broadcaster
+
+import (
+	"context"
+
+	"github.com/axelarnetwork/axelar-core/x/reward/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type RefundableBroadcaster struct {
+	broadcaster *Broadcaster
+}
+
+func (b *RefundableBroadcaster) Broadcast(ctx context.Context, msgs ...sdk.Msg) (*sdk.TxResponse, error) {
+	var refundables []sdk.Msg
+	for _, msg := range msgs {
+		refundables = append(refundables, types.NewRefundMsgRequest(b.broadcaster.clientCtx.FromAddress, msg))
+	}
+	return b.Broadcast(ctx, refundables...)
+}
+
+func WithRefund(b *Broadcaster) *RefundableBroadcaster {
+	return &RefundableBroadcaster{broadcaster: b}
+}

--- a/cmd/axelard/cmd/vald/btc/btc.go
+++ b/cmd/axelard/cmd/vald/btc/btc.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 
-	reward "github.com/axelarnetwork/axelar-core/x/reward/types"
 	tmEvents "github.com/axelarnetwork/tm-events/events"
 	"github.com/btcsuite/btcutil"
 	sdkClient "github.com/cosmos/cosmos-sdk/client"
@@ -57,10 +56,9 @@ func (mgr *Mgr) ProcessConfirmation(e tmEvents.Event) error {
 		mgr.logger.Debug(sdkerrors.Wrap(err, "tx outpoint confirmation failed").Error())
 	}
 	msg := btc.NewVoteConfirmOutpointRequest(mgr.cliCtx.FromAddress, pollKey, outPointInfo.GetOutPoint(), err == nil)
-	refundableMsg := reward.NewRefundMsgRequest(mgr.cliCtx.FromAddress, msg)
 
 	mgr.logger.Debug(fmt.Sprintf("broadcasting vote %v for poll %s", msg.Confirmed, pollKey.String()))
-	_, err = mgr.broadcaster.Broadcast(context.TODO(), refundableMsg)
+	_, err = mgr.broadcaster.Broadcast(context.TODO(), msg)
 	return err
 }
 

--- a/cmd/axelard/cmd/vald/btc/btc_test.go
+++ b/cmd/axelard/cmd/vald/btc/btc_test.go
@@ -5,14 +5,12 @@ import (
 	"strconv"
 	"testing"
 
-	rewardtypes "github.com/axelarnetwork/axelar-core/x/reward/types"
 	tmEvents "github.com/axelarnetwork/tm-events/events"
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/cosmos/cosmos-sdk/client"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/libs/log"
 
@@ -76,7 +74,7 @@ func TestMgr_ProcessConfirmation(t *testing.T) {
 		err := mgr.ProcessConfirmation(tmEvents.Event{Attributes: attributes})
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*btc.VoteConfirmOutpointRequest).Confirmed)
 	}).Repeat(repetitionCount))
 
@@ -89,7 +87,7 @@ func TestMgr_ProcessConfirmation(t *testing.T) {
 		err := mgr.ProcessConfirmation(tmEvents.Event{Attributes: attributes})
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*btc.VoteConfirmOutpointRequest).Confirmed)
 	}).Repeat(repetitionCount))
 
@@ -106,7 +104,7 @@ func TestMgr_ProcessConfirmation(t *testing.T) {
 		err := mgr.ProcessConfirmation(tmEvents.Event{Attributes: attributes})
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*btc.VoteConfirmOutpointRequest).Confirmed)
 	}).Repeat(repetitionCount))
 
@@ -124,7 +122,7 @@ func TestMgr_ProcessConfirmation(t *testing.T) {
 		err := mgr.ProcessConfirmation(tmEvents.Event{Attributes: attributes})
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*btc.VoteConfirmOutpointRequest).Confirmed)
 	})
 
@@ -141,7 +139,7 @@ func TestMgr_ProcessConfirmation(t *testing.T) {
 		err := mgr.ProcessConfirmation(tmEvents.Event{Attributes: attributes})
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.True(t, msg.(*btc.VoteConfirmOutpointRequest).Confirmed)
 	}).Repeat(repetitionCount))
 }
@@ -158,8 +156,4 @@ func randomOutpointInfo() btc.OutPointInfo {
 		Amount:   btcutil.Amount(rand.I64Between(1, 10000000)),
 		Address:  rand.StrBetween(1, 100),
 	}
-}
-
-func unwrapRefundMsg(msg sdk.Msg) sdk.Msg {
-	return msg.(*rewardtypes.RefundMsgRequest).GetInnerMessage()
 }

--- a/cmd/axelard/cmd/vald/evm/evm.go
+++ b/cmd/axelard/cmd/vald/evm/evm.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	reward "github.com/axelarnetwork/axelar-core/x/reward/types"
 	tmEvents "github.com/axelarnetwork/tm-events/events"
 	sdkClient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -80,9 +79,8 @@ func (mgr Mgr) ProcessChainConfirmation(e tmEvents.Event) (err error) {
 	_, confirmed := mgr.rpcs[strings.ToLower(chain)]
 
 	msg := evmTypes.NewVoteConfirmChainRequest(mgr.cliCtx.FromAddress, chain, pollKey, confirmed)
-	refundableMsg := reward.NewRefundMsgRequest(mgr.cliCtx.FromAddress, msg)
 	mgr.logger.Info(fmt.Sprintf("broadcasting vote %v for poll %s", msg.Confirmed, pollKey.String()))
-	_, err = mgr.broadcaster.Broadcast(context.TODO(), refundableMsg)
+	_, err = mgr.broadcaster.Broadcast(context.TODO(), msg)
 	return err
 }
 
@@ -111,10 +109,9 @@ func (mgr Mgr) ProcessGatewayDeploymentConfirmation(e tmEvents.Event) error {
 	})
 
 	msg := evmTypes.NewVoteConfirmGatewayDeploymentRequest(mgr.cliCtx.FromAddress, chain, pollKey, confirmed)
-	refundableMsg := reward.NewRefundMsgRequest(mgr.cliCtx.FromAddress, msg)
 
 	mgr.logger.Info(fmt.Sprintf("broadcasting vote %v for poll %s", msg.Confirmed, pollKey.String()))
-	_, err = mgr.broadcaster.Broadcast(context.TODO(), refundableMsg)
+	_, err = mgr.broadcaster.Broadcast(context.TODO(), msg)
 
 	return err
 }
@@ -141,9 +138,8 @@ func (mgr Mgr) ProcessDepositConfirmation(e tmEvents.Event) (err error) {
 	})
 
 	msg := evmTypes.NewVoteConfirmDepositRequest(mgr.cliCtx.FromAddress, chain, pollKey, txID, evmTypes.Address(burnAddr), confirmed)
-	refundableMsg := reward.NewRefundMsgRequest(mgr.cliCtx.FromAddress, msg)
 	mgr.logger.Info(fmt.Sprintf("broadcasting vote %v for poll %s", msg.Confirmed, pollKey.String()))
-	_, err = mgr.broadcaster.Broadcast(context.TODO(), refundableMsg)
+	_, err = mgr.broadcaster.Broadcast(context.TODO(), msg)
 	return err
 }
 
@@ -169,9 +165,8 @@ func (mgr Mgr) ProcessTokenConfirmation(e tmEvents.Event) error {
 	})
 
 	msg := evmTypes.NewVoteConfirmTokenRequest(mgr.cliCtx.FromAddress, chain, asset, pollKey, txID, confirmed)
-	refundableMsg := reward.NewRefundMsgRequest(mgr.cliCtx.FromAddress, msg)
 	mgr.logger.Info(fmt.Sprintf("broadcasting vote %v for poll %s", msg.Confirmed, pollKey.String()))
-	_, err = mgr.broadcaster.Broadcast(context.TODO(), refundableMsg)
+	_, err = mgr.broadcaster.Broadcast(context.TODO(), msg)
 	return err
 }
 
@@ -208,9 +203,8 @@ func (mgr Mgr) ProcessTransferKeyConfirmation(e tmEvents.Event) (err error) {
 	})
 
 	msg := evmTypes.NewVoteConfirmTransferKeyRequest(mgr.cliCtx.FromAddress, chain, pollKey, confirmed)
-	refundableMsg := reward.NewRefundMsgRequest(mgr.cliCtx.FromAddress, msg)
 	mgr.logger.Info(fmt.Sprintf("broadcasting vote %v for poll %s", msg.Confirmed, pollKey.String()))
-	_, err = mgr.broadcaster.Broadcast(context.TODO(), refundableMsg)
+	_, err = mgr.broadcaster.Broadcast(context.TODO(), msg)
 	return err
 }
 

--- a/cmd/axelard/cmd/vald/evm/evm_test.go
+++ b/cmd/axelard/cmd/vald/evm/evm_test.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"testing"
 
-	rewardtypes "github.com/axelarnetwork/axelar-core/x/reward/types"
 	tmEvents "github.com/axelarnetwork/tm-events/events"
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -355,7 +354,7 @@ func TestMgr_ProccessDepositConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.True(t, msg.(*evmTypes.VoteConfirmDepositRequest).Confirmed)
 	}).Repeat(repeats))
 
@@ -378,7 +377,7 @@ func TestMgr_ProccessDepositConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*evmTypes.VoteConfirmDepositRequest).Confirmed)
 	}).Repeat(repeats))
 
@@ -392,7 +391,7 @@ func TestMgr_ProccessDepositConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*evmTypes.VoteConfirmDepositRequest).Confirmed)
 	}).Repeat(repeats))
 
@@ -404,7 +403,7 @@ func TestMgr_ProccessDepositConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*evmTypes.VoteConfirmDepositRequest).Confirmed)
 	}).Repeat(repeats))
 }
@@ -479,7 +478,7 @@ func TestMgr_ProccessTokenConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.True(t, msg.(*evmTypes.VoteConfirmTokenRequest).Confirmed)
 	}).Repeat(repeats))
 
@@ -502,7 +501,7 @@ func TestMgr_ProccessTokenConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*evmTypes.VoteConfirmTokenRequest).Confirmed)
 	}).Repeat(repeats))
 
@@ -516,7 +515,7 @@ func TestMgr_ProccessTokenConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*evmTypes.VoteConfirmTokenRequest).Confirmed)
 	}).Repeat(repeats))
 
@@ -538,7 +537,7 @@ func TestMgr_ProccessTokenConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*evmTypes.VoteConfirmTokenRequest).Confirmed)
 	}).Repeat(repeats))
 
@@ -557,7 +556,7 @@ func TestMgr_ProccessTokenConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*evmTypes.VoteConfirmTokenRequest).Confirmed)
 	}).Repeat(repeats))
 }
@@ -677,7 +676,7 @@ func TestMgr_ProcessTransferKeyConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.True(t, msg.(*evmTypes.VoteConfirmTransferKeyRequest).Confirmed)
 	}).Repeat(repeats))
 
@@ -700,7 +699,7 @@ func TestMgr_ProcessTransferKeyConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*evmTypes.VoteConfirmTransferKeyRequest).Confirmed)
 	}).Repeat(repeats))
 
@@ -714,7 +713,7 @@ func TestMgr_ProcessTransferKeyConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*evmTypes.VoteConfirmTransferKeyRequest).Confirmed)
 	}).Repeat(repeats))
 
@@ -727,7 +726,7 @@ func TestMgr_ProcessTransferKeyConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*evmTypes.VoteConfirmTransferKeyRequest).Confirmed)
 	}).Repeat(repeats))
 
@@ -745,7 +744,7 @@ func TestMgr_ProcessTransferKeyConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*evmTypes.VoteConfirmTransferKeyRequest).Confirmed)
 	}).Repeat(repeats))
 
@@ -758,7 +757,7 @@ func TestMgr_ProcessTransferKeyConfirmation(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, broadcaster.BroadcastCalls(), 1)
-		msg := unwrapRefundMsg(broadcaster.BroadcastCalls()[0].Msgs[0])
+		msg := broadcaster.BroadcastCalls()[0].Msgs[0]
 		assert.False(t, msg.(*evmTypes.VoteConfirmTransferKeyRequest).Confirmed)
 	}).Repeat(repeats))
 }
@@ -802,8 +801,4 @@ func createTokenLogs(denom string, gateway, tokenAddr common.Address, deploySig 
 	}
 
 	return logs
-}
-
-func unwrapRefundMsg(msg sdk.Msg) sdk.Msg {
-	return msg.(*rewardtypes.RefundMsgRequest).GetInnerMessage()
 }

--- a/cmd/axelard/cmd/vald/start.go
+++ b/cmd/axelard/cmd/vald/start.go
@@ -173,7 +173,7 @@ func listen(clientCtx sdkClient.Context, txf tx.Factory, axelarCfg config.ValdCo
 		WithFromAddress(sender.GetAddress()).
 		WithFromName(sender.GetName())
 
-	bc := createBroadcaster(txf, clientCtx, axelarCfg, logger)
+	bc := createRefundableBroadcaster(txf, clientCtx, axelarCfg, logger)
 
 	tmClient, err := clientCtx.GetNode()
 	if err != nil {
@@ -357,9 +357,9 @@ func createEventBus(client rpcclient.Client, startBlock int64, logger log.Logger
 	return tmEvents.NewEventBus(tmEvents.NewBlockSource(client, notifier), pubsub.NewBus, logger)
 }
 
-func createBroadcaster(txf tx.Factory, ctx sdkClient.Context, axelarCfg config.ValdConfig, logger log.Logger) broadcasterTypes.Broadcaster {
+func createRefundableBroadcaster(txf tx.Factory, ctx sdkClient.Context, axelarCfg config.ValdConfig, logger log.Logger) broadcasterTypes.Broadcaster {
 	pipeline := broadcaster.NewPipelineWithRetry(10000, axelarCfg.MaxRetries, utils2.LinearBackOff(axelarCfg.MinTimeout), logger)
-	return broadcaster.NewBroadcaster(txf, ctx, pipeline, axelarCfg.BatchThreshold, axelarCfg.BatchSizeLimit, logger)
+	return broadcaster.WithRefund(broadcaster.NewBroadcaster(txf, ctx, pipeline, axelarCfg.BatchThreshold, axelarCfg.BatchSizeLimit, logger))
 }
 
 func createTSSMgr(broadcaster broadcasterTypes.Broadcaster, cliCtx client.Context, axelarCfg config.ValdConfig, logger log.Logger, valAddr string, cdc *codec.LegacyAmino) *tss.Mgr {

--- a/cmd/axelard/cmd/vald/tss/sign.go
+++ b/cmd/axelard/cmd/vald/tss/sign.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strconv"
 
-	reward "github.com/axelarnetwork/axelar-core/x/reward/types"
 	tmEvents "github.com/axelarnetwork/tm-events/events"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -175,8 +174,7 @@ func (mgr *Mgr) handleIntermediateSignMsgs(sigID string, intermediate <-chan *to
 			sigID, mgr.principalAddr, msg.ToPartyUid, msg.IsBroadcast))
 		// sender is set by broadcaster
 		tssMsg := types.NewProcessSignTrafficRequest(mgr.cliCtx.FromAddress, sigID, *msg)
-		refundableMsg := reward.NewRefundMsgRequest(mgr.cliCtx.FromAddress, tssMsg)
-		if _, err := mgr.broadcaster.Broadcast(context.TODO(), refundableMsg); err != nil {
+		if _, err := mgr.broadcaster.Broadcast(context.TODO(), tssMsg); err != nil {
 			return sdkerrors.Wrap(err, "handler goroutine: failure to broadcast outgoing sign msg")
 		}
 	}
@@ -206,8 +204,7 @@ func (mgr *Mgr) handleSignResult(sigID string, resultChan <-chan interface{}) er
 
 	key := voting.NewPollKey(tss.ModuleName, sigID)
 	vote := &tss.VoteSigRequest{Sender: mgr.cliCtx.FromAddress, PollKey: key, Result: *result}
-	refundableMsg := reward.NewRefundMsgRequest(mgr.cliCtx.FromAddress, vote)
-	_, err := mgr.broadcaster.Broadcast(context.TODO(), refundableMsg)
+	_, err := mgr.broadcaster.Broadcast(context.TODO(), vote)
 	return err
 }
 
@@ -239,9 +236,8 @@ func (mgr *Mgr) multiSigSignStart(keyID string, sigID string, shares uint32, pay
 
 	mgr.Logger.Info(fmt.Sprintf("operator %s sending multisig signatures for sig %s", mgr.principalAddr, sigID))
 	tssMsg := tss.NewSubmitMultisigSignaturesRequest(mgr.cliCtx.FromAddress, sigID, signatures)
-	refundableMsg := reward.NewRefundMsgRequest(mgr.cliCtx.FromAddress, tssMsg)
 
-	if _, err := mgr.broadcaster.Broadcast(context.TODO(), refundableMsg); err != nil {
+	if _, err := mgr.broadcaster.Broadcast(context.TODO(), tssMsg); err != nil {
 		return sdkerrors.Wrap(err, "handler goroutine: failure to broadcast outgoing multisig keys msg")
 	}
 

--- a/cmd/axelard/cmd/vald/tss/tss.go
+++ b/cmd/axelard/cmd/vald/tss/tss.go
@@ -288,10 +288,9 @@ func (mgr *Mgr) ProcessHeartBeatEvent(e tmEvents.Event) error {
 	}
 
 	tssMsg := tss.NewHeartBeatRequest(mgr.cliCtx.FromAddress, present)
-	refundableMsg := rewardtypes.NewRefundMsgRequest(mgr.cliCtx.FromAddress, tssMsg)
 
 	mgr.Logger.Info(fmt.Sprintf("operator %s sending heartbeat acknowledging keys: %s", mgr.principalAddr, present))
-	txRes, err := mgr.broadcaster.Broadcast(context.TODO(), refundableMsg)
+	txRes, err := mgr.broadcaster.Broadcast(context.TODO(), tssMsg)
 	if err != nil {
 		return sdkerrors.Wrap(err, "handler goroutine: failure to broadcast outgoing heartbeat msg")
 	}


### PR DESCRIPTION
## Description
To prevent forgetting to wrap vald messages in refund requests a new broadcaster is introduced that does this for all messages