### PR TITLE
fix(evm): burnerInfo correctly iterates over chains

### DIFF
--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -31,13 +31,13 @@ func NewGRPCQuerier(k types.BaseKeeper, n types.Nexus) Querier {
 func (q Querier) BurnerInfo(c context.Context, req *types.BurnerInfoRequest) (*types.BurnerInfoResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 
-	chains, err := queryChains(ctx, q.nexus)
-	if err != nil {
+	chains := getEVMChains(ctx, q.nexus)
+	if len(chains) == 0 {
 		return nil, status.Error(codes.NotFound, "no chains registered")
 	}
 
 	for _, chain := range chains {
-		ck := q.keeper.ForChain(string(chain))
+		ck := q.keeper.ForChain(chain)
 		burnerInfo := ck.GetBurnerInfo(ctx, req.Address)
 		if burnerInfo != nil {
 			return &types.BurnerInfoResponse{Chain: ck.GetParams(ctx).Chain, BurnerInfo: burnerInfo}, nil

--- a/x/evm/keeper/querier.go
+++ b/x/evm/keeper/querier.go
@@ -38,7 +38,7 @@ const (
 	QChains                = "chains"
 )
 
-//Bytecode labels
+// Bytecode labels
 const (
 	BCGateway           = "gateway"
 	BCGatewayDeployment = "gateway-deployment"
@@ -46,7 +46,7 @@ const (
 	BCBurner            = "burner"
 )
 
-//Token address labels
+// Token address labels
 const (
 	BySymbol = "symbol"
 	ByAsset  = "asset"
@@ -563,15 +563,20 @@ func getBatchedCommandsSig(pair tss.SigKeyPair, batchedCommands types.Hash) (typ
 }
 
 func queryChains(ctx sdk.Context, n types.Nexus) ([]byte, error) {
+	evmChains := getEVMChains(ctx, n)
+
+	response := types.QueryChainsResponse{Chains: evmChains}
+	return response.Marshal()
+}
+
+func getEVMChains(ctx sdk.Context, n types.Nexus) []string {
 	chains := n.GetChains(ctx)
 
-	evmChains := []string{}
+	var evmChains []string
 	for _, c := range chains {
 		if c.Module == types.ModuleName {
 			evmChains = append(evmChains, c.Name)
 		}
 	}
-
-	response := types.QueryChainsResponse{Chains: evmChains}
-	return response.Marshal()
+	return evmChains
 }


### PR DESCRIPTION
## Description
the BurnerInfo query iterated over a marshalled response object instead of chain names