### PR TITLE
chore: improve goimports result

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ lint:
 goimports:
 	@echo "running goimports"
 # exclude mocks and proto generated files
+	@./scripts/rm-blank-lines.sh # remove blank lines from imports
 	@goimports -l -local github.com/axelarnetwork/ . | grep -v .pb.go$ | grep -v mock | xargs goimports -local github.com/axelarnetwork/ -w
 
 # Build the project with release flags

--- a/cmd/axelard/cmd/genaccount.go
+++ b/cmd/axelard/cmd/genaccount.go
@@ -9,15 +9,14 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	authvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/spf13/cobra"
-
-	"github.com/cosmos/cosmos-sdk/server"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/genutil"
 )
 
 const (

--- a/cmd/axelard/cmd/gengovkey.go
+++ b/cmd/axelard/cmd/gengovkey.go
@@ -10,9 +10,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
 	crypto "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/server"
-	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
-
 	"github.com/cosmos/cosmos-sdk/x/genutil"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/spf13/cobra"
 
 	"github.com/axelarnetwork/axelar-core/x/permission/exported"

--- a/cmd/axelard/cmd/gennetwork.go
+++ b/cmd/axelard/cmd/gennetwork.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/spf13/cobra"
 
@@ -14,10 +17,6 @@ import (
 	bitcoinTypes "github.com/axelarnetwork/axelar-core/x/bitcoin/types"
 	evm "github.com/axelarnetwork/axelar-core/x/evm/exported"
 	evmTypes "github.com/axelarnetwork/axelar-core/x/evm/types"
-
-	"github.com/cosmos/cosmos-sdk/server"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/genutil"
 )
 
 const (

--- a/cmd/axelard/cmd/genreward.go
+++ b/cmd/axelard/cmd/genreward.go
@@ -6,14 +6,13 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/spf13/cobra"
 
 	rewardTypes "github.com/axelarnetwork/axelar-core/x/reward/types"
-
-	"github.com/cosmos/cosmos-sdk/server"
-	"github.com/cosmos/cosmos-sdk/x/genutil"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/axelard/cmd/gensnapshot.go
+++ b/cmd/axelard/cmd/gensnapshot.go
@@ -9,10 +9,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/spf13/cobra"
 
 	snapshotTypes "github.com/axelarnetwork/axelar-core/x/snapshot/types"
-
-	"github.com/spf13/cobra"
 )
 
 const flagMinProxyBalance = "min-proxy-balance"

--- a/cmd/axelard/cmd/gentss.go
+++ b/cmd/axelard/cmd/gentss.go
@@ -7,12 +7,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/spf13/cobra"
 
 	tssTypes "github.com/axelarnetwork/axelar-core/x/tss/types"
-
-	"github.com/cosmos/cosmos-sdk/x/genutil"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/axelard/cmd/genvote.go
+++ b/cmd/axelard/cmd/genvote.go
@@ -6,14 +6,13 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/spf13/cobra"
 
 	"github.com/axelarnetwork/axelar-core/x/vote"
 	voteTypes "github.com/axelarnetwork/axelar-core/x/vote/types"
-
-	"github.com/cosmos/cosmos-sdk/server"
-	"github.com/cosmos/cosmos-sdk/x/genutil"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/axelard/cmd/root.go
+++ b/cmd/axelard/cmd/root.go
@@ -36,12 +36,11 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
 
-	"github.com/axelarnetwork/axelar-core/config"
-
 	"github.com/axelarnetwork/axelar-core/app"
 	"github.com/axelarnetwork/axelar-core/app/params"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/utils"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald"
+	"github.com/axelarnetwork/axelar-core/config"
 )
 
 const minGasPrice = "0.00005uaxl"

--- a/cmd/axelard/cmd/vald/broadcaster/broadcast_test.go
+++ b/cmd/axelard/cmd/vald/broadcaster/broadcast_test.go
@@ -25,14 +25,13 @@ import (
 	coretypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/types"
 
-	. "github.com/axelarnetwork/utils/test"
-
 	"github.com/axelarnetwork/axelar-core/app"
 	mock2 "github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/broadcaster/types/mock"
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
 	"github.com/axelarnetwork/axelar-core/utils"
 	evm "github.com/axelarnetwork/axelar-core/x/evm/types"
 	"github.com/axelarnetwork/axelar-core/x/vote/exported"
+	. "github.com/axelarnetwork/utils/test"
 )
 
 func TestBroadcast(t *testing.T) {

--- a/cmd/axelard/cmd/vald/btc/btc.go
+++ b/cmd/axelard/cmd/vald/btc/btc.go
@@ -11,13 +11,12 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/tendermint/tendermint/libs/log"
 
-	tmEvents "github.com/axelarnetwork/tm-events/events"
-
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/broadcaster/types"
 	rpc3 "github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/btc/rpc"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/parse"
 	btc "github.com/axelarnetwork/axelar-core/x/bitcoin/types"
 	vote "github.com/axelarnetwork/axelar-core/x/vote/exported"
+	tmEvents "github.com/axelarnetwork/tm-events/events"
 )
 
 // Mgr manages all communication with Bitcoin

