### PR TITLE
feat: add node catchup

### DIFF
--- a/.github/workflows/take-snapshot.yaml
+++ b/.github/workflows/take-snapshot.yaml
@@ -1,0 +1,41 @@
+name: Take testnet snapshot
+
+on:
+  workflow_dispatch:
+    inputs:
+      axelard_version:
+        description: Axelar testnet snapshot label (format vX.X.X)
+        required: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Validate tag
+        env:
+          SEMVER: ${{ github.event.inputs.axelard_version }}
+        run: |
+          if [[ $SEMVER =~ v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]]; then echo "Tag is okay" && exit 0; else echo "invalid tag" && exit 1; fi
+          aws s3 ls s3://axelar-testnet-snapshots/axelartestnet-${{ github.event.inputs.axelard_version }}.tar.lz4 && echo "tag already exists, use a 
+new one" && exit 1
+          
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+          submodules: recursive
+
+      - name: Copy snapshot to s3://axelar-testnet-snapshots/axelartestnet-${{ github.event.inputs.axelard_version }}.tar.lz4
+        run: |
+          URL=`curl https://quicksync.io/axelar.json|jq -r '.[] |select(.file=="axelartestnet-lisbon-3-pruned")|.url'`
+          curl "$URL" | aws s3 cp - s3://axelar-testnet-snapshots/axelartestnet-${{ github.event.inputs.axelard_version }}.tar.lz4 

--- a/.github/workflows/testnet-catch-up.yml
+++ b/.github/workflows/testnet-catch-up.yml
@@ -1,0 +1,41 @@
+name: Testnet catch up
+
+on:
+  workflow_dispatch:
+    inputs:
+      snapshot_version:
+        description: Axelar testnet label to use (e.g. v0.15.0)
+        required: true
+      axelard_version:
+        description: Axelard version to use (e.g "v0.15.0")
+        required: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Execute SSH commmands on remote server
+      uses: JimCronqvist/action-ssh@master
+      with:
+        hosts: {{ secrets.CATCHUP_HOST }}
+        privateKey: ${{ secrets.CATCHUP_SSH_PRIVATE_KEY }}
+        command: |
+          sudo apt-get update -y
+          sudo apt install jq  liblz4-tool awscli -y
+          # clean
+          kill -9 $(pgrep -f "axelard start")
+          rm -rf ~/.axelar_testnet/.core/data
+          # Increase ulimit
+          ulimit -n 16384
+          # Download latest snapshot
+          cd ~/.axelar_testnet/.core
+          aws s3 cp s3://axelar-testnet-snapshots/axelartestnet-${{ github.event.inputs.snapshot_version }}.tar.lz4 .
+          lz4 -d axelartestnet-${{ github.event.inputs.snapshot_version }}.tar.lz4 | tar -xvf -
+          rm *.tar *.lz4
+          cd ~/axelarate-community
+          yes | KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -n testnet -a  ${{ github.event.inputs.axelard_version }}


### PR DESCRIPTION
## Description

-  Take backup pipeline allows you to take a testnet snapshot and tag it. The snapshot is uploaded from quicksync to S3 
- Catch up pipeline allows you to select a snapshot version and an axelard version to catch up
- Logs are forwarder from the host to Cloudwatch where you can apply filters

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

Run  take snapshot pipeline and check it is present in the S3 bucket
Run catchup pipeline check that the logs are forwarded to Cloudwatch where you apply filters

## Expected Behaviour

## Other Notes
