### PR TITLE
fix(test): fix parameter space in genesis test

### DIFF
--- a/x/nexus/keeper/genesis_test.go
+++ b/x/nexus/keeper/genesis_test.go
@@ -59,7 +59,7 @@ func getRandomEthereumAddress() exported.CrossChainAddress {
 func randFee(chain string, asset string) nexus.FeeInfo {
 	rate := sdk.NewDecWithPrec(sdk.Int(randInt(0, 100)).Int64(), 3)
 	min := randInt(0, 10)
-	max := randInt(min.Int64(), 100)
+	max := randInt(min.Int64()+1, 100)
 	return nexus.NewFeeInfo(chain, asset, rate, min, max)
 }
 


### PR DESCRIPTION
## Description
It was allowed that the max fee was zero and the fee rate nonzero, so fee info validation failed