--- a/cmd/axelard/cmd/vald/btc/btc_test.go
+++ b/cmd/axelard/cmd/vald/btc/btc_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/libs/log"
 
-	tmEvents "github.com/axelarnetwork/tm-events/events"
-
 	"github.com/axelarnetwork/axelar-core/app"
 	mock3 "github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/broadcaster/types/mock"
 	mock2 "github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/btc/rpc/mock"
@@ -22,6 +20,7 @@ import (
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
 	btc "github.com/axelarnetwork/axelar-core/x/bitcoin/types"
 	"github.com/axelarnetwork/axelar-core/x/vote/exported"
+	tmEvents "github.com/axelarnetwork/tm-events/events"
 )
 
 func TestMgr_ProcessConfirmation(t *testing.T) {

--- a/cmd/axelard/cmd/vald/evm/evm.go
+++ b/cmd/axelard/cmd/vald/evm/evm.go
@@ -18,8 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	tmLog "github.com/tendermint/tendermint/libs/log"
 
-	tmEvents "github.com/axelarnetwork/tm-events/events"
-
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/broadcaster/types"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/evm/rpc"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/parse"
@@ -27,6 +25,7 @@ import (
 	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
 	vote "github.com/axelarnetwork/axelar-core/x/vote/exported"
 	voteTypes "github.com/axelarnetwork/axelar-core/x/vote/types"
+	tmEvents "github.com/axelarnetwork/tm-events/events"
 	"github.com/axelarnetwork/utils/slices"
 )
 

--- a/cmd/axelard/cmd/vald/evm/evm_test.go
+++ b/cmd/axelard/cmd/vald/evm/evm_test.go
@@ -9,10 +9,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/axelarnetwork/utils/slices"
-
-	voteTypes "github.com/axelarnetwork/axelar-core/x/vote/types"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -23,8 +19,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	"golang.org/x/crypto/sha3"
 
-	tmEvents "github.com/axelarnetwork/tm-events/events"
-
 	"github.com/axelarnetwork/axelar-core/app"
 	mock2 "github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/broadcaster/types/mock"
 	evmRpc "github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/evm/rpc"
@@ -34,6 +28,9 @@ import (
 	evmTypes "github.com/axelarnetwork/axelar-core/x/evm/types"
 	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
 	"github.com/axelarnetwork/axelar-core/x/vote/exported"
+	voteTypes "github.com/axelarnetwork/axelar-core/x/vote/types"
+	tmEvents "github.com/axelarnetwork/tm-events/events"
+	"github.com/axelarnetwork/utils/slices"
 )
 
 // testHasher is the helper tool for transaction/receipt list hashing.

--- a/cmd/axelard/cmd/vald/healthcheck.go
+++ b/cmd/axelard/cmd/vald/healthcheck.go
@@ -11,16 +11,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/config"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/tss"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-
 	"github.com/axelarnetwork/axelar-core/x/snapshot/keeper"
 	"github.com/axelarnetwork/axelar-core/x/snapshot/types"
 	snapshotTypes "github.com/axelarnetwork/axelar-core/x/snapshot/types"

--- a/cmd/axelard/cmd/vald/start.go
+++ b/cmd/axelard/cmd/vald/start.go
@@ -25,17 +25,11 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 
-	tmEvents "github.com/axelarnetwork/tm-events/events"
-	"github.com/axelarnetwork/tm-events/pubsub"
-	"github.com/axelarnetwork/tm-events/tendermint"
-	"github.com/axelarnetwork/utils/jobs"
-
-	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/config"
-
 	"github.com/axelarnetwork/axelar-core/app"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/utils"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/broadcaster"
 	broadcasterTypes "github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/broadcaster/types"
+	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/config"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/evm"
 	evmRPC "github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/evm/rpc"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/tss"
@@ -43,6 +37,10 @@ import (
 	evmTypes "github.com/axelarnetwork/axelar-core/x/evm/types"
 	"github.com/axelarnetwork/axelar-core/x/tss/tofnd"
 	tssTypes "github.com/axelarnetwork/axelar-core/x/tss/types"
+	tmEvents "github.com/axelarnetwork/tm-events/events"
+	"github.com/axelarnetwork/tm-events/pubsub"
+	"github.com/axelarnetwork/tm-events/tendermint"
+	"github.com/axelarnetwork/utils/jobs"
 )
 
 // RW grants -rw------- file permissions

--- a/cmd/axelard/cmd/vald/tss/keygen.go
+++ b/cmd/axelard/cmd/vald/tss/keygen.go
@@ -11,14 +11,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	tmEvents "github.com/axelarnetwork/tm-events/events"
-
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/parse"
 	"github.com/axelarnetwork/axelar-core/utils"
 	tssexported "github.com/axelarnetwork/axelar-core/x/tss/exported"
 	"github.com/axelarnetwork/axelar-core/x/tss/tofnd"
 	tss "github.com/axelarnetwork/axelar-core/x/tss/types"
 	voting "github.com/axelarnetwork/axelar-core/x/vote/exported"
+	tmEvents "github.com/axelarnetwork/tm-events/events"
 )
 
 // ProcessKeygenStart starts the communication with the keygen protocol

