### PR TITLE
fix(multisig): create private method setKey to avoid KeygenCompleted event emitted on key assignment and rotation

### DIFF
--- a/x/multisig/keeper/keygen.go
+++ b/x/multisig/keeper/keygen.go
@@ -49,7 +49,7 @@ func (k Keeper) GetKey(ctx sdk.Context, keyID exported.KeyID) (exported.Key, boo
 
 // SetKey sets the given key
 func (k Keeper) SetKey(ctx sdk.Context, key types.Key) {
-	k.getStore(ctx).Set(keyPrefix.Append(utils.LowerCaseKey(key.ID.String())), &key)
+	k.setKey(ctx, key)
 
 	participants := key.GetParticipants()
 	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(types.NewKeygenCompleted(key.ID)))
@@ -108,6 +108,10 @@ func (k Keeper) createKeygenSession(ctx sdk.Context, id exported.KeyID, snapshot
 	)
 
 	return nil
+}
+
+func (k Keeper) setKey(ctx sdk.Context, key types.Key) {
+	k.getStore(ctx).Set(keyPrefix.Append(utils.LowerCaseKey(key.ID.String())), &key)
 }
 
 func (k Keeper) getKey(ctx sdk.Context, id exported.KeyID) (key types.Key, ok bool) {

--- a/x/multisig/keeper/rotation.go
+++ b/x/multisig/keeper/rotation.go
@@ -59,7 +59,7 @@ func (k Keeper) AssignKey(ctx sdk.Context, chainName nexus.ChainName, keyID expo
 	}
 
 	key.State = types.Assigned
-	k.SetKey(ctx, key)
+	k.setKey(ctx, key)
 	k.setKeyEpoch(ctx, types.NewKeyEpoch(nextRotationCount, chainName, keyID))
 
 	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(types.NewKeyAssigned(chainName, keyID)))
@@ -85,7 +85,7 @@ func (k Keeper) RotateKey(ctx sdk.Context, chainName nexus.ChainName) error {
 	}
 	key.State = types.Active
 
-	k.SetKey(ctx, key)
+	k.setKey(ctx, key)
 	k.setKeyRotationCount(ctx, chainName, nextRotationCount)
 
 	params := k.getParams(ctx)
@@ -135,7 +135,7 @@ func (k Keeper) deactivateKeyAtEpoch(ctx sdk.Context, chainName nexus.ChainName,
 	key := funcs.MustOk(k.getKey(ctx, keyEpoch.GetKeyID()))
 
 	key.State = types.Inactive
-	k.SetKey(ctx, key)
+	k.setKey(ctx, key)
 }
 
 func (k Keeper) getKeyEpoch(ctx sdk.Context, chainName nexus.ChainName, epoch uint64) (keyEpoch types.KeyEpoch, ok bool) {

--- a/x/multisig/keeper/rotation_test.go
+++ b/x/multisig/keeper/rotation_test.go
@@ -80,8 +80,10 @@ func TestKeeper(t *testing.T) {
 							}),
 
 						Then("should succeed", func(t *testing.T) {
+							eventCountBefore := len(ctx.EventManager().Events())
 							err := k.AssignKey(ctx, chainName, keyID1)
 							assert.NoError(t, err)
+							assert.Equal(t, 1, len(ctx.EventManager().Events())-eventCountBefore)
 
 							actual, ok := k.GetNextKeyID(ctx, chainName)
 							assert.True(t, ok)
@@ -108,8 +110,10 @@ func TestKeeper(t *testing.T) {
 					k.AssignKey(ctx, chainName, keyID1)
 				}).
 					Then("should succeed", func(t *testing.T) {
+						eventCountBefore := len(ctx.EventManager().Events())
 						err := k.RotateKey(ctx, chainName)
 						assert.NoError(t, err)
+						assert.Equal(t, 1, len(ctx.EventManager().Events())-eventCountBefore)
 
 						_, ok := k.GetNextKeyID(ctx, chainName)
 						assert.False(t, ok)


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
