### PR TITLE
chore(vald): add additional diagnostic data to heartbeat error

### DIFF
--- a/cmd/axelard/cmd/vald/tss/tss.go
+++ b/cmd/axelard/cmd/vald/tss/tss.go
@@ -336,7 +336,8 @@ func (mgr *Mgr) extractHeartBeatResponses(txRes *sdk.TxResponse) ([]tss.HeartBea
 	}
 
 	if len(heartbeatRes) == 0 {
-		return nil, fmt.Errorf("handler goroutine: failure to retrieve heartbeat reply")
+		jsonResp := mgr.cliCtx.Codec.MustMarshalJSON(txRes)
+		return nil, fmt.Errorf("handler goroutine: failure to retrieve heartbeat reply; full response: %s", jsonResp)
 	}
 	return heartbeatRes, nil
 }


### PR DESCRIPTION
## Description
One of the validators ran into this error:
> One strange error that I haven't received before: ERR handler goroutine: failure to retrieve heartbeat reply module=vald. Still looks like it submitted the tx though

It shouldn't be possible to get into this case, but without seeing the full response it is next to impossible to figure out what is going wrong. So this change extends the logged data