### PR TITLE
fix: migrate signing threshold correctly

### DIFF
--- a/x/tss/keeper/migrate.go
+++ b/x/tss/keeper/migrate.go
@@ -136,7 +136,7 @@ func migrateKeyType(ctx sdk.Context, tss Keeper, snapshotter types.Snapshotter, 
 		ID:               multisigExported.KeyID(key.ID),
 		Snapshot:         s,
 		PubKeys:          pubkeys,
-		SigningThreshold: utils.NewThreshold(keyInfo.TargetNum, keyInfo.Count()),
+		SigningThreshold: utils.NewThreshold(keyInfo.TargetNum, int64(len(s.Participants))),
 	}
 
 	if err := newKey.ValidateBasic(); err != nil {


### PR DESCRIPTION
The denominator of the signing threshold was using the wrong source, making the threshold always ==1. With this fix the pre-migration threshold is preserved.