### PR TITLE
fix(nexus): delete uaxl fee info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,7 +143,7 @@ require (
 	go.etcd.io/bbolt v1.3.6 // indirect
 	golang.org/x/net v0.0.0-20220412020605-290c469a71a5 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e // indirect
+	golang.org/x/sys v0.0.0-20220519141025-dcacdad47464 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1511,6 +1511,8 @@ golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a h1:N2T1jUrTQE9Re6TFF5PhvEHXH
 golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e h1:w36l2Uw3dRan1K3TyXriXvY+6T56GNmlKGcqiQUJDfM=
 golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220519141025-dcacdad47464 h1:MpIuURY70f0iKp/oooEFtB2oENcHITo/z1b6u41pKCw=
+golang.org/x/sys v0.0.0-20220519141025-dcacdad47464/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=

--- a/x/nexus/keeper/migrate.go
+++ b/x/nexus/keeper/migrate.go
@@ -21,7 +21,7 @@ const uaxlAsset = "uaxl"
 func GetMigrationHandler(k Keeper) func(ctx sdk.Context) error {
 	return func(ctx sdk.Context) error {
 		deregisterUaxlAsset(ctx, k)
-		removeUaxlFeeInfo(ctx, k)
+		removeUaxlEVMFeeInfo(ctx, k)
 		addModuleParams(ctx, k)
 
 		if err := migrateChainMaintainers(ctx, k); err != nil {
@@ -51,7 +51,7 @@ func deregisterUaxlAsset(ctx sdk.Context, k Keeper) {
 	}
 }
 
-func removeUaxlFeeInfo(ctx sdk.Context, k Keeper) {
+func removeUaxlEVMFeeInfo(ctx sdk.Context, k Keeper) {
 	for _, feeInfo := range k.getFeeInfos(ctx) {
 		if feeInfo.Asset != uaxlAsset {
 			continue

--- a/x/nexus/keeper/migrate.go
+++ b/x/nexus/keeper/migrate.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/axelarnetwork/axelar-core/utils"
 	evmTypes "github.com/axelarnetwork/axelar-core/x/evm/types"
 	"github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	"github.com/axelarnetwork/axelar-core/x/nexus/types"
@@ -14,11 +15,13 @@ const uaxlAsset = "uaxl"
 // GetMigrationHandler returns the handler that performs in-place store migrations from v0.14 to v0.15. The
 // migration includes:
 // - deregister uaxl asset for all EVM chains
+// - remove uaxl fee info
 // - add module parameters
 // - migrate .Maintainers in chain stats into .MaintainerStates
 func GetMigrationHandler(k Keeper) func(ctx sdk.Context) error {
 	return func(ctx sdk.Context) error {
 		deregisterUaxlAsset(ctx, k)
+		removeUaxlFeeInfo(ctx, k)
 		addModuleParams(ctx, k)
 
 		if err := migrateChainMaintainers(ctx, k); err != nil {
@@ -45,6 +48,21 @@ func deregisterUaxlAsset(ctx sdk.Context, k Keeper) {
 		})
 
 		k.setChainState(ctx, chainState)
+	}
+}
+
+func removeUaxlFeeInfo(ctx sdk.Context, k Keeper) {
+	for _, feeInfo := range k.getFeeInfos(ctx) {
+		if feeInfo.Asset != uaxlAsset {
+			continue
+		}
+
+		chain, ok := k.GetChain(ctx, feeInfo.Chain)
+		if !ok || chain.Module != evmTypes.ModuleName {
+			continue
+		}
+
+		k.getStore(ctx).Delete(assetFeePrefix.Append(utils.LowerCaseKey(chain.Name.String())).Append(utils.KeyFromStr(uaxlAsset)))
 	}
 }
 

--- a/x/nexus/keeper/migrate_test.go
+++ b/x/nexus/keeper/migrate_test.go
@@ -44,6 +44,53 @@ func TestGetMigrationHandler_deregisterUaxlAsset(t *testing.T) {
 	assert.True(t, keeper.IsAssetRegistered(ctx, evm.Ethereum, anotherAsset))
 }
 
+func TestGetMigrationHandler_removeUaxlFeeInfo(t *testing.T) {
+	ctx, keeper := setup()
+	uaxlAsset := "uaxl"
+	anotherAsset := rand.NormalizedStr(5)
+
+	keeper.SetChain(ctx, axelarnet.Axelarnet)
+	keeper.SetChain(ctx, evm.Ethereum)
+	if err := keeper.RegisterAsset(ctx, axelarnet.Axelarnet, exported.NewAsset(uaxlAsset, true)); err != nil {
+		panic(err)
+	}
+	if err := keeper.RegisterAsset(ctx, evm.Ethereum, exported.NewAsset(uaxlAsset, false)); err != nil {
+		panic(err)
+	}
+	if err := keeper.RegisterAsset(ctx, evm.Ethereum, exported.NewAsset(anotherAsset, false)); err != nil {
+		panic(err)
+	}
+
+	expectedFeeInfo := exported.NewFeeInfo(axelarnet.Axelarnet.Name, uaxlAsset, sdk.OneDec(), sdk.NewInt(100), sdk.NewInt(100000))
+	expectedEthereumFeeInfo := exported.NewFeeInfo(evm.Ethereum.Name, uaxlAsset, sdk.OneDec(), sdk.NewInt(100), sdk.NewInt(100000))
+	anotherAssetFeeInfo := exported.NewFeeInfo(axelarnet.Axelarnet.Name, anotherAsset, sdk.OneDec(), sdk.NewInt(10), sdk.NewInt(10000))
+
+	if err := keeper.RegisterFee(ctx, axelarnet.Axelarnet, expectedFeeInfo); err != nil {
+		panic(err)
+	}
+	if err := keeper.RegisterFee(ctx, evm.Ethereum, expectedEthereumFeeInfo); err != nil {
+		panic(err)
+	}
+	if err := keeper.RegisterFee(ctx, evm.Ethereum, anotherAssetFeeInfo); err != nil {
+		panic(err)
+	}
+
+	handler := GetMigrationHandler(keeper)
+	err := handler(ctx)
+	assert.NoError(t, err)
+
+	actualFeeInfo, ok := keeper.GetFeeInfo(ctx, axelarnet.Axelarnet, uaxlAsset)
+	assert.True(t, ok)
+	assert.Equal(t, expectedFeeInfo, actualFeeInfo)
+
+	actualFeeInfo, ok = keeper.GetFeeInfo(ctx, evm.Ethereum, uaxlAsset)
+	assert.False(t, ok)
+
+	actualFeeInfo, ok = keeper.GetFeeInfo(ctx, evm.Ethereum, anotherAsset)
+	assert.True(t, ok)
+	assert.Equal(t, anotherAssetFeeInfo, actualFeeInfo)
+}
+
 func TestGetMigrationHandler_addNewParams(t *testing.T) {
 	ctx, keeper := setup()
 

--- a/x/tss/keeper/migrate.go
+++ b/x/tss/keeper/migrate.go
@@ -36,12 +36,12 @@ func migrateSignInfo(ctx sdk.Context, k types.TSSKeeper) error {
 			continue
 		}
 
-		sigMatadataProto, err := codectypes.NewAnyWithValue(&sigMetadata)
+		sigMetadataProto, err := codectypes.NewAnyWithValue(&sigMetadata)
 		if err != nil {
 			return err
 		}
 
-		signInfo.ModuleMetadata = sigMatadataProto
+		signInfo.ModuleMetadata = sigMetadataProto
 		signInfo.Metadata = ""
 
 		k.SetInfoForSig(ctx, signInfo.SigID, signInfo)


### PR DESCRIPTION
## Description

Delete fee info registered for uaxl on EVM chains.
While not deleting uaxl fee info doesn't break anything, we should do it for consistency.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
