### PR TITLE
feat: check release existence

### DIFF
--- a/.github/workflows/build-docker-image-and-binaries.yaml
+++ b/.github/workflows/build-docker-image-and-binaries.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Github tag to release binaries for (reusing same tag will overwrite previously released binaries)
+        description: Github tag to release binaries for (reusing an existing tag will make the pipeline fail)
         required: true
         default: latest
 

--- a/.github/workflows/build-docker-image-and-binaries.yaml
+++ b/.github/workflows/build-docker-image-and-binaries.yaml
@@ -24,11 +24,20 @@ jobs:
       id-token: write
 
     steps:
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
       - name: Validate tag
         env:
           SEMVER: ${{ github.event.inputs.tag }}
         run: |
           if [[ $SEMVER =~ v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]]; then echo "Tag is okay" && exit 0; else echo "invalid tag" && exit 1; fi
+          aws s3 ls s3://axelar-releases/axelard/$SEMVER && echo "tag already exists, use a new one" && exit 1          
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -153,13 +162,6 @@ jobs:
           tag: ${{ github.event.inputs.tag }}
           overwrite: true
           file_glob: true
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
 
       - name: Upload binaries to S3
         env:


### PR DESCRIPTION
## Description

- Move AWS authentication at the beginning of deployment because the checks should be done before the builds/uploads
- Check if a folder (release) exists in AWS S3, if yes, a 0 code will be returned, an error message displayed, and exit 1.
- This check will eliminate the risk of overwriting existing releases

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test
Manual test with existing tag : 
aws s3 ls s3://axelar-releases/axelard/v0.14.1 && echo "tag already exists, use a new one" && echo "return code is $?"
Manual test with non existing tag : 
aws s3 ls s3://axelar-releases/axelard/v5.5.5 && echo "tag is Ok" && echo "return code is $?"

## Expected Behaviour
If the tag exists, return code will be 0, an error message will be displayed, the workflow will exit in error, (in the code exit 1)
If it does not exists, the pipeline will continue.

## Other Notes
