### PR TITLE
feat: use bash in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 trap stop_gracefully TERM INT


### PR DESCRIPTION
## Description

We use source  in entrypoint.sh, we should use bash instead of sh, because source is a bash builtin command.
It is needed for Rosetta build and debian base image build.
No side effects are expected with that change.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
