### PR TITLE
fix: use lower default gas price and don't overwrite flags

### DIFF
--- a/cmd/axelard/cmd/root.go
+++ b/cmd/axelard/cmd/root.go
@@ -210,18 +210,13 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	// Add rosetta command
 	rootCmd.AddCommand(server.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Codec))
 
-	defaults := map[string]string{
-		flags.FlagBroadcastMode:    flags.BroadcastBlock,
-		flags.FlagSkipConfirmation: "true",
-		flags.FlagGasPrices:        "0.05uaxl",
-	}
-	// overwrite default and set as current value
-	utils.OverwriteFlagDefaults(rootCmd, defaults, true)
-
 	// Only set default, not actual value, so it can be overwritten by env variable
 	utils.OverwriteFlagDefaults(rootCmd, map[string]string{
-		flags.FlagChainID:        app.Name,
-		flags.FlagKeyringBackend: "file",
+		flags.FlagBroadcastMode:    flags.BroadcastBlock,
+		flags.FlagChainID:          app.Name,
+		flags.FlagGasPrices:        "0.00005uaxl",
+		flags.FlagKeyringBackend:   "file",
+		flags.FlagSkipConfirmation: "true",
 	}, false)
 
 	rootCmd.PersistentFlags().String(tmcli.OutputFlag, "text", "Output format (text|json)")

--- a/docs/cli/axelard_gentx.md
+++ b/docs/cli/axelard_gentx.md
@@ -48,7 +48,7 @@ axelard gentx [key_name] [amount] [flags]
       --from string                         Name or address of private key with which to sign
       --gas string                          gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float                adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string                   Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string                   Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only                       Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                                help for gentx
       --identity string                     The (optional) identity signature (ex. UPort or Keybase)

