### PR TITLE
fix(vote)!: correctly unmarshal poll metadata

### DIFF
--- a/x/evm/types/codec.go
+++ b/x/evm/types/codec.go
@@ -49,6 +49,7 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 		&SigMetadata{},
 		&Event{},
 		&VoteEvents{},
+		&PollMetadata{},
 	)
 }
 

--- a/x/vote/exported/types.go
+++ b/x/vote/exported/types.go
@@ -19,7 +19,15 @@ var _ codectypes.UnpackInterfacesMessage = PollMetadata{}
 // UnpackInterfaces implements UnpackInterfacesMessage
 func (m PollMetadata) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
 	var data codec.ProtoMarshaler
-	return unpacker.UnpackAny(m.Result, &data)
+	if err := unpacker.UnpackAny(m.Result, &data); err != nil {
+		return err
+	}
+
+	if err := unpacker.UnpackAny(m.ModuleMetadata, &data); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // VoteHandler defines a struct that can handle the poll result

--- a/x/vote/keeper/poll_test.go
+++ b/x/vote/keeper/poll_test.go
@@ -250,7 +250,7 @@ func TestPoll(t *testing.T) {
 
 		givenPollBuilder.
 			When2(whenPollIsInitialized).
-			Then("should not be able to vote for a compelted poll outside the grace period", func(t *testing.T) {
+			Then("should not be able to vote for a completed poll outside the grace period", func(t *testing.T) {
 				for _, voter := range voters[0:3] {
 					poll.Vote(voter, ctx.BlockHeight(), &evmtypes.VoteEvents{})
 				}


### PR DESCRIPTION
The poll struct has multiple `Any` fields, but only the result field was unpacked in `UnpackInterfaces`. In addition, the concrete metadata type in the evm module needed to be registered to the `ProtoMarshaler` interface