### PR TITLE
fix(evm): emit events from cached ctx

### DIFF
--- a/x/evm/keeper/vote_handler.go
+++ b/x/evm/keeper/vote_handler.go
@@ -53,6 +53,7 @@ func NewVoteHandler(cdc codec.Codec, keeper types.BaseKeeper, nexus types.Nexus,
 		}
 
 		writeCache()
+		ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
 		return nil
 	}
 }
@@ -141,6 +142,7 @@ func handleVoteConfirmDeposit(ctx sdk.Context, keeper types.ChainKeeper, n types
 			sdk.NewAttribute(types.AttributeKeyTokenAddress, burnerInfo.TokenAddress.Hex()),
 			sdk.NewAttribute(types.AttributeKeyTxID, event.TxId.Hex()),
 			sdk.NewAttribute(types.AttributeKeyTransferID, transferID.String()),
+			sdk.NewAttribute(sdk.AttributeKeyAction, types.AttributeValueConfirm),
 		))
 
 	return nil


### PR DESCRIPTION
## Description
related to #1439, we also have the issue with vote handler in v0.17. 
Event handling will be moved to endblocker in v0.18.

## Todos

- [ ] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [x] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