--- a/docs/cli/axelard_tx_axelarnet_add-cosmos-based-chain.md
+++ b/docs/cli/axelard_tx_axelarnet_add-cosmos-based-chain.md
@@ -17,7 +17,7 @@ axelard tx axelarnet add-cosmos-based-chain [name] [address prefix] [native asse
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for add-cosmos-based-chain
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_axelarnet_confirm-deposit.md
+++ b/docs/cli/axelard_tx_axelarnet_confirm-deposit.md
@@ -17,7 +17,7 @@ axelard tx axelarnet confirm-deposit [denom] [burnerAddr] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-deposit
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_axelarnet_execute-pending-transfers.md
+++ b/docs/cli/axelard_tx_axelarnet_execute-pending-transfers.md
@@ -17,7 +17,7 @@ axelard tx axelarnet execute-pending-transfers [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for execute-pending-transfers
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_axelarnet_link.md
+++ b/docs/cli/axelard_tx_axelarnet_link.md
@@ -17,7 +17,7 @@ axelard tx axelarnet link [recipient chain] [recipient address] [asset] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for link
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_axelarnet_register-asset.md
+++ b/docs/cli/axelard_tx_axelarnet_register-asset.md
@@ -17,7 +17,7 @@ axelard tx axelarnet register-asset [chain] [denom] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-asset
       --is-native-asset          is it a native asset from cosmos chain

--- a/docs/cli/axelard_tx_axelarnet_register-fee-collector.md
+++ b/docs/cli/axelard_tx_axelarnet_register-fee-collector.md
@@ -17,7 +17,7 @@ axelard tx axelarnet register-fee-collector [fee collector] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-fee-collector
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_axelarnet_register-path.md
+++ b/docs/cli/axelard_tx_axelarnet_register-path.md
@@ -17,7 +17,7 @@ axelard tx axelarnet register-path [chain] [path] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-path
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_axelarnet_route-ibc-transfers.md
+++ b/docs/cli/axelard_tx_axelarnet_route-ibc-transfers.md
@@ -17,7 +17,7 @@ axelard tx axelarnet route-ibc-transfers [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for route-ibc-transfers
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_bank_send.md
+++ b/docs/cli/axelard_tx_bank_send.md
@@ -18,7 +18,7 @@ axelard tx bank send [from_key_or_address] [to_address] [amount] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for send
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_broadcast.md
+++ b/docs/cli/axelard_tx_broadcast.md
@@ -26,7 +26,7 @@ axelard tx broadcast [file_path] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for broadcast
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_crisis_invariant-broken.md
+++ b/docs/cli/axelard_tx_crisis_invariant-broken.md
@@ -17,7 +17,7 @@ axelard tx crisis invariant-broken [module-name] [invariant-route] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for invariant-broken
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_decode.md
+++ b/docs/cli/axelard_tx_decode.md
@@ -17,7 +17,7 @@ axelard tx decode [amino-byte-string] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for decode
   -x, --hex                      Treat input as hexadecimal instead of base64

--- a/docs/cli/axelard_tx_distribution_fund-community-pool.md
+++ b/docs/cli/axelard_tx_distribution_fund-community-pool.md
@@ -24,7 +24,7 @@ axelard tx distribution fund-community-pool [amount] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for fund-community-pool
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_distribution_set-withdraw-addr.md
+++ b/docs/cli/axelard_tx_distribution_set-withdraw-addr.md
@@ -24,7 +24,7 @@ axelard tx distribution set-withdraw-addr [withdraw-addr] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for set-withdraw-addr
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_distribution_withdraw-all-rewards.md
+++ b/docs/cli/axelard_tx_distribution_withdraw-all-rewards.md
@@ -25,7 +25,7 @@ axelard tx distribution withdraw-all-rewards [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for withdraw-all-rewards
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_distribution_withdraw-rewards.md
+++ b/docs/cli/axelard_tx_distribution_withdraw-rewards.md
@@ -27,7 +27,7 @@ axelard tx distribution withdraw-rewards [validator-addr] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for withdraw-rewards
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_encode.md
+++ b/docs/cli/axelard_tx_encode.md
@@ -23,7 +23,7 @@ axelard tx encode [file] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for encode
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_add-chain.md
+++ b/docs/cli/axelard_tx_evm_add-chain.md
@@ -21,7 +21,7 @@ axelard tx evm add-chain [name] [key type] [chain config] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for add-chain
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_confirm-chain.md
+++ b/docs/cli/axelard_tx_evm_confirm-chain.md
@@ -17,7 +17,7 @@ axelard tx evm confirm-chain [chain] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-chain
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_confirm-erc20-deposit.md
+++ b/docs/cli/axelard_tx_evm_confirm-erc20-deposit.md
@@ -17,7 +17,7 @@ axelard tx evm confirm-erc20-deposit [chain] [txID] [amount] [burnerAddr] [flags
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-erc20-deposit
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_confirm-erc20-token.md
+++ b/docs/cli/axelard_tx_evm_confirm-erc20-token.md
@@ -17,7 +17,7 @@ axelard tx evm confirm-erc20-token [chain] [origin chain] [origin asset] [txID] 
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-erc20-token
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_confirm-gateway-tx.md
+++ b/docs/cli/axelard_tx_evm_confirm-gateway-tx.md
@@ -17,7 +17,7 @@ axelard tx evm confirm-gateway-tx [chain] [txID] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-gateway-tx
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_confirm-transfer-operatorship.md
+++ b/docs/cli/axelard_tx_evm_confirm-transfer-operatorship.md
@@ -17,7 +17,7 @@ axelard tx evm confirm-transfer-operatorship [chain] [txID] [keyID] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-transfer-operatorship
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_confirm-transfer-ownership.md
+++ b/docs/cli/axelard_tx_evm_confirm-transfer-ownership.md
@@ -17,7 +17,7 @@ axelard tx evm confirm-transfer-ownership [chain] [txID] [keyID] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for confirm-transfer-ownership
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_create-approve-contract-calls.md
+++ b/docs/cli/axelard_tx_evm_create-approve-contract-calls.md
@@ -17,7 +17,7 @@ axelard tx evm create-approve-contract-calls [chain] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for create-approve-contract-calls
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_create-burn-tokens.md
+++ b/docs/cli/axelard_tx_evm_create-burn-tokens.md
@@ -17,7 +17,7 @@ axelard tx evm create-burn-tokens [chain] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for create-burn-tokens
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_create-deploy-token.md
+++ b/docs/cli/axelard_tx_evm_create-deploy-token.md
@@ -18,7 +18,7 @@ axelard tx evm create-deploy-token [evm chain] [origin chain] [origin asset] [to
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for create-deploy-token
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_create-pending-transfers.md
+++ b/docs/cli/axelard_tx_evm_create-pending-transfers.md
@@ -17,7 +17,7 @@ axelard tx evm create-pending-transfers [chain] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for create-pending-transfers
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_link.md
+++ b/docs/cli/axelard_tx_evm_link.md
@@ -17,7 +17,7 @@ axelard tx evm link [chain] [recipient chain] [recipient address] [asset name] [
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for link
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_set-gateway.md
+++ b/docs/cli/axelard_tx_evm_set-gateway.md
@@ -17,7 +17,7 @@ axelard tx evm set-gateway [chain] [address] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for set-gateway
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_sign-commands.md
+++ b/docs/cli/axelard_tx_evm_sign-commands.md
@@ -17,7 +17,7 @@ axelard tx evm sign-commands [chain] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for sign-commands
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_transfer-operatorship.md
+++ b/docs/cli/axelard_tx_evm_transfer-operatorship.md
@@ -17,7 +17,7 @@ axelard tx evm transfer-operatorship [chain] [keyID] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for transfer-operatorship
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_evm_transfer-ownership.md
+++ b/docs/cli/axelard_tx_evm_transfer-ownership.md
@@ -17,7 +17,7 @@ axelard tx evm transfer-ownership [chain] [keyID] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for transfer-ownership
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_feegrant_grant.md
+++ b/docs/cli/axelard_tx_feegrant_grant.md
@@ -30,7 +30,7 @@ axelard tx feegrant grant [granter_key_or_address] [grantee] [flags]
       --from string                Name or address of private key with which to sign
       --gas string                 gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float       adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string          Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string          Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only              Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                       help for grant
       --keyring-backend string     Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_feegrant_revoke.md
+++ b/docs/cli/axelard_tx_feegrant_revoke.md
@@ -25,7 +25,7 @@ axelard tx feegrant revoke [granter] [grantee] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for revoke
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_gov_deposit.md
+++ b/docs/cli/axelard_tx_gov_deposit.md
@@ -25,7 +25,7 @@ axelard tx gov deposit [proposal-id] [deposit] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for deposit
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_gov_submit-proposal.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal.md
@@ -40,7 +40,7 @@ axelard tx gov submit-proposal [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for submit-proposal
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_gov_submit-proposal_cancel-software-upgrade.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal_cancel-software-upgrade.md
@@ -23,7 +23,7 @@ axelard tx gov submit-proposal cancel-software-upgrade [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for cancel-software-upgrade
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_gov_submit-proposal_community-pool-spend.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal_community-pool-spend.md
@@ -35,7 +35,7 @@ axelard tx gov submit-proposal community-pool-spend [proposal-file] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for community-pool-spend
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_gov_submit-proposal_ibc-upgrade.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal_ibc-upgrade.md
@@ -33,7 +33,7 @@ axelard tx gov submit-proposal ibc-upgrade [name] [height] [path/to/upgraded_cli
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for ibc-upgrade
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_gov_submit-proposal_param-change.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal_param-change.md
@@ -49,7 +49,7 @@ axelard tx gov submit-proposal param-change [proposal-file] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for param-change
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_gov_submit-proposal_software-upgrade.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal_software-upgrade.md
@@ -25,7 +25,7 @@ axelard tx gov submit-proposal software-upgrade [name] (--upgrade-height [height
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for software-upgrade
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_gov_submit-proposal_update-client.md
+++ b/docs/cli/axelard_tx_gov_submit-proposal_update-client.md
@@ -25,7 +25,7 @@ axelard tx gov submit-proposal update-client [subject-client-id] [substitute-cli
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for update-client
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_gov_vote.md
+++ b/docs/cli/axelard_tx_gov_vote.md
@@ -25,7 +25,7 @@ axelard tx gov vote [proposal-id] [option] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for vote
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_gov_weighted-vote.md
+++ b/docs/cli/axelard_tx_gov_weighted-vote.md
@@ -25,7 +25,7 @@ axelard tx gov weighted-vote [proposal-id] [weighted-options] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for weighted-vote
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_ibc-transfer_transfer.md
+++ b/docs/cli/axelard_tx_ibc-transfer_transfer.md
@@ -33,7 +33,7 @@ axelard tx ibc-transfer transfer [src-port] [src-channel] [receiver] [amount] [f
       --from string                     Name or address of private key with which to sign
       --gas string                      gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float            adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string               Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string               Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only                   Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                            help for transfer
       --keyring-backend string          Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_ibc_client_create.md
+++ b/docs/cli/axelard_tx_ibc_client_create.md
@@ -29,7 +29,7 @@ axelard tx ibc client create [path/to/client_state.json] [path/to/consensus_stat
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for create
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_ibc_client_upgrade.md
+++ b/docs/cli/axelard_tx_ibc_client_upgrade.md
@@ -29,7 +29,7 @@ axelard tx ibc client upgrade [client-identifier] [path/to/client_state.json] [p
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for upgrade
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_multisign-batch.md
+++ b/docs/cli/axelard_tx_multisign-batch.md
@@ -30,7 +30,7 @@ axelard tx multisign-batch [file] [name] [[signature-file]...] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for multisign-batch
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_multisign.md
+++ b/docs/cli/axelard_tx_multisign.md
@@ -38,7 +38,7 @@ axelard tx multisign [file] [name] [[signature]...] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for multisign
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_nexus_activate-chain.md
+++ b/docs/cli/axelard_tx_nexus_activate-chain.md
@@ -17,7 +17,7 @@ axelard tx nexus activate-chain [chain]... [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for activate-chain
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_nexus_deactivate-chain.md
+++ b/docs/cli/axelard_tx_nexus_deactivate-chain.md
@@ -17,7 +17,7 @@ axelard tx nexus deactivate-chain [chain]... [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for deactivate-chain
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_nexus_deregister-chain-maintainer.md
+++ b/docs/cli/axelard_tx_nexus_deregister-chain-maintainer.md
@@ -17,7 +17,7 @@ axelard tx nexus deregister-chain-maintainer [chain]... [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for deregister-chain-maintainer
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_nexus_register-asset-fee.md
+++ b/docs/cli/axelard_tx_nexus_register-asset-fee.md
@@ -17,7 +17,7 @@ axelard tx nexus register-asset-fee [chain] [asset] [fee-rate] [min-fee] [max-fe
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-asset-fee
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_nexus_register-chain-maintainer.md
+++ b/docs/cli/axelard_tx_nexus_register-chain-maintainer.md
@@ -17,7 +17,7 @@ axelard tx nexus register-chain-maintainer [chain]... [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-chain-maintainer
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_permission_deregister-controller.md
+++ b/docs/cli/axelard_tx_permission_deregister-controller.md
@@ -17,7 +17,7 @@ axelard tx permission deregister-controller [controller] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for deregister-controller
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_permission_register-controller.md
+++ b/docs/cli/axelard_tx_permission_register-controller.md
@@ -17,7 +17,7 @@ axelard tx permission register-controller [controller] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-controller
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_permission_update-governance-key.md
+++ b/docs/cli/axelard_tx_permission_update-governance-key.md
@@ -17,7 +17,7 @@ axelard tx permission update-governance-key [threshold] [[pubKey]...] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for update-governance-key
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_sign-batch.md
+++ b/docs/cli/axelard_tx_sign-batch.md
@@ -35,7 +35,7 @@ axelard tx sign-batch [file] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for sign-batch
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_sign.md
+++ b/docs/cli/axelard_tx_sign.md
@@ -34,7 +34,7 @@ axelard tx sign [file] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for sign
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_slashing_unjail.md
+++ b/docs/cli/axelard_tx_slashing_unjail.md
@@ -23,7 +23,7 @@ axelard tx slashing unjail [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for unjail
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_snapshot_deactivate-proxy.md
+++ b/docs/cli/axelard_tx_snapshot_deactivate-proxy.md
@@ -17,7 +17,7 @@ axelard tx snapshot deactivate-proxy [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for deactivate-proxy
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_snapshot_register-proxy.md
+++ b/docs/cli/axelard_tx_snapshot_register-proxy.md
@@ -17,7 +17,7 @@ axelard tx snapshot register-proxy [proxy address] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-proxy
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_snapshot_send-tokens.md
+++ b/docs/cli/axelard_tx_snapshot_send-tokens.md
@@ -17,7 +17,7 @@ axelard tx snapshot send-tokens [amount] [address 1] ... [address n] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for send-tokens
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_staking_create-validator.md
+++ b/docs/cli/axelard_tx_staking_create-validator.md
@@ -22,7 +22,7 @@ axelard tx staking create-validator [flags]
       --from string                         Name or address of private key with which to sign
       --gas string                          gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float                adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string                   Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string                   Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only                       Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                                help for create-validator
       --identity string                     The optional identity signature (ex. UPort or Keybase)

--- a/docs/cli/axelard_tx_staking_delegate.md
+++ b/docs/cli/axelard_tx_staking_delegate.md
@@ -24,7 +24,7 @@ axelard tx staking delegate [validator-addr] [amount] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for delegate
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_staking_edit-validator.md
+++ b/docs/cli/axelard_tx_staking_edit-validator.md
@@ -19,7 +19,7 @@ axelard tx staking edit-validator [flags]
       --from string                  Name or address of private key with which to sign
       --gas string                   gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float         adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string            Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string            Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only                Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                         help for edit-validator
       --identity string              The (optional) identity signature (ex. UPort or Keybase) (default "[do-not-modify]")

--- a/docs/cli/axelard_tx_staking_redelegate.md
+++ b/docs/cli/axelard_tx_staking_redelegate.md
@@ -24,7 +24,7 @@ axelard tx staking redelegate [src-validator-addr] [dst-validator-addr] [amount]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for redelegate
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_staking_unbond.md
+++ b/docs/cli/axelard_tx_staking_unbond.md
@@ -24,7 +24,7 @@ axelard tx staking unbond [validator-addr] [amount] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for unbond
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_tss_register-external-keys.md
+++ b/docs/cli/axelard_tx_tss_register-external-keys.md
@@ -17,7 +17,7 @@ axelard tx tss register-external-keys [chain] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for register-external-keys
       --key strings              key ID and public key in the hex format, e.g. [keyID:keyHex]

--- a/docs/cli/axelard_tx_tss_rotate.md
+++ b/docs/cli/axelard_tx_tss_rotate.md
@@ -17,7 +17,7 @@ axelard tx tss rotate [chain] [role] [keyID] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for rotate
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_tss_start-keygen.md
+++ b/docs/cli/axelard_tx_tss_start-keygen.md
@@ -17,7 +17,7 @@ axelard tx tss start-keygen [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for start-keygen
       --id string                unique ID for new key (required)

--- a/docs/cli/axelard_tx_validate-signatures.md
+++ b/docs/cli/axelard_tx_validate-signatures.md
@@ -27,7 +27,7 @@ axelard tx validate-signatures [file] [flags]
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for validate-signatures
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")

--- a/docs/cli/axelard_tx_vesting_create-vesting-account.md
+++ b/docs/cli/axelard_tx_vesting_create-vesting-account.md
@@ -26,7 +26,7 @@ axelard tx vesting create-vesting-account [to_address] [amount] [end_time] [flag
       --from string              Name or address of private key with which to sign
       --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
       --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
-      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.05uaxl")
+      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom) (default "0.00005uaxl")
       --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
   -h, --help                     help for create-vesting-account
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "file")


### PR DESCRIPTION
## Description

- Set the default gas price to network minimum of `0.00005uaxl`
- Don't let flag defaults overwrite env vars to allow customization

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
