### PR TITLE
feat: add bash scripts

### DIFF
--- a/scripts/checksum-binaries.sh
+++ b/scripts/checksum-binaries.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+
+PATCH="$1"
+
+if test "$#" -ne 1
+then
+   echo "error: 1 parameters are expected (patch version)"
+   echo "example : ./checksum-binaries.sh v0.16.1"
+   exit
+fi
+
+if [[ ! "$1" =~ v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]]; 
+then 
+   echo "error: a semantic tag is expected as first parameter"
+   echo  "example v0.16.1"
+   exit
+fi
+
+for OS in "linux-amd64" "linux-arm64" "darwin-arm64" "darwin-amd64"
+do
+   curl --silent  -LJO "https://github.com/axelarnetwork/axelar-core/releases/download/${PATCH}/axelard-${OS}-${PATCH}.zip"
+   curl --silent  -LJO "https://github.com/axelarnetwork/axelar-core/releases/download/${PATCH}/axelard-${OS}-${PATCH}"
+   curl --silent  -LJO "https://github.com/axelarnetwork/axelar-core/releases/download/${PATCH}/axelard-${OS}-${PATCH}.zip.sha256"
+   curl --silent  -LJO "https://github.com/axelarnetwork/axelar-core/releases/download/${PATCH}/axelard-${OS}-${PATCH}.sha256"
+   OS_ZIPHASH=$(cat "axelard-${OS}-${PATCH}.zip.sha256")
+   OS_ZIPHASH_CALCULATED=$(shasum -a 256 axelard-${OS}-${PATCH}.zip | awk '{print $1}')
+   OS_HASH=$(cat "axelard-${OS}-${PATCH}.sha256")
+   OS_HASH_CALCULATED=$(shasum -a 256 axelard-${OS}-${PATCH} | awk '{print $1}')
+   echo "### $OS ###"
+   test "$OS_ZIPHASH" == "$OS_ZIPHASH_CALCULATED" && echo "checksum ok for axelard-$OS-$PATCH.zip" || echo "ERROR: checksum mismatch for axelard-$OS-$PATCH.zip"
+   test "$OS_HASH" == "$OS_HASH_CALCULATED" && echo "checksum ok for axelard-$OS-$PATCH" || echo "ERROR: checksum mismatch for axelard-$OS-$PATCH" 
+done
+

--- a/scripts/gen-tx-gov.sh
+++ b/scripts/gen-tx-gov.sh
@@ -44,13 +44,14 @@ curl --silent -LJO "https://github.com/axelarnetwork/axelar-core/releases/downlo
 DW_ARM64_HASH=$(cat axelard-darwin-arm64-${PATCH}.zip.sha256)
 rm axelard-darwin-arm64-${PATCH}.zip.sha256
 
-# Retrieve DARWIN AMD64 Hsh from github
+# Retrieve DARWIN AMD64 Hash from github
 curl --silent -LJO "https://github.com/axelarnetwork/axelar-core/releases/download/${PATCH}/axelard-darwin-amd64-${PATCH}.zip.sha256"
 DW_AMD64_HASH=$(cat axelard-darwin-amd64-${PATCH}.zip.sha256)
 rm axelard-darwin-amd64-${PATCH}.zip.sha256
 
-# Create txgov.sh script that will contain the governance tx. Text for the tx is always the same excepted for some variables.
+# Create upgrade-tx.sh script that will contain the governance tx. Text for the tx is always the same excepted for some variables.
 # We make a sed on multiple patterns (*_HASH) to replace the variables by the correct value.
+# The script will display the generated tx and save it in  upgrade-tx.sh
 cat <<EOF > upgrade-tx.sh | sed -e "s/LX_AMD64_HASH/$LX_AMD64_HASH/; s/LX_ARM64_HASH/$LX_ARM64_HASH/; s/DW_AMD64_HASH/$DW_AMD64_HASH/; s/DW_ARM64_HASH/$DW_ARM64_HASH/"
 axelard tx gov submit-proposal software-upgrade "$MINOR" --upgrade-height $HEIGHT_NUMBER --upgrade-info '{"binaries":{"linux/amd64":"https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/$PATCH/axelard-linux-amd64-$PATCH.zip?checksum=sha256:$LX_AMD64_HASH","linux/arm64":"https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/$PATCH/axelard-linux-arm64-$PATCH.zip?checksum=sha256:$LX_ARM64_HASH","darwin/amd64":"https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/$PATCH/axelard-darwin-amd64-$PATCH.zip?checksum=sha256:$DW_AMD64_HASH","darwin/arm64":"https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/$PATCH/axelard-darwin-arm64-$PATCH.zip?checksum=sha256:$DW_ARM64_HASH"}}' --deposit 100000000uaxl --description  "This proposal is intended to upgrade axelar core to $MINOR" --title "Axelar $MINOR Upgrade Proposal" --from validator --gas auto --gas-adjustment 1.2
 EOF