--- a/cmd/axelard/cmd/vald/tss/keygen_test.go
+++ b/cmd/axelard/cmd/vald/tss/keygen_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	"google.golang.org/grpc"
 
-	tmEvents "github.com/axelarnetwork/tm-events/events"
-
 	"github.com/axelarnetwork/axelar-core/app"
 	mock2 "github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/broadcaster/types/mock"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/tss/rpc/mock"
@@ -23,6 +21,7 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/tss/tofnd"
 	tss "github.com/axelarnetwork/axelar-core/x/tss/types"
 	mock3 "github.com/axelarnetwork/axelar-core/x/tss/types/mock"
+	tmEvents "github.com/axelarnetwork/tm-events/events"
 )
 
 func TestMgr_ProcessKeygenStart(t *testing.T) {

--- a/cmd/axelard/cmd/vald/tss/rpc/rpcClient.go
+++ b/cmd/axelard/cmd/vald/tss/rpc/rpcClient.go
@@ -3,7 +3,6 @@ package rpc
 import "github.com/axelarnetwork/axelar-core/x/tss/tofnd"
 
 //go:generate moq -pkg mock -out ./mock/rpcClient.go . Client MultiSigClient
-
 // Client defines the interface of a grpc client to communicate with tofnd
 type Client interface {
 	tofnd.GG20Client

--- a/cmd/axelard/cmd/vald/tss/sign.go
+++ b/cmd/axelard/cmd/vald/tss/sign.go
@@ -10,8 +10,6 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/ethereum/go-ethereum/common"
 
-	tmEvents "github.com/axelarnetwork/tm-events/events"
-
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/parse"
 	"github.com/axelarnetwork/axelar-core/utils"
 	tssexported "github.com/axelarnetwork/axelar-core/x/tss/exported"
@@ -19,6 +17,7 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/tss/types"
 	tss "github.com/axelarnetwork/axelar-core/x/tss/types"
 	voting "github.com/axelarnetwork/axelar-core/x/vote/exported"
+	tmEvents "github.com/axelarnetwork/tm-events/events"
 )
 
 // ProcessSignStart starts the communication with the sign protocol

--- a/cmd/axelard/cmd/vald/tss/sign_test.go
+++ b/cmd/axelard/cmd/vald/tss/sign_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	"google.golang.org/grpc"
 
-	tmEvents "github.com/axelarnetwork/tm-events/events"
-
 	"github.com/axelarnetwork/axelar-core/app"
 	mock2 "github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/broadcaster/types/mock"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/tss/rpc/mock"
@@ -22,6 +20,7 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/tss/tofnd"
 	tss "github.com/axelarnetwork/axelar-core/x/tss/types"
 	mock3 "github.com/axelarnetwork/axelar-core/x/tss/types/mock"
+	tmEvents "github.com/axelarnetwork/tm-events/events"
 )
 
 func TestMgr_ProcessSignStart(t *testing.T) {

--- a/cmd/axelard/cmd/vald/tss/timeout_test.go
+++ b/cmd/axelard/cmd/vald/tss/timeout_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/axelarnetwork/axelar-core/app"

--- a/cmd/axelard/cmd/vald/tss/tss.go
+++ b/cmd/axelard/cmd/vald/tss/tss.go
@@ -15,11 +15,10 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	"google.golang.org/grpc"
 
-	rewardtypes "github.com/axelarnetwork/axelar-core/x/reward/types"
-
 	broadcasterTypes "github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/broadcaster/types"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/parse"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/vald/tss/rpc"
+	rewardtypes "github.com/axelarnetwork/axelar-core/x/reward/types"
 	snapshot "github.com/axelarnetwork/axelar-core/x/snapshot/exported"
 	"github.com/axelarnetwork/axelar-core/x/tss/exported"
 	"github.com/axelarnetwork/axelar-core/x/tss/tofnd"

--- a/scripts/rm-blank-lines.sh
+++ b/scripts/rm-blank-lines.sh
@@ -2,7 +2,7 @@
 
 if [ "$(uname)" == "Darwin" ]; then
   # shellcheck disable=SC2038
-  find . -type f  -path '*.go' ! -path '*.pb.go' ! -path '*/mock/*' | xargs sed -i '' '/import/, /)/ {/^$/ d;}'
+  find . -type f  -path '*.go' ! -path '*.pb.go' ! -path '*.pb.gw.go' ! -path '*/mock/*' | xargs sed -i '' '/import/, /)/ {/^$/ d;}'
 else
   # shellcheck disable=SC2038
   find . -type f  -path '*.go' ! -path '*.pb.go' ! -path '*.pb.gw.go' ! -path '*/mock/*' | xargs sed -i '/import/, /)/ {/^$/ d}'

--- a/scripts/rm-blank-lines.sh
+++ b/scripts/rm-blank-lines.sh
@@ -5,5 +5,5 @@ if [ "$(uname)" == "Darwin" ]; then
   find . -type f  -path '*.go' ! -path '*.pb.go' ! -path '*/mock/*' | xargs sed -i '' '/import/, /)/ {/^$/ d;}'
 else
   # shellcheck disable=SC2038
-  find . -type f  -path '*.go' ! -path '*.pb.go' ! -path '*/mock/*' | xargs sed -i '/import/, /)/ {/^$/ d}'
+  find . -type f  -path '*.go' ! -path '*.pb.go' ! -path '*.pb.gw.go' ! -path '*/mock/*' | xargs sed -i '/import/, /)/ {/^$/ d}'
 fi

--- a/scripts/rm-blank-lines.sh
+++ b/scripts/rm-blank-lines.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [ "$(uname)" == "Darwin" ]; then
+  # shellcheck disable=SC2038
+  find . -type f  -path '*.go' ! -path '*.pb.go' ! -path '*/mock/*' | xargs sed -i '' '/import/, /)/ {/^$/ d;}'
+else
+  # shellcheck disable=SC2038
+  find . -type f  -path '*.go' ! -path '*.pb.go' ! -path '*/mock/*' | xargs sed -i '/import/, /)/ {/^$/ d}'
+fi

--- a/testutils/fake/interfaces/store.go
+++ b/testutils/fake/interfaces/store.go
@@ -3,7 +3,6 @@ package interfaces
 import sdkTypes "github.com/cosmos/cosmos-sdk/types"
 
 //go:generate moq -out ./mock/store.go -pkg mock . MultiStore CacheMultiStore KVStore
-
 // Interface wrappers for mocking
 type (
 	// MultiStore wrapper for github.com/cosmos/cosmos-sdk/types.MultiStore

--- a/testutils/rand/rand.go
+++ b/testutils/rand/rand.go
@@ -8,11 +8,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/address"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"golang.org/x/text/unicode/norm"
-
-	"github.com/ethereum/go-ethereum/common/math"
 )
 
 const (

--- a/x/ante/check_refund.go
+++ b/x/ante/check_refund.go
@@ -8,9 +8,8 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	antetypes "github.com/cosmos/cosmos-sdk/x/auth/ante"
 
-	rewardtypes "github.com/axelarnetwork/axelar-core/x/reward/types"
-
 	"github.com/axelarnetwork/axelar-core/x/ante/types"
+	rewardtypes "github.com/axelarnetwork/axelar-core/x/reward/types"
 )
 
 // CheckRefundFeeDecorator record potential refund for tss and vote txs

--- a/x/axelarnet/client/rest/tx.go
+++ b/x/axelarnet/client/rest/tx.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gorilla/mux"
 
 	clientUtils "github.com/axelarnetwork/axelar-core/utils"
-
 	"github.com/axelarnetwork/axelar-core/x/axelarnet/types"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
 )

