### PR TITLE
fix: do the broadcast backlog length check at the correct location

### DIFF
--- a/cmd/axelard/cmd/vald/broadcaster/broadcast.go
+++ b/cmd/axelard/cmd/vald/broadcaster/broadcast.go
@@ -73,7 +73,7 @@ func (b *Broadcaster) processBacklog() {
 			batch = append(batch, task)
 			msgCount += len(task.Msgs)
 
-			// if there are no new tasks are in the backlog, stop filling up the batch
+			// if there are no new tasks in the backlog, stop filling up the batch
 			if b.backlog.Len() == 0 {
 				break
 			}

--- a/cmd/axelard/cmd/vald/broadcaster/broadcast.go
+++ b/cmd/axelard/cmd/vald/broadcaster/broadcast.go
@@ -62,9 +62,9 @@ func (b *Broadcaster) processBacklog() {
 		msgCount := 0
 		for {
 			// we cannot split a single task, so take at least one task and then fill up the batch
-			// until the size limit is reached or no new tasks are in the backlog
+			// until the size limit is reached
 			batchWouldBeTooLarge := len(batch) > 0 && msgCount+len(b.backlog.Peek().Msgs) > b.batchSizeLimit
-			if batchWouldBeTooLarge || b.backlog.Len() == 0 {
+			if batchWouldBeTooLarge {
 				break
 			}
 
@@ -72,6 +72,11 @@ func (b *Broadcaster) processBacklog() {
 
 			batch = append(batch, task)
 			msgCount += len(task.Msgs)
+
+			// if there are no new tasks are in the backlog, stop filling up the batch
+			if b.backlog.Len() == 0 {
+				break
+			}
 		}
 
 		b.logger.Debug("high traffic; merging batches", "batch_size", msgCount)

--- a/cmd/axelard/cmd/vald/broadcaster/broadcast.go
+++ b/cmd/axelard/cmd/vald/broadcaster/broadcast.go
@@ -60,17 +60,14 @@ func (b *Broadcaster) processBacklog() {
 
 		var batch []broadcastTask
 		msgCount := 0
-		b.logger.Debug("start creating a batch")
 		for {
 			// we cannot split a single task, so take at least one task and then fill up the batch
 			// until the size limit is reached
 			batchWouldBeTooLarge := len(batch) > 0 && msgCount+len(b.backlog.Peek().Msgs) > b.batchSizeLimit
 			if batchWouldBeTooLarge {
-				b.logger.Debug("batch is full")
 				break
 			}
 
-			b.logger.Debug("popping msgs from backlog")
 			task := b.backlog.Pop()
 
 			batch = append(batch, task)
@@ -78,10 +75,8 @@ func (b *Broadcaster) processBacklog() {
 
 			// if there are no new tasks in the backlog, stop filling up the batch
 			if b.backlog.Len() == 0 {
-				b.logger.Debug("backlog empty")
 				break
 			}
-			b.logger.Debug("checking more msgs in the backlog")
 		}
 
 		b.logger.Debug("high traffic; merging batches", "batch_size", msgCount)

--- a/cmd/axelard/cmd/vald/broadcaster/broadcast.go
+++ b/cmd/axelard/cmd/vald/broadcaster/broadcast.go
@@ -60,14 +60,17 @@ func (b *Broadcaster) processBacklog() {
 
 		var batch []broadcastTask
 		msgCount := 0
+		b.logger.Debug("start creating a batch")
 		for {
 			// we cannot split a single task, so take at least one task and then fill up the batch
 			// until the size limit is reached
 			batchWouldBeTooLarge := len(batch) > 0 && msgCount+len(b.backlog.Peek().Msgs) > b.batchSizeLimit
 			if batchWouldBeTooLarge {
+				b.logger.Debug("batch is full")
 				break
 			}
 
+			b.logger.Debug("popping msgs from backlog")
 			task := b.backlog.Pop()
 
 			batch = append(batch, task)
@@ -75,8 +78,10 @@ func (b *Broadcaster) processBacklog() {
 
 			// if there are no new tasks in the backlog, stop filling up the batch
 			if b.backlog.Len() == 0 {
+				b.logger.Debug("backlog empty")
 				break
 			}
+			b.logger.Debug("checking more msgs in the backlog")
 		}
 
 		b.logger.Debug("high traffic; merging batches", "batch_size", msgCount)

--- a/cmd/axelard/cmd/vald/broadcaster/broadcast.go
+++ b/cmd/axelard/cmd/vald/broadcaster/broadcast.go
@@ -379,10 +379,10 @@ func (bl *backlog) Peek() broadcastTask {
 }
 
 func (bl *backlog) Len() int {
-	bl.loadHead()
-
+	// do not block in this function because it might be used to inform other calls like Peek()
 	if len(bl.head.Msgs) == 0 {
-		return 0
+		// head is not currently loaded
+		return len(bl.tail)
 	}
 
 	return 1 + len(bl.tail)


### PR DESCRIPTION
## Description
Currently the broadcaster runs into a deadlock, because the length check of the backlog is done AFTER a peek into the backlog. Not only does peek not change the backlog length, but will also block on an empty backlog. Now it is done correctly after a pop from the backlog