--- a/scripts/gen-tx-gov.sh
+++ b/scripts/gen-tx-gov.sh
@@ -1,0 +1,53 @@
+#! /bin/bash
+
+if test "$#" -ne 2
+then
+   echo "error: 2 parameters are expected (patch version and upgrade height number)"
+   echo "example : ./gen-tx-gov.sh v0.16.1 1336350"
+    exit
+fi
+
+if [[ ! "$1" =~ v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]]; 
+then 
+   echo "error: a semantic tag is expected as first parameter"
+   echo  "example v0.16.1"
+   exit
+fi
+
+re='^[0-9]+$'
+if ! [[ "$2" =~ $re ]]
+then
+   echo "error: an integer is expected as second parameter" >&2
+   exit
+fi
+
+PATCH="$1"
+MINOR=$(echo $PATCH | sed 's/..$//g')
+HEIGHT_NUMBER="$2"
+
+# LINUX AMD64
+curl --silent -LJO "https://github.com/axelarnetwork/axelar-core/releases/download/${PATCH}/axelard-linux-amd64-${PATCH}.zip.sha256"
+LX_AMD64_HASH=$(cat axelard-linux-amd64-${PATCH}.zip.sha256)
+rm axelard-linux-amd64-${PATCH}.zip.sha256
+
+# LINUX ARM64
+curl --silent -LJO "https://github.com/axelarnetwork/axelar-core/releases/download/${PATCH}/axelard-linux-arm64-${PATCH}.zip.sha256"
+LX_ARM64_HASH=$(cat axelard-linux-arm64-${PATCH}.zip.sha256)
+rm axelard-linux-arm64-${PATCH}.zip.sha256
+
+# DARWIN ARM64
+curl --silent -LJO "https://github.com/axelarnetwork/axelar-core/releases/download/${PATCH}/axelard-darwin-arm64-${PATCH}.zip.sha256"
+DW_ARM64_HASH=$(cat axelard-darwin-arm64-${PATCH}.zip.sha256)
+rm axelard-darwin-arm64-${PATCH}.zip.sha256
+
+# DARWIN AMD64
+curl --silent -LJO "https://github.com/axelarnetwork/axelar-core/releases/download/${PATCH}/axelard-darwin-amd64-${PATCH}.zip.sha256"
+DW_AMD64_HASH=$(cat axelard-darwin-amd64-${PATCH}.zip.sha256)
+rm axelard-darwin-amd64-${PATCH}.zip.sha256
+
+cat <<EOF > txgov.txt | sed -e "s/LX_AMD64_HASH/$LX_AMD64_HASH/; s/LX_ARM64_HASH/$LX_ARM64_HASH/; s/DW_AMD64_HASH/$DW_AMD64_HASH/; s/DW_ARM64_HASH/$DW_ARM64_HASH/"
+axelard tx gov submit-proposal software-upgrade "$MINOR" --upgrade-height $HEIGHT_NUMBER --upgrade-info '{"binaries":{"linux/amd64":"https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/$PATCH/axelard-linux-amd64-$PATCH.zip?checksum=sha256:$LX_AMD64_HASH","linux/arm64":"https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/$PATCH/axelard-linux-arm64-$PATCH.zip?checksum=sha256:$LX_ARM64_HASH","darwin/amd64":"https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/$PATCH/axelard-darwin-amd64-$PATCH.zip?checksum=sha256:$DW_AMD64_HASH","darwin/arm64":"https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/$PATCH/axelard-darwin-arm64-$PATCH.zip?checksum=sha256:$DW_ARM64_HASH"}}' --deposit 100000000uaxl --description  "This proposal is intended to upgrade axelar core to $MINOR" --title "Axelar $MINOR Upgrade Proposal" --from validator --gas auto --gas-adjustment 1.2
+EOF
+
+cat txgov.txt
+rm txgov.txt

--- a/scripts/gen-tx-gov.sh
+++ b/scripts/gen-tx-gov.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
+# Test number of params
 if test "$#" -ne 2
 then
    echo "error: 2 parameters are expected (patch version and upgrade height number)"
@@ -7,13 +8,16 @@ then
     exit
 fi
 
-if [[ ! "$1" =~ v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]]; 
+# Test semantic tag format
+SEM_PATTERN='v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'
+if [[ ! "$1" =~ $SEM_PATTERN ]]; 
 then 
    echo "error: a semantic tag is expected as first parameter"
    echo  "example v0.16.1"
    exit
 fi
 
