### PR TITLE
fix(make): use fixed base image version for `make proto-gen`

### DIFF
--- a/Dockerfile.protocgen
+++ b/Dockerfile.protocgen
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM tendermintdev/sdk-proto-gen as build
+FROM tendermintdev/sdk-proto-gen:v0.1 as build
 
 RUN apk add --no-cache --update \
   git \


### PR DESCRIPTION
## Description
The latest image of `tendermintdev/sdk-proto-gen` breaks our build pipeline because the `buf protoc` command is deprecated. Until we can update our scripts, we use image v0.1.0 with an older binary