### PR TITLE
fix(evm): token query response

### DIFF
--- a/x/evm/keeper/querier.go
+++ b/x/evm/keeper/querier.go
@@ -435,7 +435,10 @@ func QueryTokenAddressByAsset(ctx sdk.Context, k types.ChainKeeper, n types.Nexu
 		return nil, sdkerrors.Wrap(types.ErrEVM, fmt.Sprintf("token for asset '%s' non-existent", asset))
 	}
 
-	resp := types.QueryTokenAddressResponse{Address: token.GetAddress().Hex()}
+	resp := types.QueryTokenAddressResponse{
+		Address:   token.GetAddress().Hex(),
+		Confirmed: token.Is(types.Confirmed),
+	}
 	return types.ModuleCdc.MarshalLengthPrefixed(&resp)
 }
 


### PR DESCRIPTION
## Description

The response from `axelard q evm token-address [chain] --asset [denom]` would always return `status: false` even if the token was confirmed

## Todos

- [ ] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [x] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
