### PR TITLE
fix(evm): use default separator for command ID

### DIFF
--- a/x/evm/types/types.go
+++ b/x/evm/types/types.go
@@ -820,7 +820,7 @@ func CreateDeployTokenCommand(chainID sdk.Int, keyID tss.KeyID, asset string, to
 	}
 
 	return Command{
-		ID:         NewCommandID([]byte(fmt.Sprintf("%s-%s", asset, tokenDetails.Symbol)), chainID),
+		ID:         NewCommandID([]byte(fmt.Sprintf("%s_%s", asset, tokenDetails.Symbol)), chainID),
 		Command:    AxelarGatewayCommandDeployToken,
 		Params:     params,
 		KeyID:      keyID,

--- a/x/evm/types/types_test.go
+++ b/x/evm/types/types_test.go
@@ -97,6 +97,7 @@ func TestDeployToken(t *testing.T) {
 		Capacity:  sdk.NewIntFromBigInt(big.NewInt(rand.I64Between(100, 100000))),
 	}
 	address := Address(common.BytesToAddress(rand.Bytes(common.AddressLength)))
+	asset := rand.Str(5)
 
 	capBz := make([]byte, 8)
 	binary.BigEndian.PutUint64(capBz, details.Capacity.Uint64())
@@ -109,10 +110,12 @@ func TestDeployToken(t *testing.T) {
 		hex.EncodeToString([]byte(details.TokenName)),
 		hex.EncodeToString([]byte(details.Symbol)),
 	)
-	actual, err := CreateDeployTokenCommand(chainID, keyID, rand.Str(5), details, address)
+	expectedCommandID := NewCommandID([]byte(asset+"_"+details.Symbol), chainID)
+	actual, err := CreateDeployTokenCommand(chainID, keyID, asset, details, address)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedParams, hex.EncodeToString(actual.Params))
+	assert.Equal(t, expectedCommandID, actual.ID)
 
 	decodedName, decodedSymbol, decodedDecs, decodedCap, tokenAddress, err := decodeDeployTokenParams(actual.Params)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Description

`-` is not forbidden in asset and symbol string, so could cause a duplicate command ID. Use `_` separator instead that is forbidden in strings.

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
