### PR TITLE
fix(multisig): sign sender address for pubkey authentication

### DIFF
--- a/cmd/axelard/cmd/vald/multisig/keygen.go
+++ b/cmd/axelard/cmd/vald/multisig/keygen.go
@@ -25,7 +25,7 @@ func (mgr *Mgr) ProcessKeygenStarted(event *types.KeygenStarted) error {
 		return err
 	}
 
-	payloadHash := sha256.Sum256([]byte(keyUID))
+	payloadHash := sha256.Sum256(mgr.ctx.FromAddress)
 	sig, err := mgr.sign(keyUID, payloadHash[:], partyUID, pubKey)
 	if err != nil {
 		return err

--- a/x/multisig/types/msg_submit_pub_key.go
+++ b/x/multisig/types/msg_submit_pub_key.go
@@ -39,7 +39,7 @@ func (m SubmitPubKeyRequest) ValidateBasic() error {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 	}
 
-	hash := sha256.Sum256([]byte(m.KeyID))
+	hash := sha256.Sum256([]byte(m.Sender))
 	if !m.Signature.Verify(hash[:], m.PubKey) {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "signature does not match the public key")
 	}


### PR DESCRIPTION
## Description

Revert to signing the sender/proxy address (which is unique for each validator) to verify the pub key being submitted. This stops one validator from broadcasting another validator's pubkey instead and cause them to lose rewards.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