--- a/x/axelarnet/module.go
+++ b/x/axelarnet/module.go
@@ -5,10 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gorilla/mux"
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/spf13/cobra"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -18,6 +14,9 @@ import (
 	"github.com/cosmos/ibc-go/v2/modules/apps/transfer"
 	channeltypes "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types"
 	ibcexported "github.com/cosmos/ibc-go/v2/modules/core/exported"
+	"github.com/gorilla/mux"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/spf13/cobra"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 

--- a/x/axelarnet/types/expected_keepers.go
+++ b/x/axelarnet/types/expected_keepers.go
@@ -1,11 +1,10 @@
 package types
 
 import (
-	clienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
-	ibcclient "github.com/cosmos/ibc-go/v2/modules/core/exported"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ibctypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
+	clienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
+	ibcclient "github.com/cosmos/ibc-go/v2/modules/core/exported"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/libs/log"
 

--- a/x/axelarnet/types/types.go
+++ b/x/axelarnet/types/types.go
@@ -6,12 +6,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/axelarnetwork/axelar-core/utils"
-	"github.com/axelarnetwork/axelar-core/x/axelarnet/exported"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/address"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/axelarnetwork/axelar-core/utils"
+	"github.com/axelarnetwork/axelar-core/x/axelarnet/exported"
 )
 
 // NewLinkedAddress creates a new address to make a deposit which can be transferred to another blockchain

--- a/x/bitcoin/client/rest/tx.go
+++ b/x/bitcoin/client/rest/tx.go
@@ -10,9 +10,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/gorilla/mux"
 
-	"github.com/axelarnetwork/axelar-core/x/bitcoin/types"
-
 	clientUtils "github.com/axelarnetwork/axelar-core/utils"
+	"github.com/axelarnetwork/axelar-core/x/bitcoin/types"
 )
 
 // rest routes

--- a/x/bitcoin/keeper/tss_handler.go
+++ b/x/bitcoin/keeper/tss_handler.go
@@ -4,18 +4,16 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
-	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
-
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/axelarnetwork/axelar-core/x/bitcoin/exported"
 	"github.com/axelarnetwork/axelar-core/x/bitcoin/types"
