### PR TITLE
fix: disallow unbonded chain maintainer registration

### DIFF
--- a/x/nexus/keeper/msg_server.go
+++ b/x/nexus/keeper/msg_server.go
@@ -40,8 +40,13 @@ func (s msgServer) RegisterChainMaintainer(c context.Context, req *types.Registe
 		return nil, fmt.Errorf("account %v is not registered as a validator proxy", req.Sender.String())
 	}
 
-	if s.staking.Validator(ctx, validator) == nil {
+	valAddr := s.staking.Validator(ctx, validator)
+	if valAddr == nil {
 		return nil, fmt.Errorf("account %v is not registered as a validator", validator)
+	}
+
+	if !valAddr.IsBonded() {
+		return nil, fmt.Errorf("validator %v is not bonded", validator)
 	}
 
 	for _, chainStr := range req.Chains {

--- a/x/snapshot/keeper/keeper.go
+++ b/x/snapshot/keeper/keeper.go
@@ -495,10 +495,6 @@ func (k Keeper) CreateSnapshot(
 		participants = append(participants, exported.NewParticipant(validator.GetOperator(), weight))
 	}
 
-	if len(participants) == 0 {
-		return exported.Snapshot{}, fmt.Errorf("no participants selected")
-	}
-
 	bondedWeight := sdk.ZeroUint()
 	k.staking.IterateBondedValidatorsByPower(ctx, func(_ int64, v stakingtypes.ValidatorI) (stop bool) {
 		if v == nil {
@@ -519,6 +515,10 @@ func (k Keeper) CreateSnapshot(
 	participantsWeight := snapshot.GetParticipantsWeight()
 	if participantsWeight.LT(snapshot.CalculateMinPassingWeight(threshold)) {
 		return exported.Snapshot{}, fmt.Errorf("given threshold %s cannot be met (participants weight: %s, bonded weight: %s)", threshold.String(), participantsWeight, bondedWeight)
+	}
+
+	if err := snapshot.ValidateBasic(); err != nil {
+		return exported.Snapshot{}, err
 	}
 
 	return snapshot, nil

--- a/x/snapshot/keeper/keeper.go
+++ b/x/snapshot/keeper/keeper.go
@@ -482,7 +482,7 @@ func (k Keeper) CreateSnapshot(
 	participants := make([]exported.Participant, 0, len(candidates))
 	for _, candidate := range candidates {
 		validator := k.staking.Validator(ctx, candidate)
-		if !filterFunc(validator) {
+		if validator == nil || !filterFunc(validator) {
 			continue
 		}
 
@@ -493,7 +493,10 @@ func (k Keeper) CreateSnapshot(
 			continue
 		}
 		participants = append(participants, exported.NewParticipant(validator.GetOperator(), weight))
+	}
 
+	if len(participants) == 0 {
+		return exported.Snapshot{}, fmt.Errorf("no participants selected")
 	}
 
 	bondedWeight := sdk.ZeroUint()

--- a/x/snapshot/keeper/keeper_test.go
+++ b/x/snapshot/keeper/keeper_test.go
@@ -484,7 +484,7 @@ func TestKeeper(t *testing.T) {
 			Then("no participants are selected", func(t *testing.T) {
 				_, err := k.CreateSnapshot(ctx, candidates, filterFunc, weightFunc, threshold)
 
-				assert.Error(t, err)
+				assert.ErrorContains(t, err, "snapshot cannot have no participant")
 			}).
 			Run(t)
 

--- a/x/snapshot/keeper/keeper_test.go
+++ b/x/snapshot/keeper/keeper_test.go
@@ -474,6 +474,20 @@ func TestKeeper(t *testing.T) {
 				assert.ElementsMatch(t, participantsWithNonZeroWeights, slices.Map(maps.Values(s.Participants),
 					func(p exported.Participant) sdk.ValAddress { return p.Address }))
 			}).Run(t)
+
+		givenKeeper.
+			When2(whenAllParamsAreGood).
+			When("candidate is not a validator", func() {
+				candidates = []sdk.ValAddress{rand.ValAddr()}
+				threshold = utils.ZeroThreshold
+			}).
+			Then("no participants are selected", func(t *testing.T) {
+				_, err := k.CreateSnapshot(ctx, candidates, filterFunc, weightFunc, threshold)
+
+				assert.Error(t, err)
+			}).
+			Run(t)
+
 	})
 }
 


### PR DESCRIPTION
## Description

- Don't allow chain maintainer registration by validators not in the active set
- Check if snapshot candidates are validators

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
