### PR TITLE
 fix!: correctly unmarshal ProtoMarshaler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.45.4
 	github.com/cosmos/ibc-go/v2 v2.2.0
 	github.com/ethereum/go-ethereum v1.10.17
+	github.com/go-errors/errors v1.4.2
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -399,6 +399,8 @@ github.com/gin-gonic/gin v1.7.0/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjX
 github.com/glycerine/go-unsnap-stream v0.0.0-20180323001048-9f0cb55181dd/go.mod h1:/20jfyN9Y5QPEAprSgKAUr+glWDY39ZiUEAYOEv5dsE=
 github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31/go.mod h1:Ogl1Tioa0aV7gstGFO7KhffUsb9M4ydbEbbxpcEDc24=
 github.com/go-chi/chi/v5 v5.0.0/go.mod h1:BBug9lr0cqtdAhsu6R4AAdvufI0/XBzAQSsUqJpoZOs=
+github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
+github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/utils/abci.go
+++ b/utils/abci.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/go-errors/errors"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 )
@@ -22,6 +23,7 @@ func RunEndBlocker(c sdk.Context, l Logger, endBlocker func(sdk.Context) ([]abci
 	defer func() {
 		if r := recover(); r != nil {
 			l.Logger(ctx).Error(fmt.Sprintf("panicked running end blocker due to error %v", r))
+			l.Logger(ctx).Debug(errors.Wrap(r, 1).ErrorStack())
 		}
 	}()
 

--- a/utils/store.go
+++ b/utils/store.go
@@ -55,6 +55,8 @@ func (store KVStore) SetRaw(key Key, value []byte) {
 
 // Get unmarshals the raw bytes stored under the given key into the value object. Returns true if the key exists.
 func (store KVStore) Get(key Key, value codec.ProtoMarshaler) bool {
+	value.Reset()
+
 	bz := store.KVStore.Get(key.AsKey())
 	if bz == nil {
 		return false
@@ -98,6 +100,7 @@ type iterator struct {
 
 // UnmarshalValue returns the value marshalled into the given type
 func (i iterator) UnmarshalValue(value codec.ProtoMarshaler) {
+	value.Reset()
 	i.cdc.MustUnmarshalLengthPrefixed(i.Value(), value)
 }
 

--- a/utils/store_test.go
+++ b/utils/store_test.go
@@ -4,9 +4,14 @@ import (
 	"strings"
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/tendermint/libs/log"
+	abci "github.com/tendermint/tendermint/proto/tendermint/types"
 
+	"github.com/axelarnetwork/axelar-core/app/params"
 	"github.com/axelarnetwork/axelar-core/testutils"
+	"github.com/axelarnetwork/axelar-core/testutils/fake"
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
 )
 
@@ -46,4 +51,53 @@ func TestKey(t *testing.T) {
 		assert.True(t, compKey1.Equals(compKey2))
 	}).Repeat(repeats))
 
+}
+
+func TestKVStore_Get(t *testing.T) {
+	encConf := params.MakeEncodingConfig()
+	ctx := sdk.NewContext(fake.NewMultiStore(), abci.Header{}, false, log.TestingLogger())
+	store := NewNormalizedStore(ctx.KVStore(sdk.NewKVStoreKey("test")), encConf.Codec)
+
+	filledState := QueueState{
+		Items: map[string]QueueState_Item{"state": {Key: []byte("stateKey1"), Value: []byte("stateValue1")}},
+	}
+	emptyState := QueueState{}
+
+	store.Set(KeyFromStr("key"), &emptyState)
+
+	assert.True(t, store.Get(KeyFromStr("key"), &filledState))
+	assert.Equal(t, emptyState, filledState)
+}
+
+func TestKVStore_Iterator(t *testing.T) {
+	encConf := params.MakeEncodingConfig()
+	ctx := sdk.NewContext(fake.NewMultiStore(), abci.Header{}, false, log.TestingLogger())
+	store := NewNormalizedStore(ctx.KVStore(sdk.NewKVStoreKey("test")), encConf.Codec)
+
+	filledState := QueueState{
+		Items: map[string]QueueState_Item{"state": {Key: []byte("stateKey1"), Value: []byte("stateValue1")}},
+	}
+	emptyState := QueueState{}
+
+	storeKey := KeyFromStr("prefix_key")
+	store.Set(storeKey, &emptyState)
+
+	iter := store.Iterator(KeyFromStr("prefix"))
+
+	assert.True(t, iter.Valid())
+	iter.UnmarshalValue(&filledState)
+
+	assert.Equal(t, emptyState, filledState)
+}
+
+func Test_Reset(t *testing.T) {
+	var state QueueState
+	assert.NotPanics(t, func() {
+		(&state).Reset()
+	})
+
+	assert.NotPanics(t, func() {
+		state = QueueState{}
+		(&state).Reset()
+	})
 }

--- a/x/nexus/keeper/chain.go
+++ b/x/nexus/keeper/chain.go
@@ -84,8 +84,11 @@ func (k Keeper) setFeeInfo(ctx sdk.Context, chain exported.Chain, asset string, 
 
 // GetFeeInfo retrieves the fee info for an asset on a chain, and returns zero fees if it doesn't exist
 func (k Keeper) GetFeeInfo(ctx sdk.Context, chain exported.Chain, asset string) (feeInfo exported.FeeInfo, found bool) {
-	feeInfo = exported.ZeroFeeInfo(chain.Name, asset)
-	return feeInfo, k.getStore(ctx).Get(assetFeePrefix.Append(utils.LowerCaseKey(chain.Name.String())).Append(utils.KeyFromStr(asset)), &feeInfo)
+	found = k.getStore(ctx).Get(assetFeePrefix.Append(utils.LowerCaseKey(chain.Name.String())).Append(utils.KeyFromStr(asset)), &feeInfo)
+	if !found {
+		feeInfo = exported.ZeroFeeInfo(chain.Name, asset)
+	}
+	return feeInfo, found
 }
 
 // RegisterFee registers the fee info for an asset on a chain


### PR DESCRIPTION
The ProtoMarshaler object given to the unmarshaler must be reset to zero values before unmarshaling, otherwise in some edge cases the result of the unmarshaling is not equivalent with the marshaled protobuf.