+	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
 )
 
 type signingAbortError struct {

--- a/x/bitcoin/types/tests/types_test.go
+++ b/x/bitcoin/types/tests/types_test.go
@@ -22,11 +22,10 @@ import (
 	"github.com/axelarnetwork/axelar-core/testutils"
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
 	"github.com/axelarnetwork/axelar-core/x/bitcoin/types"
-	tssTestUtils "github.com/axelarnetwork/axelar-core/x/tss/exported/testutils"
-
 	evm "github.com/axelarnetwork/axelar-core/x/evm/exported"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
+	tssTestUtils "github.com/axelarnetwork/axelar-core/x/tss/exported/testutils"
 )
 
 const (

--- a/x/evm/client/cli/query.go
+++ b/x/evm/client/cli/query.go
@@ -11,9 +11,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/axelarnetwork/axelar-core/utils"
-	"github.com/axelarnetwork/axelar-core/x/evm/keeper"
-
 	evmclient "github.com/axelarnetwork/axelar-core/x/evm/client"
+	"github.com/axelarnetwork/axelar-core/x/evm/keeper"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
 	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
 )

--- a/x/evm/client/rest/query.go
+++ b/x/evm/client/rest/query.go
@@ -10,10 +10,9 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/axelarnetwork/axelar-core/utils"
+	evmclient "github.com/axelarnetwork/axelar-core/x/evm/client"
 	"github.com/axelarnetwork/axelar-core/x/evm/keeper"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
-
-	evmclient "github.com/axelarnetwork/axelar-core/x/evm/client"
 )
 
 // query parameters

--- a/x/evm/keeper/baseKeeper.go
+++ b/x/evm/keeper/baseKeeper.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tendermint/tendermint/libs/log"
-
+	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/cosmos/cosmos-sdk/codec"
 	params "github.com/cosmos/cosmos-sdk/x/params/types"
+	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/axelarnetwork/axelar-core/utils"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"

