### PR TITLE
fix: extend heartbeat validity window

### DIFF
--- a/x/tss/keeper/keeper.go
+++ b/x/tss/keeper/keeper.go
@@ -181,6 +181,11 @@ func (k Keeper) GetHeartbeatPeriodInBlocks(ctx sdk.Context) int64 {
 	return result
 }
 
+// GetHeartbeatValidityInBlocks returns the number of blocks a heartbeat is considered valid
+func (k Keeper) GetHeartbeatValidityInBlocks(ctx sdk.Context) int64 {
+	return 2 * k.GetHeartbeatPeriodInBlocks(ctx)
+}
+
 // GetKeyRequirement gets the key requirement for a given chain of a given role
 func (k Keeper) GetKeyRequirement(ctx sdk.Context, keyRole exported.KeyRole, keyType exported.KeyType) (exported.KeyRequirement, bool) {
 	for _, keyRequirement := range k.GetParams(ctx).KeyRequirements {
@@ -320,7 +325,7 @@ func (k Keeper) IsOperatorAvailable(ctx sdk.Context, validator sdk.ValAddress, k
 	}
 	height := int64(binary.LittleEndian.Uint64(bz))
 
-	return (ctx.BlockHeight()-height) <= k.GetHeartbeatPeriodInBlocks(ctx) && k.operatorHasKeys(ctx, validator, keyIDs...)
+	return (ctx.BlockHeight()-height) <= k.GetHeartbeatValidityInBlocks(ctx) && k.operatorHasKeys(ctx, validator, keyIDs...)
 }
 
 // GetAvailableOperators gets all operators that still have a non-stale heartbeat
@@ -338,7 +343,7 @@ func (k Keeper) GetAvailableOperators(ctx sdk.Context, keyIDs ...exported.KeyID)
 		}
 
 		height := int64(binary.LittleEndian.Uint64(iter.Value()))