+# Test second param is an integer 
 re='^[0-9]+$'
 if ! [[ "$2" =~ $re ]]
 then
@@ -25,29 +29,30 @@ PATCH="$1"
 MINOR=$(echo $PATCH | sed 's/..$//g')
 HEIGHT_NUMBER="$2"
 
-# LINUX AMD64
+# Retrieve LINUX AMD64 Hash from github
 curl --silent -LJO "https://github.com/axelarnetwork/axelar-core/releases/download/${PATCH}/axelard-linux-amd64-${PATCH}.zip.sha256"
 LX_AMD64_HASH=$(cat axelard-linux-amd64-${PATCH}.zip.sha256)
 rm axelard-linux-amd64-${PATCH}.zip.sha256
 
-# LINUX ARM64
+# Retrieve LINUX ARM64 Hash from github
 curl --silent -LJO "https://github.com/axelarnetwork/axelar-core/releases/download/${PATCH}/axelard-linux-arm64-${PATCH}.zip.sha256"
 LX_ARM64_HASH=$(cat axelard-linux-arm64-${PATCH}.zip.sha256)
 rm axelard-linux-arm64-${PATCH}.zip.sha256
 
-# DARWIN ARM64
+# Retrieve DARWIN ARM64 Hash from github
 curl --silent -LJO "https://github.com/axelarnetwork/axelar-core/releases/download/${PATCH}/axelard-darwin-arm64-${PATCH}.zip.sha256"
 DW_ARM64_HASH=$(cat axelard-darwin-arm64-${PATCH}.zip.sha256)
 rm axelard-darwin-arm64-${PATCH}.zip.sha256
 
-# DARWIN AMD64
+# Retrieve DARWIN AMD64 Hsh from github
 curl --silent -LJO "https://github.com/axelarnetwork/axelar-core/releases/download/${PATCH}/axelard-darwin-amd64-${PATCH}.zip.sha256"
 DW_AMD64_HASH=$(cat axelard-darwin-amd64-${PATCH}.zip.sha256)
 rm axelard-darwin-amd64-${PATCH}.zip.sha256
 
-cat <<EOF > txgov.txt | sed -e "s/LX_AMD64_HASH/$LX_AMD64_HASH/; s/LX_ARM64_HASH/$LX_ARM64_HASH/; s/DW_AMD64_HASH/$DW_AMD64_HASH/; s/DW_ARM64_HASH/$DW_ARM64_HASH/"
+# Create txgov.sh script that will contain the governance tx. Text for the tx is always the same excepted for some variables.
+# We make a sed on multiple patterns (*_HASH) to replace the variables by the correct value.
+cat <<EOF > upgrade-tx.sh | sed -e "s/LX_AMD64_HASH/$LX_AMD64_HASH/; s/LX_ARM64_HASH/$LX_ARM64_HASH/; s/DW_AMD64_HASH/$DW_AMD64_HASH/; s/DW_ARM64_HASH/$DW_ARM64_HASH/"
 axelard tx gov submit-proposal software-upgrade "$MINOR" --upgrade-height $HEIGHT_NUMBER --upgrade-info '{"binaries":{"linux/amd64":"https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/$PATCH/axelard-linux-amd64-$PATCH.zip?checksum=sha256:$LX_AMD64_HASH","linux/arm64":"https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/$PATCH/axelard-linux-arm64-$PATCH.zip?checksum=sha256:$LX_ARM64_HASH","darwin/amd64":"https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/$PATCH/axelard-darwin-amd64-$PATCH.zip?checksum=sha256:$DW_AMD64_HASH","darwin/arm64":"https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/$PATCH/axelard-darwin-arm64-$PATCH.zip?checksum=sha256:$DW_ARM64_HASH"}}' --deposit 100000000uaxl --description  "This proposal is intended to upgrade axelar core to $MINOR" --title "Axelar $MINOR Upgrade Proposal" --from validator --gas auto --gas-adjustment 1.2
 EOF
 
-cat txgov.txt
-rm txgov.txt
+cat upgrade-tx.sh


### PR DESCRIPTION
## Description
- Add checksum-binaries.sh in /scripts folder : this script take a semantic tag in parameter, it will download binaries, zips and their sha256 file. It checks automatically they match and display a status message. the script will not delete downloaded binaries zip and sha256 files.
- Add gen-tx-gov.sh in /scripts folder : it takes 2 parameters, a semantic tag and an upgrade height number, it generates the governance transaction for a tag.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test
./checksum-binaries.sh
./gen-tx-gov.sh

## Expected Behaviour

- Scripts will fail if ran without parameters, follow the usage to validate they work fine

- ./gen-tx-gov.sh v0.14.1 and check it is the same that the one sent manually.

## Other Notes
