### PR TITLE
fix: handle mpc sessions in the end blocker of previous block on expiry

### DIFF
--- a/x/multisig/abci.go
+++ b/x/multisig/abci.go
@@ -23,7 +23,9 @@ func EndBlocker(ctx sdk.Context, _ abci.RequestEndBlock, k types.Keeper, rewarde
 }
 
 func handleKeygens(ctx sdk.Context, k types.Keeper, rewarder types.Rewarder) {
-	for _, keygen := range k.GetKeygenSessionsByExpiry(ctx, ctx.BlockHeight()) {
+	// we handle sessions that'll expire on the next block,
+	// to avoid waiting for an additional block
+	for _, keygen := range k.GetKeygenSessionsByExpiry(ctx, ctx.BlockHeight()+1) {
 		k.DeleteKeygenSession(ctx, keygen.GetKeyID())
 
 		pool := rewarder.GetPool(ctx, types.ModuleName)
@@ -46,8 +48,9 @@ func handleKeygens(ctx sdk.Context, k types.Keeper, rewarder types.Rewarder) {
 }
 
 func handleSignings(ctx sdk.Context, k types.Keeper, rewarder types.Rewarder) {
-	for _, signing := range k.GetSigningSessionsByExpiry(ctx, ctx.BlockHeight()) {
-
+	// we handle sessions that'll expire on the next block,
+	// to avoid waiting for an additional block
+	for _, signing := range k.GetSigningSessionsByExpiry(ctx, ctx.BlockHeight()+1) {
 		_ = utils.RunCached(ctx, k, func(cachedCtx sdk.Context) ([]abci.ValidatorUpdate, error) {
 			k.DeleteSigningSession(cachedCtx, signing.GetID())
 			module := signing.GetModule()

--- a/x/multisig/abci_test.go
+++ b/x/multisig/abci_test.go
@@ -53,7 +53,7 @@ func TestEndBlocker(t *testing.T) {
 		givenKeepersAndCtx.
 			When("a pending keygen session expiry equal to the block height", func() {
 				k.GetKeygenSessionsByExpiryFunc = func(_ sdk.Context, expiry int64) []types.KeygenSession {
-					if expiry != ctx.BlockHeight() {
+					if expiry != ctx.BlockHeight()+1 {
 						return nil
 					}
 
@@ -89,7 +89,7 @@ func TestEndBlocker(t *testing.T) {
 					State: exported.Completed,
 				}
 				k.GetKeygenSessionsByExpiryFunc = func(_ sdk.Context, expiry int64) []types.KeygenSession {
-					if expiry != ctx.BlockHeight() {
+					if expiry != ctx.BlockHeight()+1 {
 						return nil
 					}
 
@@ -122,7 +122,7 @@ func TestEndBlocker(t *testing.T) {
 					State: exported.Completed,
 				}
 				k.GetKeygenSessionsByExpiryFunc = func(_ sdk.Context, expiry int64) []types.KeygenSession {
-					if expiry != ctx.BlockHeight() {
+					if expiry != ctx.BlockHeight()+1 {
 						return nil
 					}
 
@@ -174,7 +174,7 @@ func TestEndBlocker(t *testing.T) {
 			Branch(
 				When("a pending signing session expiry equal to the block height", func() {
 					k.GetSigningSessionsByExpiryFunc = func(_ sdk.Context, expiry int64) []types.SigningSession {
-						if expiry != ctx.BlockHeight() {
+						if expiry != ctx.BlockHeight()+1 {
 							return nil
 						}
 
@@ -212,7 +212,7 @@ func TestEndBlocker(t *testing.T) {
 				When("a completed signing session expiry equal to the block height", func() {
 					signingSession = newSigningSession(module)
 					k.GetSigningSessionsByExpiryFunc = func(_ sdk.Context, expiry int64) []types.SigningSession {
-						if expiry != ctx.BlockHeight() {
+						if expiry != ctx.BlockHeight()+1 {
 							return nil
 						}
 
@@ -239,7 +239,7 @@ func TestEndBlocker(t *testing.T) {
 					missingCount = uint64(rand.I64Between(1, 5))
 					signingSession = newSigningSessionWithMissingParticipants(module, missingCount)
 					k.GetSigningSessionsByExpiryFunc = func(_ sdk.Context, expiry int64) []types.SigningSession {
-						if expiry != ctx.BlockHeight() {
+						if expiry != ctx.BlockHeight()+1 {
 							return nil
 						}
 
@@ -266,7 +266,7 @@ func TestEndBlocker(t *testing.T) {
 
 				When("multiple completed signing sessions are triggered", func() {
 					k.GetSigningSessionsByExpiryFunc = func(_ sdk.Context, expiry int64) []types.SigningSession {
-						if expiry != ctx.BlockHeight() {
+						if expiry != ctx.BlockHeight()+1 {
 							return nil
 						}
 						return []types.SigningSession{
@@ -295,7 +295,7 @@ func TestEndBlocker(t *testing.T) {
 
 				When("multiple completed signing sessions are triggered", func() {
 					k.GetSigningSessionsByExpiryFunc = func(_ sdk.Context, expiry int64) []types.SigningSession {
-						if expiry != ctx.BlockHeight() {
+						if expiry != ctx.BlockHeight()+1 {
 							return nil
 						}
 						return []types.SigningSession{
@@ -320,7 +320,7 @@ func TestEndBlocker(t *testing.T) {
 						_, err := multisig.EndBlocker(ctx, abci.RequestEndBlock{}, k, rewarder)
 						assert.NoError(t, err)
 						assert.False(t, ctx.MultiStore().GetKVStore(storeKey).Has(rolledBackKey))
-						assert.Equal(t, len(k.DeleteSigningSessionCalls()), len(k.GetSigningSessionsByExpiry(ctx, ctx.BlockHeight())))
+						assert.Equal(t, len(k.DeleteSigningSessionCalls()), len(k.GetSigningSessionsByExpiry(ctx, ctx.BlockHeight()+1)))
 					}),
 			).
 			Run(t, 20)

--- a/x/multisig/keeper/msg_server_test.go
+++ b/x/multisig/keeper/msg_server_test.go
@@ -70,7 +70,7 @@ func TestMsgServer(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, k.GetKeygenSessionsByExpiry(ctx, expiresAt), 1)
-		assert.Len(t, k.GetKeygenSessionsByExpiry(ctx, ctx.BlockHeight()+types.DefaultParams().KeygenGracePeriod+1), 0)
+		assert.Len(t, k.GetKeygenSessionsByExpiry(ctx, ctx.BlockHeight()+types.DefaultParams().KeygenGracePeriod), 0)
 	})
 	requestIsMade := When("a request is made", func() {
 		sk := funcs.Must(btcec.NewPrivateKey())

--- a/x/multisig/keeper/msg_server_test.go
+++ b/x/multisig/keeper/msg_server_test.go
@@ -70,7 +70,7 @@ func TestMsgServer(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, k.GetKeygenSessionsByExpiry(ctx, expiresAt), 1)
-		assert.Len(t, k.GetKeygenSessionsByExpiry(ctx, ctx.BlockHeight()+types.DefaultParams().KeygenGracePeriod), 0)
+		assert.Len(t, k.GetKeygenSessionsByExpiry(ctx, ctx.BlockHeight()+types.DefaultParams().KeygenGracePeriod+1), 0)
 	})
 	requestIsMade := When("a request is made", func() {
 		sk := funcs.Must(btcec.NewPrivateKey())
@@ -218,7 +218,7 @@ func TestMsgServer(t *testing.T) {
 					Snapshot: snapshot.NewSnapshot(ctx.BlockTime(), ctx.BlockHeight(), participants, sdk.NewUint(uint64(participantCount))),
 					PubKeys: slices.ToMap(publicKeys, func(pk exported.PublicKey) string {
 						result := validators[pubKeyIndex]
-						pubKeyIndex += 1
+						pubKeyIndex++
 
 						return result.String()
 					}),
@@ -277,7 +277,7 @@ func TestMsgServer(t *testing.T) {
 
 					When("signing session exists", func() {
 						payloadHash = rand.Bytes(exported.HashLength)
-						k.Sign(ctx, keyID, payloadHash, module)
+						funcs.MustNoErr(k.Sign(ctx, keyID, payloadHash, module))
 
 						events := ctx.EventManager().Events().ToABCIEvents()
 						sigID = funcs.Must(sdk.ParseTypedEvent(events[len(events)-1])).(*types.SigningStarted).SigID

--- a/x/multisig/types/keygen.go
+++ b/x/multisig/types/keygen.go
@@ -31,17 +31,6 @@ func NewKeygenSession(id exported.KeyID, keygenThreshold utils.Threshold, signin
 
 // ValidateBasic returns an error if the given keygen session is invalid; nil otherwise
 func (m KeygenSession) ValidateBasic() error {
-	var keyErr error
-	if m.State == exported.Completed {
-		keyErr = m.Key.ValidateBasic()
-	} else {
-		keyErr = validateBasicPendingKey(m.Key)
-	}
-
-	if keyErr != nil {
-		return keyErr
-	}
-
 	if m.KeygenThreshold.LT(m.Key.SigningThreshold) {
 		return fmt.Errorf("keygen threshold must be >=signing threshold")
 	}
@@ -50,12 +39,33 @@ func (m KeygenSession) ValidateBasic() error {
 		return fmt.Errorf("expires at must be >0")
 	}
 
-	if m.State == exported.Completed && m.CompletedAt == 0 {
-		return fmt.Errorf("completed keygen session must have completed at set")
+	if m.CompletedAt >= m.ExpiresAt {
+		return fmt.Errorf("completed at must be < expires at")
 	}
 
-	if m.State != exported.Completed && m.CompletedAt != 0 {
-		return fmt.Errorf("pending keygen session must not have completed at set")
+	if m.GracePeriod < 0 {
+		return fmt.Errorf("grace period must be >=0")
+	}
+
+	switch m.GetState() {
+	case exported.Pending:
+		if m.CompletedAt != 0 {
+			return fmt.Errorf("pending keygen session must not have completed at set")
+		}
+
+		if err := validateBasicPendingKey(m.Key); err != nil {
+			return err
+		}
+	case exported.Completed:
+		if m.CompletedAt <= 0 {
+			return fmt.Errorf("completed keygen session must have completed at set")
+		}
+
+		if err := m.Key.ValidateBasic(); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unexpected state %s", m.GetState())
 	}
 
 	return nil

--- a/x/multisig/types/signing.go
+++ b/x/multisig/types/signing.go
@@ -57,6 +57,14 @@ func (m SigningSession) ValidateBasic() error {
 		return fmt.Errorf("expires at must be >0")
 	}
 
+	if m.CompletedAt >= m.ExpiresAt {
+		return fmt.Errorf("completed at must be < expires at")
+	}
+
+	if m.GracePeriod < 0 {
+		return fmt.Errorf("grace period must be >=0")
+	}
+
 	if err := utils.ValidateString(m.Module); err != nil {
 		return err
 	}
@@ -67,14 +75,13 @@ func (m SigningSession) ValidateBasic() error {
 			return fmt.Errorf("pending signing session must not have completed at set")
 		}
 	case exported.Completed:
-		if m.CompletedAt == 0 {
+		if m.CompletedAt <= 0 {
 			return fmt.Errorf("completed signing session must have completed at set")
 		}
 
 		if m.GetParticipantsWeight().LT(m.Key.GetMinPassingWeight()) {
 			return fmt.Errorf("completed signing session must have completed multi signature")
 		}
-
 	default:
 		return fmt.Errorf("unexpected state %s", m.GetState())
 	}

--- a/x/multisig/types/signing_test.go
+++ b/x/multisig/types/signing_test.go
@@ -312,7 +312,7 @@ func TestSigningSession(t *testing.T) {
 		givenNewSignSession.
 			When2(whenSignaturesAreCreated).
 			When("is expired", func() {
-				blockHeight = signingSession.ExpiresAt + 1
+				blockHeight = signingSession.ExpiresAt
 			}).
 			When2(whenParticipantIsValid).
 			Then("should return error", func(t *testing.T) {
@@ -361,7 +361,6 @@ func TestSigningSession(t *testing.T) {
 			When2(whenIsNotExpired).
 			When2(whenParticipantIsValid).
 			When("is completed", func() {
-				blockHeight -= 1
 				funcs.MustNoErr(signingSession.AddSig(blockHeight, validators[2], signatures[validators[2].String()]))
 				funcs.MustNoErr(signingSession.AddSig(blockHeight, validators[1], signatures[validators[1].String()]))
 			}).

--- a/x/multisig/types/types_test.go
+++ b/x/multisig/types/types_test.go
@@ -136,7 +136,7 @@ func TestKeygenSession(t *testing.T) {
 				participant = keygenSession.GetKey().Snapshot.GetParticipantAddresses()[0]
 				pubKey = typestestutils.PublicKey()
 
-				keygenSession.AddKey(blockHeight, participant, pubKey)
+				funcs.MustNoErr(keygenSession.AddKey(blockHeight, participant, pubKey))
 			}).
 			Then("should return error", func(t *testing.T) {
 				err := keygenSession.AddKey(blockHeight, participant, pubKey)
@@ -150,7 +150,7 @@ func TestKeygenSession(t *testing.T) {
 				participant = keygenSession.GetKey().Snapshot.GetParticipantAddresses()[0]
 				pubKey = typestestutils.PublicKey()
 
-				keygenSession.AddKey(blockHeight, participant, pubKey)
+				funcs.MustNoErr(keygenSession.AddKey(blockHeight, participant, pubKey))
 				participant = keygenSession.GetKey().Snapshot.GetParticipantAddresses()[1]
 			}).
 			Then("should return error", func(t *testing.T) {
@@ -323,7 +323,6 @@ func TestKey(t *testing.T) {
 }
 
 func TestSignature_Verify(t *testing.T) {
-
 	var (
 		sk      *btcec.PrivateKey
 		payload []byte
@@ -334,7 +333,6 @@ func TestSignature_Verify(t *testing.T) {
 	}).
 		Given("a payload", func() {
 			payload = rand.Bytes(30)
-
 		}).
 		Branch(
 			When("a signature is created", func() {
@@ -353,5 +351,4 @@ func TestSignature_Verify(t *testing.T) {
 					assert.False(t, sig.Verify(payload, sk.PubKey().SerializeCompressed()))
 				}),
 		).Run(t)
-
 }


### PR DESCRIPTION
## Description

Currently, expiry height is a block where no key/signatures can be submitted. But since we process the keygen/signing in the end blocker, this adds an extra block for completion that doesn't get counted in the grace period. Specifically, signing with grace period of 1 will take 2 blocks after threshold is achieved for handling by the end blocker. Instead, handle sessions expiring in the next block.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