-		if (ctx.BlockHeight() - height) > k.GetHeartbeatPeriodInBlocks(ctx) {
+		if (ctx.BlockHeight() - height) > k.GetHeartbeatValidityInBlocks(ctx) {
 			k.Logger(ctx).Debug(fmt.Sprintf("excluding validator %s due to stale heartbeat "+
 				"[current height %d, event height %d]", validator, ctx.BlockHeight(), height))
 			continue

--- a/x/tss/keeper/keeperSign_test.go
+++ b/x/tss/keeper/keeperSign_test.go
@@ -87,7 +87,7 @@ func TestStartSign_EnoughActiveValidators(t *testing.T) {
 	}
 
 	height := s.Keeper.GetHeartbeatPeriodInBlocks(s.Ctx) * rand.I64Between(1, 10)
-	height += rand.I64Between(0, s.Keeper.GetHeartbeatPeriodInBlocks(s.Ctx))
+	height += rand.I64Between(0, s.Keeper.GetHeartbeatValidityInBlocks(s.Ctx))
 	s.Ctx = s.Ctx.WithBlockHeight(height)
 
 	for _, val := range snap.Validators {
@@ -183,7 +183,7 @@ func TestStartSign_NoEnoughActiveValidators(t *testing.T) {
 	}
 
 	height := s.Keeper.GetHeartbeatPeriodInBlocks(s.Ctx) * rand.I64Between(1, 10)
-	height += rand.I64Between(0, s.Keeper.GetHeartbeatPeriodInBlocks(s.Ctx))
+	height += rand.I64Between(0, s.Keeper.GetHeartbeatValidityInBlocks(s.Ctx))
 	s.Ctx = s.Ctx.WithBlockHeight(height)
 
 	for _, val := range snap.Validators {

--- a/x/tss/keeper/keeper_test.go
+++ b/x/tss/keeper/keeper_test.go
@@ -153,7 +153,7 @@ func TestAvailableOperator(t *testing.T) {
 		keyIDs := randKeyIDs()
 
 		eventHeight := s.Keeper.GetHeartbeatPeriodInBlocks(s.Ctx) * rand.I64Between(1, 10)
-		height := eventHeight + rand.I64Between(1, s.Keeper.GetHeartbeatPeriodInBlocks(s.Ctx))
+		height := eventHeight + rand.I64Between(1, s.Keeper.GetHeartbeatValidityInBlocks(s.Ctx))
 		repeats := int(rand.I64Between(5, 20))
 
 		for i := 0; i < repeats; i++ {
@@ -166,7 +166,7 @@ func TestAvailableOperator(t *testing.T) {
 
 			// available
 			s.Keeper.SetAvailableOperator(s.Ctx, availableValidator, keyIDs...)
-			s.Ctx = s.Ctx.WithBlockHeight(eventHeight + s.Keeper.GetHeartbeatPeriodInBlocks(s.Ctx))
+			s.Ctx = s.Ctx.WithBlockHeight(eventHeight + s.Keeper.GetHeartbeatValidityInBlocks(s.Ctx))
 			assert.Len(t, s.Keeper.GetAvailableOperators(s.Ctx), i+1)
 			assert.True(t, s.Keeper.IsOperatorAvailable(s.Ctx, availableValidator))
 			assert.Contains(t, s.Keeper.GetAvailableOperators(s.Ctx), availableValidator)
@@ -200,7 +200,7 @@ func TestAvailableOperator(t *testing.T) {
 
 			// available
 			s.Keeper.SetAvailableOperator(s.Ctx, availableValidator, keyIDs...)
-			s.Ctx = s.Ctx.WithBlockHeight(eventHeight + s.Keeper.GetHeartbeatPeriodInBlocks(s.Ctx))
+			s.Ctx = s.Ctx.WithBlockHeight(eventHeight + s.Keeper.GetHeartbeatValidityInBlocks(s.Ctx))
 			assert.Len(t, s.Keeper.GetAvailableOperators(s.Ctx), i+1)
 			assert.True(t, s.Keeper.IsOperatorAvailable(s.Ctx, availableValidator))
 			assert.Contains(t, s.Keeper.GetAvailableOperators(s.Ctx), availableValidator)
@@ -254,7 +254,7 @@ func TestAvailableOperator(t *testing.T) {
 		keyIDs := randKeyIDs()
 
 		eventHeight := s.Keeper.GetHeartbeatPeriodInBlocks(s.Ctx) * rand.I64Between(1, 10)
-		height := eventHeight - (rand.I64Between(1, 100) + s.Keeper.GetHeartbeatPeriodInBlocks(s.Ctx))
+		height := eventHeight - (rand.I64Between(1, 100) + s.Keeper.GetHeartbeatValidityInBlocks(s.Ctx))
 		repeats := int(rand.I64Between(5, 20))
 
 		t.Logf("next event height %d, current height %d", eventHeight, height)
@@ -278,7 +278,7 @@ func TestAvailableOperator(t *testing.T) {
 		keyIDs := randKeyIDs()
 
 		eventHeight := s.Keeper.GetHeartbeatPeriodInBlocks(s.Ctx) * rand.I64Between(1, 10)
-		height := eventHeight - (1 + s.Keeper.GetHeartbeatPeriodInBlocks(s.Ctx))
+		height := eventHeight - (1 + s.Keeper.GetHeartbeatValidityInBlocks(s.Ctx))
 		repeats := int(rand.I64Between(5, 20))
 
 		for i := 0; i < repeats; i++ {

--- a/x/tss/types/expected_keepers.go
+++ b/x/tss/types/expected_keepers.go
@@ -109,6 +109,7 @@ type TSSKeeper interface {
 	SetExternalKeyIDs(ctx sdk.Context, chain nexus.Chain, keyIDs []exported.KeyID)
 	GetExternalMultisigThreshold(ctx sdk.Context) utils.Threshold
 	GetHeartbeatPeriodInBlocks(ctx sdk.Context) int64
+	GetHeartbeatValidityInBlocks(ctx sdk.Context) int64
 	GetOldActiveKeys(ctx sdk.Context, chain nexus.Chain, keyRole exported.KeyRole) ([]exported.Key, error)
 	GetMaxSimultaneousSignShares(ctx sdk.Context) int64
 

--- a/x/tss/types/mock/expected_keepers.go
+++ b/x/tss/types/mock/expected_keepers.go
@@ -1267,6 +1267,9 @@ var _ types.TSSKeeper = &TSSKeeperMock{}
 // 			GetHeartbeatPeriodInBlocksFunc: func(ctx github_com_cosmos_cosmos_sdk_types.Context) int64 {
 // 				panic("mock out the GetHeartbeatPeriodInBlocks method")
 // 			},
+// 			GetHeartbeatValidityInBlocksFunc: func(ctx github_com_cosmos_cosmos_sdk_types.Context) int64 {
+// 				panic("mock out the GetHeartbeatValidityInBlocks method")
+// 			},
 // 			GetInfoForSigFunc: func(ctx github_com_cosmos_cosmos_sdk_types.Context, sigID string) (github_com_axelarnetwork_axelar_core_x_tss_exported.SignInfo, bool) {
 // 				panic("mock out the GetInfoForSig method")
 // 			},
@@ -1438,6 +1441,9 @@ type TSSKeeperMock struct {
 
 	// GetHeartbeatPeriodInBlocksFunc mocks the GetHeartbeatPeriodInBlocks method.
 	GetHeartbeatPeriodInBlocksFunc func(ctx github_com_cosmos_cosmos_sdk_types.Context) int64
+
+	// GetHeartbeatValidityInBlocksFunc mocks the GetHeartbeatValidityInBlocks method.
+	GetHeartbeatValidityInBlocksFunc func(ctx github_com_cosmos_cosmos_sdk_types.Context) int64
 
 	// GetInfoForSigFunc mocks the GetInfoForSig method.
 	GetInfoForSigFunc func(ctx github_com_cosmos_cosmos_sdk_types.Context, sigID string) (github_com_axelarnetwork_axelar_core_x_tss_exported.SignInfo, bool)
@@ -1681,6 +1687,11 @@ type TSSKeeperMock struct {
 		}
 		// GetHeartbeatPeriodInBlocks holds details about calls to the GetHeartbeatPeriodInBlocks method.
 		GetHeartbeatPeriodInBlocks []struct {
+			// Ctx is the ctx argument value.
+			Ctx github_com_cosmos_cosmos_sdk_types.Context
+		}
+		// GetHeartbeatValidityInBlocks holds details about calls to the GetHeartbeatValidityInBlocks method.
+		GetHeartbeatValidityInBlocks []struct {
 			// Ctx is the ctx argument value.
 			Ctx github_com_cosmos_cosmos_sdk_types.Context
 		}
@@ -2014,6 +2025,7 @@ type TSSKeeperMock struct {
 	lockGetExternalMultisigThreshold    sync.RWMutex
 	lockGetGroupRecoveryInfo            sync.RWMutex
 	lockGetHeartbeatPeriodInBlocks      sync.RWMutex
+	lockGetHeartbeatValidityInBlocks    sync.RWMutex
 	lockGetInfoForSig                   sync.RWMutex
 	lockGetKey                          sync.RWMutex
 	lockGetKeyRequirement               sync.RWMutex
@@ -2636,6 +2648,37 @@ func (mock *TSSKeeperMock) GetHeartbeatPeriodInBlocksCalls() []struct {
 	mock.lockGetHeartbeatPeriodInBlocks.RLock()
 	calls = mock.calls.GetHeartbeatPeriodInBlocks
 	mock.lockGetHeartbeatPeriodInBlocks.RUnlock()
+	return calls
+}
+
+// GetHeartbeatValidityInBlocks calls GetHeartbeatValidityInBlocksFunc.
+func (mock *TSSKeeperMock) GetHeartbeatValidityInBlocks(ctx github_com_cosmos_cosmos_sdk_types.Context) int64 {
+	if mock.GetHeartbeatValidityInBlocksFunc == nil {
+		panic("TSSKeeperMock.GetHeartbeatValidityInBlocksFunc: method is nil but TSSKeeper.GetHeartbeatValidityInBlocks was just called")
+	}
+	callInfo := struct {
+		Ctx github_com_cosmos_cosmos_sdk_types.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockGetHeartbeatValidityInBlocks.Lock()
+	mock.calls.GetHeartbeatValidityInBlocks = append(mock.calls.GetHeartbeatValidityInBlocks, callInfo)
+	mock.lockGetHeartbeatValidityInBlocks.Unlock()
+	return mock.GetHeartbeatValidityInBlocksFunc(ctx)
+}
+
+// GetHeartbeatValidityInBlocksCalls gets all the calls that were made to GetHeartbeatValidityInBlocks.
+// Check the length with:
+//     len(mockedTSSKeeper.GetHeartbeatValidityInBlocksCalls())
+func (mock *TSSKeeperMock) GetHeartbeatValidityInBlocksCalls() []struct {
+	Ctx github_com_cosmos_cosmos_sdk_types.Context
+} {
+	var calls []struct {
+		Ctx github_com_cosmos_cosmos_sdk_types.Context
+	}
+	mock.lockGetHeartbeatValidityInBlocks.RLock()
+	calls = mock.calls.GetHeartbeatValidityInBlocks
+	mock.lockGetHeartbeatValidityInBlocks.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
## Description

- consider a heartbeat valid for twice the heartbeat period

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
