### PR TITLE
fix(evm): evm command decode for transferOwnership/Operatorship

### DIFF
--- a/x/evm/abci.go
+++ b/x/evm/abci.go
@@ -404,14 +404,32 @@ func handleConfirmedEvents(ctx sdk.Context, bk types.BaseKeeper, n types.Nexus, 
 		}
 		// skip if destination chain is not activated
 		if !n.IsChainActivated(ctx, destinationChain) {
+			bk.Logger(ctx).Debug(fmt.Sprintf("skipping confirmed event %s due to destination chain being inactive", event.GetID()),
+				"chain", event.Chain.String(),
+				"destination_chain", destinationChainName.String(),
+				"eventID", event.GetID(),
+			)
+
 			return false
 		}
 		// skip if destination chain has not got gateway set yet
 		if _, ok := bk.ForChain(destinationChainName).GetGatewayAddress(ctx); !ok {
+			bk.Logger(ctx).Debug(fmt.Sprintf("skipping confirmed event %s due to destination chain not having gateway set", event.GetID()),
+				"chain", event.Chain.String(),
+				"destination_chain", destinationChainName.String(),
+				"eventID", event.GetID(),
+			)
+
 			return false
 		}
 		// skip if destination chain has the secondary key rotation in progress
 		if _, nextSecondaryKeyAssigned := s.GetNextKeyID(ctx, destinationChain, tss.SecondaryKey); nextSecondaryKeyAssigned {
+			bk.Logger(ctx).Debug(fmt.Sprintf("skipping confirmed event %s due to destination chain in the middle of secondary key rotation", event.GetID()),
+				"chain", event.Chain.String(),
+				"destination_chain", destinationChainName.String(),
+				"eventID", event.GetID(),
+			)
+
 			return false
 		}
 
@@ -428,6 +446,11 @@ func handleConfirmedEvents(ctx sdk.Context, bk types.BaseKeeper, n types.Nexus, 
 
 		var event types.Event
 		for queue.Dequeue(&event, shouldHandleEvent) {
+			bk.Logger(ctx).Debug("handling confirmed event",
+				"chain", chain.Name.String(),
+				"eventID", event.GetID(),
+			)
+
 			var ok bool
 
 			switch event.GetEvent().(type) {
@@ -459,6 +482,11 @@ func handleConfirmedEvents(ctx sdk.Context, bk types.BaseKeeper, n types.Nexus, 
 
 				continue
 			}
+
+			bk.Logger(ctx).Debug("completed handling event",
+				"chain", chain.Name.String(),
+				"eventID", event.GetID(),
+			)
 
 			if err := ck.SetEventCompleted(ctx, event.GetID()); err != nil {
 				return err

--- a/x/evm/types/types.go
+++ b/x/evm/types/types.go
@@ -1806,13 +1806,13 @@ func (c Command) DecodeParams() (map[string]string, error) {
 		addresses, threshold, decodeMultisigErr := decodeTransferMultisigParams(c.Params)
 
 		switch {
-		case decodeSinglesigErr != nil:
+		case decodeSinglesigErr == nil:
 			param := "newOwner"
 			if c.Command == AxelarGatewayCommandTransferOperatorship {
 				param = "newOperator"
 			}
 			params[param] = address.Hex()
-		case decodeMultisigErr != nil:
+		case decodeMultisigErr == nil:
 			var addressStrs []string
 			for _, address := range addresses {
 				addressStrs = append(addressStrs, address.Hex())

--- a/x/evm/types/types_test.go
+++ b/x/evm/types/types_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -16,6 +17,7 @@ import (
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	tss "github.com/axelarnetwork/axelar-core/x/tss/exported"
 	tssTestUtils "github.com/axelarnetwork/axelar-core/x/tss/exported/testutils"
+	"github.com/axelarnetwork/utils/slices"
 )
 
 func TestCreateApproveContractCallWithMintCommand(t *testing.T) {
@@ -206,6 +208,10 @@ func TestCreateSinglesigTransferCommand_Ownership(t *testing.T) {
 
 	_, _, err = decodeTransferMultisigParams(actual.Params)
 	assert.Error(t, err)
+
+	params, err := actual.DecodeParams()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"newOwner": newOwnerAddr.Hex()}, params)
 }
 
 func TestCreateSinglesigTransferCommand_Operatorship(t *testing.T) {
@@ -230,6 +236,10 @@ func TestCreateSinglesigTransferCommand_Operatorship(t *testing.T) {
 
 	_, _, err = decodeTransferMultisigParams(actual.Params)
 	assert.Error(t, err)
+
+	params, err := actual.DecodeParams()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"newOperator": newOperatorAddr.Hex()}, params)
 }
 
 func TestCreateMultisigTransferCommand_Ownership(t *testing.T) {
@@ -262,6 +272,13 @@ func TestCreateMultisigTransferCommand_Ownership(t *testing.T) {
 
 	_, err = decodeTransferSinglesigParams(actual.Params)
 	assert.Error(t, err)
+
+	params, err := actual.DecodeParams()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"newOwners":    strings.Join(slices.Map(addresses, func(addr common.Address) string { return addr.Hex() }), ";"),
+		"newThreshold": strconv.FormatUint(uint64(threshold), 10),
+	}, params)
 }
 func TestCreateMultisigTransferCommand_Operatorship(t *testing.T) {
 	chainID := sdk.NewInt(1)
@@ -276,7 +293,7 @@ func TestCreateMultisigTransferCommand_Operatorship(t *testing.T) {
 
 	expectedParams := "000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003000000000000000000000000d59ca627af68d29c547b91066297a7c469a7bf72000000000000000000000000c2fcc7bcf743153c58efd44e6e723e9819e9a10a0000000000000000000000002ad611e02e4f7063f515c8f190e5728719937205"
 	actual, err := CreateMultisigTransferCommand(
-		Ownership,
+		Operatorship,
 		chainID,
 		keyID,
 		threshold,
@@ -293,6 +310,13 @@ func TestCreateMultisigTransferCommand_Operatorship(t *testing.T) {
 
 	_, err = decodeTransferSinglesigParams(actual.Params)
 	assert.Error(t, err)
+
+	params, err := actual.DecodeParams()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"newOperators": strings.Join(slices.Map(addresses, func(addr common.Address) string { return addr.Hex() }), ";"),
+		"newThreshold": strconv.FormatUint(uint64(threshold), 10),
+	}, params)
 }
 
 func TestGetSignHash(t *testing.T) {


### PR DESCRIPTION
## Description
1. Fix EVM command decode for transferOwnership/Operatorship
2. Improve logging during event process in EVM's endblocker
## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [x] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