--- a/x/evm/keeper/chainKeeper.go
+++ b/x/evm/keeper/chainKeeper.go
@@ -8,12 +8,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	params "github.com/cosmos/cosmos-sdk/x/params/types"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-
-	evmTypes "github.com/ethereum/go-ethereum/core/types"
-
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	evmTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/axelarnetwork/axelar-core/utils"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -8,15 +8,9 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-
-	evmTest "github.com/axelarnetwork/axelar-core/x/evm/types/testutils"
-	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
-	tssTestUtils "github.com/axelarnetwork/axelar-core/x/tss/exported/testutils"
-	vote "github.com/axelarnetwork/axelar-core/x/vote/exported"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/axelarnetwork/axelar-core/testutils"
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
@@ -24,7 +18,11 @@ import (
 	evmKeeper "github.com/axelarnetwork/axelar-core/x/evm/keeper"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
 	"github.com/axelarnetwork/axelar-core/x/evm/types/mock"
+	evmTest "github.com/axelarnetwork/axelar-core/x/evm/types/testutils"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
+	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
+	tssTestUtils "github.com/axelarnetwork/axelar-core/x/tss/exported/testutils"
+	vote "github.com/axelarnetwork/axelar-core/x/vote/exported"
 )
 
 func TestQueryPendingCommands(t *testing.T) {

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -13,16 +13,15 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/axelarnetwork/axelar-core/app"
-	"github.com/axelarnetwork/axelar-core/x/evm/exported"
-	"github.com/axelarnetwork/axelar-core/x/evm/types/mock"
-	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
-
 	"github.com/axelarnetwork/axelar-core/app/params"
 	"github.com/axelarnetwork/axelar-core/testutils"
 	"github.com/axelarnetwork/axelar-core/testutils/fake"
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
+	"github.com/axelarnetwork/axelar-core/x/evm/exported"
 	evmKeeper "github.com/axelarnetwork/axelar-core/x/evm/keeper"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
+	"github.com/axelarnetwork/axelar-core/x/evm/types/mock"
+	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
 )
 
 func TestCommands(t *testing.T) {

--- a/x/evm/keeper/msg_server_test.go
+++ b/x/evm/keeper/msg_server_test.go
@@ -8,23 +8,16 @@ import (
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-
-	evmTestUtils "github.com/axelarnetwork/axelar-core/x/evm/types/testutils"
-	tssTestUtils "github.com/axelarnetwork/axelar-core/x/tss/exported/testutils"
-	voteMock "github.com/axelarnetwork/axelar-core/x/vote/exported/mock"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramsKeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	"github.com/ethereum/go-ethereum/common"
-	evmCrypto "github.com/ethereum/go-ethereum/crypto"
-	abci "github.com/tendermint/tendermint/abci/types"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-
 	evmTypes "github.com/ethereum/go-ethereum/core/types"
+	evmCrypto "github.com/ethereum/go-ethereum/crypto"
 	evmParams "github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/assert"
+	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
-
-	paramsKeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/axelarnetwork/axelar-core/app"
 	"github.com/axelarnetwork/axelar-core/testutils"
@@ -36,10 +29,13 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/evm/keeper"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
 	"github.com/axelarnetwork/axelar-core/x/evm/types/mock"
+	evmTestUtils "github.com/axelarnetwork/axelar-core/x/evm/types/testutils"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	snapshot "github.com/axelarnetwork/axelar-core/x/snapshot/exported"
 	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
+	tssTestUtils "github.com/axelarnetwork/axelar-core/x/tss/exported/testutils"
 	vote "github.com/axelarnetwork/axelar-core/x/vote/exported"
+	voteMock "github.com/axelarnetwork/axelar-core/x/vote/exported/mock"
 )
 
 var (

--- a/x/evm/keeper/querier.go
+++ b/x/evm/keeper/querier.go
@@ -3,12 +3,11 @@ package keeper
 import (
 	"fmt"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // Query labels

--- a/x/evm/keeper/vote_handler.go
+++ b/x/evm/keeper/vote_handler.go
@@ -8,12 +8,11 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/axelarnetwork/utils/slices"
-
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
 	vote "github.com/axelarnetwork/axelar-core/x/vote/exported"
+	"github.com/axelarnetwork/utils/slices"
 )
 
 // NewVoteHandler returns the handler for processing vote delivered by the vote module

--- a/x/evm/keeper/vote_handler_test.go
+++ b/x/evm/keeper/vote_handler_test.go
@@ -5,11 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	fakeMock "github.com/axelarnetwork/axelar-core/testutils/fake/interfaces/mock"
-
-	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
-	tssTestUtils "github.com/axelarnetwork/axelar-core/x/tss/exported/testutils"
-
 	"github.com/btcsuite/btcd/btcec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -18,17 +13,19 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
-	"github.com/axelarnetwork/utils/slices"
-
 	"github.com/axelarnetwork/axelar-core/app/params"
 	"github.com/axelarnetwork/axelar-core/testutils"
+	fakeMock "github.com/axelarnetwork/axelar-core/testutils/fake/interfaces/mock"
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
 	"github.com/axelarnetwork/axelar-core/x/evm/exported"
 	"github.com/axelarnetwork/axelar-core/x/evm/keeper"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
 	"github.com/axelarnetwork/axelar-core/x/evm/types/mock"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
+	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
+	tssTestUtils "github.com/axelarnetwork/axelar-core/x/tss/exported/testutils"
 	vote "github.com/axelarnetwork/axelar-core/x/vote/exported"
+	"github.com/axelarnetwork/utils/slices"
 )
 
 func TestHandleVoteResult(t *testing.T) {

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/tendermint/tendermint/libs/log"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -16,6 +14,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/axelarnetwork/axelar-core/utils"
 	"github.com/axelarnetwork/axelar-core/x/evm/client/cli"

--- a/x/evm/types/expected_keepers.go
+++ b/x/evm/types/expected_keepers.go
@@ -2,10 +2,9 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	params "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/tendermint/tendermint/libs/log"
-
-	params "github.com/cosmos/cosmos-sdk/x/params/types"
 
 	"github.com/axelarnetwork/axelar-core/utils"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"

--- a/x/evm/types/types_test.go
+++ b/x/evm/types/types_test.go
@@ -9,9 +9,8 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
 	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"

--- a/x/nexus/client/cli/query.go
+++ b/x/nexus/client/cli/query.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/axelarnetwork/axelar-core/utils"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
-
 	"github.com/axelarnetwork/axelar-core/x/nexus/keeper"
 	"github.com/axelarnetwork/axelar-core/x/nexus/types"
 )

--- a/x/nexus/keeper/genesis_test.go
+++ b/x/nexus/keeper/genesis_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/axelarnetwork/axelar-core/app/params"
 	"github.com/axelarnetwork/axelar-core/testutils/fake"
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
-
 	axelarnet "github.com/axelarnetwork/axelar-core/x/axelarnet/exported"
 	axelarnetkeeper "github.com/axelarnetwork/axelar-core/x/axelarnet/keeper"
 	axelarnetTypes "github.com/axelarnetwork/axelar-core/x/axelarnet/types"

--- a/x/nexus/keeper/transfer_test.go
+++ b/x/nexus/keeper/transfer_test.go
@@ -4,12 +4,9 @@ import (
 	mathrand "math/rand"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common/math"
-
-	"github.com/axelarnetwork/axelar-core/utils"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -18,6 +15,7 @@ import (
 	"github.com/axelarnetwork/axelar-core/app/params"
 	"github.com/axelarnetwork/axelar-core/testutils/fake"
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
+	"github.com/axelarnetwork/axelar-core/utils"
 	axelarnet "github.com/axelarnetwork/axelar-core/x/axelarnet/exported"
 	axelarnettypes "github.com/axelarnetwork/axelar-core/x/axelarnet/types"
 	evm "github.com/axelarnetwork/axelar-core/x/evm/exported"

--- a/x/nexus/types/expected_keepers.go
+++ b/x/nexus/types/expected_keepers.go
@@ -3,12 +3,11 @@ package types
 import (
 	"context"
 
-	evm "github.com/axelarnetwork/axelar-core/x/evm/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/tendermint/tendermint/libs/log"
 
+	evm "github.com/axelarnetwork/axelar-core/x/evm/types"
 	"github.com/axelarnetwork/axelar-core/x/nexus/exported"
 )
 

--- a/x/nexus/types/genesis.go
+++ b/x/nexus/types/genesis.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	axelarnet "github.com/axelarnetwork/axelar-core/x/axelarnet/exported"

--- a/x/reward/abci.go
+++ b/x/reward/abci.go
@@ -2,9 +2,8 @@ package reward
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	abci "github.com/tendermint/tendermint/abci/types"
-
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/axelarnetwork/axelar-core/x/reward/exported"
 	"github.com/axelarnetwork/axelar-core/x/reward/types"

--- a/x/reward/types/expected_keepers.go
+++ b/x/reward/types/expected_keepers.go
@@ -2,10 +2,9 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/tendermint/tendermint/libs/log"
-
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/tendermint/tendermint/libs/log"
 
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	"github.com/axelarnetwork/axelar-core/x/reward/exported"

--- a/x/snapshot/client/cli/query.go
+++ b/x/snapshot/client/cli/query.go
@@ -3,14 +3,13 @@ package cli
 import (
 	"fmt"
 
-	"github.com/axelarnetwork/axelar-core/x/snapshot/keeper"
-	"github.com/axelarnetwork/axelar-core/x/snapshot/types"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/spf13/cobra"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/axelarnetwork/axelar-core/x/snapshot/keeper"
+	"github.com/axelarnetwork/axelar-core/x/snapshot/types"
 )
 
 // GetQueryCmd returns the cli query commands for this module

--- a/x/snapshot/client/rest/query.go
+++ b/x/snapshot/client/rest/query.go
@@ -4,17 +4,14 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/gorilla/mux"
 
 	"github.com/axelarnetwork/axelar-core/utils"
-
-	"github.com/cosmos/cosmos-sdk/client"
-
-	"github.com/axelarnetwork/axelar-core/x/snapshot/types"
-
 	"github.com/axelarnetwork/axelar-core/x/snapshot/keeper"
+	"github.com/axelarnetwork/axelar-core/x/snapshot/types"
 )
 
 // GetHandlerQueryProxy returns the proxy address associated to some operator address

--- a/x/snapshot/exported/types.go
+++ b/x/snapshot/exported/types.go
@@ -10,7 +10,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
-
 	"github.com/gogo/protobuf/proto"
 
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"

--- a/x/snapshot/keeper/keeper_test.go
+++ b/x/snapshot/keeper/keeper_test.go
@@ -8,9 +8,14 @@ import (
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	params "github.com/cosmos/cosmos-sdk/x/params/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/crypto/ed25519"
+	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/axelarnetwork/axelar-core/app"
@@ -19,19 +24,10 @@ import (
 	"github.com/axelarnetwork/axelar-core/testutils/fake"
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
 	"github.com/axelarnetwork/axelar-core/utils"
+	snapshotMock "github.com/axelarnetwork/axelar-core/x/snapshot/exported/mock"
 	"github.com/axelarnetwork/axelar-core/x/snapshot/keeper"
 	"github.com/axelarnetwork/axelar-core/x/snapshot/types"
 	"github.com/axelarnetwork/axelar-core/x/snapshot/types/mock"
-
-	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-
-	snapshotMock "github.com/axelarnetwork/axelar-core/x/snapshot/exported/mock"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/tendermint/tendermint/libs/log"
-
 	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
 )
 

--- a/x/snapshot/module.go
+++ b/x/snapshot/module.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/axelarnetwork/axelar-core/x/snapshot/client/cli"
 	"github.com/axelarnetwork/axelar-core/x/snapshot/client/rest"
-
 	"github.com/axelarnetwork/axelar-core/x/snapshot/keeper"
 	"github.com/axelarnetwork/axelar-core/x/snapshot/types"
 )

--- a/x/snapshot/types/codec.go
+++ b/x/snapshot/types/codec.go
@@ -5,11 +5,10 @@ import (
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/axelarnetwork/axelar-core/x/snapshot/exported"
-
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/axelarnetwork/axelar-core/x/snapshot/exported"
 )
 
 // RegisterLegacyAminoCodec registers concrete types on codec

--- a/x/tss/client/cli/query.go
+++ b/x/tss/client/cli/query.go
@@ -3,10 +3,9 @@ package cli
 import (
 	"fmt"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/spf13/cobra"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/tss/exported"
 	"github.com/axelarnetwork/axelar-core/x/tss/keeper"
 	"github.com/axelarnetwork/axelar-core/x/tss/tofnd"
-
 	"github.com/axelarnetwork/axelar-core/x/tss/types"
 )
 

--- a/x/tss/client/rest/query.go
+++ b/x/tss/client/rest/query.go
@@ -5,18 +5,15 @@ import (
 	"net/http"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/rest"
+	"github.com/gorilla/mux"
 
 	"github.com/axelarnetwork/axelar-core/utils"
-
 	"github.com/axelarnetwork/axelar-core/x/tss/keeper"
 	"github.com/axelarnetwork/axelar-core/x/tss/tofnd"
 	"github.com/axelarnetwork/axelar-core/x/tss/types"
-
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/gorilla/mux"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/rest"
 )
 
 // query parameters

--- a/x/tss/keeper/grpc_query_test.go
+++ b/x/tss/keeper/grpc_query_test.go
@@ -3,7 +3,10 @@ package keeper_test
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -14,10 +17,6 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/tss/keeper"
 	"github.com/axelarnetwork/axelar-core/x/tss/types"
 	"github.com/axelarnetwork/axelar-core/x/tss/types/mock"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/tendermint/tendermint/libs/log"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
 func TestNextKeyID(t *testing.T) {

--- a/x/tss/keeper/keeper.go
+++ b/x/tss/keeper/keeper.go
@@ -8,9 +8,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	params "github.com/cosmos/cosmos-sdk/x/params/types"
-	"github.com/tendermint/tendermint/libs/log"
-
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/axelarnetwork/axelar-core/utils"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"

--- a/x/tss/keeper/keeper_test.go
+++ b/x/tss/keeper/keeper_test.go
@@ -7,14 +7,14 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	params "github.com/cosmos/cosmos-sdk/x/params/types"
+	slashingTypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
-	slashingTypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
-
 	appParams "github.com/axelarnetwork/axelar-core/app/params"
 	"github.com/axelarnetwork/axelar-core/testutils"
+	"github.com/axelarnetwork/axelar-core/testutils/fake"
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
 	rand2 "github.com/axelarnetwork/axelar-core/testutils/rand"
 	bitcoin "github.com/axelarnetwork/axelar-core/x/bitcoin/exported"
@@ -22,11 +22,9 @@ import (
 	snapMock "github.com/axelarnetwork/axelar-core/x/snapshot/exported/mock"
 	"github.com/axelarnetwork/axelar-core/x/tss/exported"
 	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
+	"github.com/axelarnetwork/axelar-core/x/tss/types"
 	tssMock "github.com/axelarnetwork/axelar-core/x/tss/types/mock"
 	vote "github.com/axelarnetwork/axelar-core/x/vote/exported"
-
-	"github.com/axelarnetwork/axelar-core/testutils/fake"
-	"github.com/axelarnetwork/axelar-core/x/tss/types"
 )
 
 var (

--- a/x/tss/keeper/querier.go
+++ b/x/tss/keeper/querier.go
@@ -12,9 +12,8 @@ import (
 
 	"github.com/axelarnetwork/axelar-core/x/tss/exported"
 	"github.com/axelarnetwork/axelar-core/x/tss/tofnd"
-	voting "github.com/axelarnetwork/axelar-core/x/vote/exported"
-
 	"github.com/axelarnetwork/axelar-core/x/tss/types"
+	voting "github.com/axelarnetwork/axelar-core/x/vote/exported"
 )
 
 // Query paths

--- a/x/tss/types/codec.go
+++ b/x/tss/types/codec.go
@@ -7,7 +7,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	reward "github.com/axelarnetwork/axelar-core/x/reward/exported"
-
 	"github.com/axelarnetwork/axelar-core/x/tss/tofnd"
 )
 

--- a/x/tss/types/expected_keepers.go
+++ b/x/tss/types/expected_keepers.go
@@ -8,12 +8,11 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/axelarnetwork/axelar-core/utils"
-	tofnd2 "github.com/axelarnetwork/axelar-core/x/tss/tofnd"
-
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	reward "github.com/axelarnetwork/axelar-core/x/reward/exported"
 	snapshot "github.com/axelarnetwork/axelar-core/x/snapshot/exported"
 	"github.com/axelarnetwork/axelar-core/x/tss/exported"
+	tofnd2 "github.com/axelarnetwork/axelar-core/x/tss/tofnd"
 	vote "github.com/axelarnetwork/axelar-core/x/vote/exported"
 )
 

--- a/x/tss/types/types_test.go
+++ b/x/tss/types/types_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/cosmos/cosmos-sdk/types/address"
 	"github.com/stretchr/testify/assert"
 

--- a/x/vote/abci.go
+++ b/x/vote/abci.go
@@ -1,10 +1,10 @@
 package vote
 
 import (
-	"github.com/axelarnetwork/axelar-core/x/vote/keeper"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/axelarnetwork/axelar-core/x/vote/keeper"
 )
 
 // BeginBlocker check for infraction evidence or downtime of validators

--- a/x/vote/keeper/genesis_test.go
+++ b/x/vote/keeper/genesis_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/axelarnetwork/axelar-core/testutils/fake"
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
 	"github.com/axelarnetwork/axelar-core/utils"
-
 	reward "github.com/axelarnetwork/axelar-core/x/reward/exported"
 	rewardMock "github.com/axelarnetwork/axelar-core/x/reward/exported/mock"
 	"github.com/axelarnetwork/axelar-core/x/vote/exported"


### PR DESCRIPTION
## Description
`goimports` keeps blank lines in imports as they were. This means that import statements can become quite jumbled and do not adhere to the three sections (std lib, external, same organization). `make goimports` now removes blank lines in imports first before calling `goimports` so imports get fully sorted.
