### PR TITLE
fix: emit events from cached end blocker

### DIFF
--- a/utils/abci.go
+++ b/utils/abci.go
@@ -32,6 +32,7 @@ func RunEndBlocker(c sdk.Context, l Logger, endBlocker func(sdk.Context) ([]abci
 	}
 
 	writeCache()
+	c.EventManager().EmitEvents(ctx.EventManager().Events())
 
 	return updates
 }

--- a/utils/abci_test.go
+++ b/utils/abci_test.go
@@ -13,11 +13,14 @@ import (
 	fakeMock "github.com/axelarnetwork/axelar-core/testutils/fake/interfaces/mock"
 	"github.com/axelarnetwork/axelar-core/utils"
 	"github.com/axelarnetwork/axelar-core/utils/mock"
+	testutils "github.com/axelarnetwork/utils/test"
 )
 
 func setup() (sdk.Context, utils.Logger, *fakeMock.MultiStoreMock, *fakeMock.CacheMultiStoreMock) {
 	store := &fakeMock.MultiStoreMock{}
-	cacheStore := &fakeMock.CacheMultiStoreMock{}
+	cacheStore := &fakeMock.CacheMultiStoreMock{
+		WriteFunc: func() {},
+	}
 	store.CacheMultiStoreFunc = func() sdk.CacheMultiStore { return cacheStore }
 
 	ctx := sdk.NewContext(store, tmproto.Header{}, false, log.TestingLogger())
@@ -53,7 +56,6 @@ func TestRunEndBlocker(t *testing.T) {
 
 	t.Run("should return updates and write if end blocker succeeds", func(t *testing.T) {
 		ctx, l, store, cacheStore := setup()
-		cacheStore.WriteFunc = func() {}
 
 		expected := []types.ValidatorUpdate{{}}
 		actual := utils.RunEndBlocker(ctx, l, func(sdk.Context) ([]types.ValidatorUpdate, error) {
@@ -64,4 +66,23 @@ func TestRunEndBlocker(t *testing.T) {
 		assert.Len(t, store.CacheMultiStoreCalls(), 1)
 		assert.Len(t, cacheStore.WriteCalls(), 1)
 	})
+
+	var (
+		baseCtx sdk.Context
+		logger  utils.Logger
+	)
+	testutils.Given("a base context with event manager", func() {
+		ctx, l, store, _ := setup()
+		logger = l
+		baseCtx = ctx.
+			WithMultiStore(store).
+			WithEventManager(sdk.NewEventManager())
+	}).When("running an end blocker that emits events", func() {
+		utils.RunEndBlocker(baseCtx, logger, func(cachedCtx sdk.Context) ([]types.ValidatorUpdate, error) {
+			cachedCtx.EventManager().EmitEvent(sdk.Event{})
+			return nil, nil
+		})
+	}).Then("pass events down to the base context", func(t *testing.T) {
+		assert.Len(t, baseCtx.EventManager().Events(), 1)
+	}).Run(t)
 }

--- a/utils/abci_test.go
+++ b/utils/abci_test.go
@@ -71,13 +71,13 @@ func TestRunEndBlocker(t *testing.T) {
 		baseCtx sdk.Context
 		logger  utils.Logger
 	)
-	testutils.Given("a base context with event manager", func() {
+	testutils.Given("a base context with event manager", func(t *testing.T) {
 		ctx, l, store, _ := setup()
 		logger = l
 		baseCtx = ctx.
 			WithMultiStore(store).
 			WithEventManager(sdk.NewEventManager())
-	}).When("running an end blocker that emits events", func() {
+	}).When("running an end blocker that emits events", func(t *testing.T) {
 		utils.RunEndBlocker(baseCtx, logger, func(cachedCtx sdk.Context) ([]types.ValidatorUpdate, error) {
 			cachedCtx.EventManager().EmitEvent(sdk.Event{})
 			return nil, nil


### PR DESCRIPTION
## Description
Because of the added caching in our endblockers, events were not passed down to the base context when the endblocker was successful.