### PR TITLE
fix(evm): check burner address in confirm deposit

### DIFF
--- a/x/evm/keeper/chainKeeper.go
+++ b/x/evm/keeper/chainKeeper.go
@@ -228,19 +228,23 @@ func (k chainKeeper) getTokenAddress(ctx sdk.Context, details types.TokenDetails
 	return tokenAddr, nil
 }
 
-// GetBurnerAddressAndSalt calculates a burner address and the corresponding salt for the given token address, recipient and axelar gateway address
-func (k chainKeeper) GetBurnerAddressAndSalt(ctx sdk.Context, token types.ERC20Token, recipient string, gatewayAddr types.Address) (types.Address, types.Hash, error) {
+// GenerateSalt calculates a salt based on network params and recipient address to use for burner address generation
+func (k chainKeeper) GenerateSalt(ctx sdk.Context, recipient string) types.Hash {
 	nonce := utils.GetNonce(ctx.HeaderHash(), ctx.BlockGasMeter())
 	bz := []byte(recipient)
 	bz = append(bz, nonce[:]...)
 	salt := types.Hash(common.BytesToHash(crypto.Keccak256Hash(bz).Bytes()))
+	return salt
+}
 
+// GetBurnerAddress calculates a burner address for the given token address, salt, and axelar gateway address
+func (k chainKeeper) GetBurnerAddress(ctx sdk.Context, token types.ERC20Token, salt types.Hash, gatewayAddr types.Address) (types.Address, error) {
 	var tokenBurnerCodeHash types.Hash
 	if token.IsExternal() {
 		// always use the latest burner byte code for external token
 		burnerCode, ok := k.GetBurnerByteCode(ctx)
 		if !ok {
-			return types.Address{}, types.Hash{}, fmt.Errorf("burner code not found for chain %s", k.chainLowerKey)
+			return types.Address{}, fmt.Errorf("burner code not found for chain %s", k.chainLowerKey)
 		}
 		tokenBurnerCodeHash = types.Hash(crypto.Keccak256Hash(burnerCode))
 	} else {
@@ -252,28 +256,28 @@ func (k chainKeeper) GetBurnerAddressAndSalt(ctx sdk.Context, token types.ERC20T
 	case types.BurnerCodeHashV1:
 		addressType, err := abi.NewType("address", "address", nil)
 		if err != nil {
-			return types.Address{}, types.Hash{}, err
+			return types.Address{}, err
 		}
 
 		bytes32Type, err := abi.NewType("bytes32", "bytes32", nil)
 		if err != nil {
-			return types.Address{}, types.Hash{}, err
+			return types.Address{}, err
 		}
 
 		arguments := abi.Arguments{{Type: addressType}, {Type: bytes32Type}}
 		params, err := arguments.Pack(token.GetAddress(), salt)
 		if err != nil {
-			return types.Address{}, types.Hash{}, err
+			return types.Address{}, err
 		}
 
 		initCodeHash = types.Hash(crypto.Keccak256Hash(append(token.GetBurnerCode(), params...)))
 	case types.BurnerCodeHashV2, types.BurnerCodeHashV3, types.BurnerCodeHashV4, types.BurnerCodeHashV5:
 		initCodeHash = tokenBurnerCodeHash
 	default:
-		return types.Address{}, types.Hash{}, fmt.Errorf("unsupported burner code with hash %s for chain %s", tokenBurnerCodeHash.Hex(), k.chainLowerKey)
+		return types.Address{}, fmt.Errorf("unsupported burner code with hash %s for chain %s", tokenBurnerCodeHash.Hex(), k.chainLowerKey)
 	}
 
-	return types.Address(crypto.CreateAddress2(common.Address(gatewayAddr), salt, initCodeHash.Bytes())), salt, nil
+	return types.Address(crypto.CreateAddress2(common.Address(gatewayAddr), salt, initCodeHash.Bytes())), nil
 }
 
 // GetBurnerByteCode returns the bytecode for the burner contract

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -188,7 +188,7 @@ func TestGetTokenAddress(t *testing.T) {
 	assert.Equal(t, expected, token.GetAddress().Hex())
 }
 
-func TestGetBurnerAddressAndSalt(t *testing.T) {
+func TestGetBurnerAddress(t *testing.T) {
 	encCfg := app.MakeEncodingConfig()
 	ctx := sdk.NewContext(fake.NewMultiStore(), tmproto.Header{Height: rand.PosI64()}, false, log.TestingLogger())
 	ctx = ctx.WithHeaderHash(common.Hex2Bytes("CA36CA3751A5B6E8B8ED4072BFA5E6E5BAC8B6E06E02DE029E1BD86AB141F2F1"))
@@ -216,7 +216,8 @@ func TestGetBurnerAddressAndSalt(t *testing.T) {
 			IsExternal:   false,
 			BurnerCode:   bzBurnable,
 		})
-		actualburnerAddr, actualSalt, err := chainKeeper.GetBurnerAddressAndSalt(ctx, token, recipient, axelarGateway)
+		actualSalt := chainKeeper.GenerateSalt(ctx, recipient)
+		actualburnerAddr, err := chainKeeper.GetBurnerAddress(ctx, token, actualSalt, axelarGateway)
 
 		assert.NoError(t, err)
 		assert.Equal(t, expectedBurnerAddr, actualburnerAddr.Hex())
@@ -237,7 +238,8 @@ func TestGetBurnerAddressAndSalt(t *testing.T) {
 			IsExternal:   true,
 			BurnerCode:   nil,
 		})
-		actualburnerAddr, actualSalt, err := chainKeeper.GetBurnerAddressAndSalt(ctx, token, recipient, axelarGateway)
+		actualSalt := chainKeeper.GenerateSalt(ctx, recipient)
+		actualburnerAddr, err := chainKeeper.GetBurnerAddress(ctx, token, actualSalt, axelarGateway)
 
 		assert.NoError(t, err)
 		assert.Equal(t, expectedBurnerAddr, actualburnerAddr.Hex())

--- a/x/evm/types/expected_keepers.go
+++ b/x/evm/types/expected_keepers.go
@@ -48,7 +48,8 @@ type ChainKeeper interface {
 	GetGatewayAddress(ctx sdk.Context) (Address, bool)
 	GetDeposit(ctx sdk.Context, txID Hash, burnerAddr Address) (ERC20Deposit, DepositStatus, bool)
 	GetBurnerInfo(ctx sdk.Context, address Address) *BurnerInfo
-	GetBurnerAddressAndSalt(ctx sdk.Context, token ERC20Token, recipient string, gatewayAddr Address) (Address, Hash, error)
+	GenerateSalt(ctx sdk.Context, recipient string) Hash
+	GetBurnerAddress(ctx sdk.Context, token ERC20Token, salt Hash, gatewayAddr Address) (Address, error)
 	SetBurnerInfo(ctx sdk.Context, burnerInfo BurnerInfo)
 	DeleteDeposit(ctx sdk.Context, deposit ERC20Deposit)
 	SetDeposit(ctx sdk.Context, deposit ERC20Deposit, state DepositStatus)

--- a/x/evm/types/mock/expected_keepers.go
+++ b/x/evm/types/mock/expected_keepers.go
@@ -1886,11 +1886,14 @@ var _ evmtypes.ChainKeeper = &ChainKeeperMock{}
 // 			EnqueueCommandFunc: func(ctx github_com_cosmos_cosmos_sdk_types.Context, cmd evmtypes.Command) error {
 // 				panic("mock out the EnqueueCommand method")
 // 			},
+// 			GenerateSaltFunc: func(ctx github_com_cosmos_cosmos_sdk_types.Context, recipient string) evmtypes.Hash {
+// 				panic("mock out the GenerateSalt method")
+// 			},
 // 			GetBatchByIDFunc: func(ctx github_com_cosmos_cosmos_sdk_types.Context, id []byte) evmtypes.CommandBatch {
 // 				panic("mock out the GetBatchByID method")
 // 			},
-// 			GetBurnerAddressAndSaltFunc: func(ctx github_com_cosmos_cosmos_sdk_types.Context, token evmtypes.ERC20Token, recipient string, gatewayAddr evmtypes.Address) (evmtypes.Address, evmtypes.Hash, error) {
-// 				panic("mock out the GetBurnerAddressAndSalt method")
+// 			GetBurnerAddressFunc: func(ctx github_com_cosmos_cosmos_sdk_types.Context, token evmtypes.ERC20Token, salt evmtypes.Hash, gatewayAddr evmtypes.Address) (evmtypes.Address, error) {
+// 				panic("mock out the GetBurnerAddress method")
 // 			},
 // 			GetBurnerByteCodeFunc: func(ctx github_com_cosmos_cosmos_sdk_types.Context) ([]byte, bool) {
 // 				panic("mock out the GetBurnerByteCode method")
@@ -2013,11 +2016,14 @@ type ChainKeeperMock struct {
 	// EnqueueCommandFunc mocks the EnqueueCommand method.
 	EnqueueCommandFunc func(ctx github_com_cosmos_cosmos_sdk_types.Context, cmd evmtypes.Command) error
 
+	// GenerateSaltFunc mocks the GenerateSalt method.
+	GenerateSaltFunc func(ctx github_com_cosmos_cosmos_sdk_types.Context, recipient string) evmtypes.Hash
+
 	// GetBatchByIDFunc mocks the GetBatchByID method.
 	GetBatchByIDFunc func(ctx github_com_cosmos_cosmos_sdk_types.Context, id []byte) evmtypes.CommandBatch
 
-	// GetBurnerAddressAndSaltFunc mocks the GetBurnerAddressAndSalt method.
-	GetBurnerAddressAndSaltFunc func(ctx github_com_cosmos_cosmos_sdk_types.Context, token evmtypes.ERC20Token, recipient string, gatewayAddr evmtypes.Address) (evmtypes.Address, evmtypes.Hash, error)
+	// GetBurnerAddressFunc mocks the GetBurnerAddress method.
+	GetBurnerAddressFunc func(ctx github_com_cosmos_cosmos_sdk_types.Context, token evmtypes.ERC20Token, salt evmtypes.Hash, gatewayAddr evmtypes.Address) (evmtypes.Address, error)
 
 	// GetBurnerByteCodeFunc mocks the GetBurnerByteCode method.
 	GetBurnerByteCodeFunc func(ctx github_com_cosmos_cosmos_sdk_types.Context) ([]byte, bool)
@@ -2155,6 +2161,13 @@ type ChainKeeperMock struct {
 			// Cmd is the cmd argument value.
 			Cmd evmtypes.Command
 		}
+		// GenerateSalt holds details about calls to the GenerateSalt method.
+		GenerateSalt []struct {
+			// Ctx is the ctx argument value.
+			Ctx github_com_cosmos_cosmos_sdk_types.Context
+			// Recipient is the recipient argument value.
+			Recipient string
+		}
 		// GetBatchByID holds details about calls to the GetBatchByID method.
 		GetBatchByID []struct {
 			// Ctx is the ctx argument value.
@@ -2162,14 +2175,14 @@ type ChainKeeperMock struct {
 			// ID is the id argument value.
 			ID []byte
 		}
-		// GetBurnerAddressAndSalt holds details about calls to the GetBurnerAddressAndSalt method.
-		GetBurnerAddressAndSalt []struct {
+		// GetBurnerAddress holds details about calls to the GetBurnerAddress method.
+		GetBurnerAddress []struct {
 			// Ctx is the ctx argument value.
 			Ctx github_com_cosmos_cosmos_sdk_types.Context
 			// Token is the token argument value.
 			Token evmtypes.ERC20Token
-			// Recipient is the recipient argument value.
-			Recipient string
+			// Salt is the salt argument value.
+			Salt evmtypes.Hash
 			// GatewayAddr is the gatewayAddr argument value.
 			GatewayAddr evmtypes.Address
 		}
@@ -2378,8 +2391,9 @@ type ChainKeeperMock struct {
 	lockDeleteDeposit                 sync.RWMutex
 	lockDeleteUnsignedCommandBatchID  sync.RWMutex
 	lockEnqueueCommand                sync.RWMutex
+	lockGenerateSalt                  sync.RWMutex
 	lockGetBatchByID                  sync.RWMutex
-	lockGetBurnerAddressAndSalt       sync.RWMutex
+	lockGetBurnerAddress              sync.RWMutex
 	lockGetBurnerByteCode             sync.RWMutex
 	lockGetBurnerInfo                 sync.RWMutex
 	lockGetChainID                    sync.RWMutex
@@ -2590,6 +2604,41 @@ func (mock *ChainKeeperMock) EnqueueCommandCalls() []struct {
 	return calls
 }
 
+// GenerateSalt calls GenerateSaltFunc.
+func (mock *ChainKeeperMock) GenerateSalt(ctx github_com_cosmos_cosmos_sdk_types.Context, recipient string) evmtypes.Hash {
+	if mock.GenerateSaltFunc == nil {
+		panic("ChainKeeperMock.GenerateSaltFunc: method is nil but ChainKeeper.GenerateSalt was just called")
+	}
+	callInfo := struct {
+		Ctx       github_com_cosmos_cosmos_sdk_types.Context
+		Recipient string
+	}{
+		Ctx:       ctx,
+		Recipient: recipient,
+	}
+	mock.lockGenerateSalt.Lock()
+	mock.calls.GenerateSalt = append(mock.calls.GenerateSalt, callInfo)
+	mock.lockGenerateSalt.Unlock()
+	return mock.GenerateSaltFunc(ctx, recipient)
+}
+
+// GenerateSaltCalls gets all the calls that were made to GenerateSalt.
+// Check the length with:
+//     len(mockedChainKeeper.GenerateSaltCalls())
+func (mock *ChainKeeperMock) GenerateSaltCalls() []struct {
+	Ctx       github_com_cosmos_cosmos_sdk_types.Context
+	Recipient string
+} {
+	var calls []struct {
+		Ctx       github_com_cosmos_cosmos_sdk_types.Context
+		Recipient string
+	}
+	mock.lockGenerateSalt.RLock()
+	calls = mock.calls.GenerateSalt
+	mock.lockGenerateSalt.RUnlock()
+	return calls
+}
+
 // GetBatchByID calls GetBatchByIDFunc.
 func (mock *ChainKeeperMock) GetBatchByID(ctx github_com_cosmos_cosmos_sdk_types.Context, id []byte) evmtypes.CommandBatch {
 	if mock.GetBatchByIDFunc == nil {
@@ -2625,46 +2674,46 @@ func (mock *ChainKeeperMock) GetBatchByIDCalls() []struct {
 	return calls
 }
 
-// GetBurnerAddressAndSalt calls GetBurnerAddressAndSaltFunc.
-func (mock *ChainKeeperMock) GetBurnerAddressAndSalt(ctx github_com_cosmos_cosmos_sdk_types.Context, token evmtypes.ERC20Token, recipient string, gatewayAddr evmtypes.Address) (evmtypes.Address, evmtypes.Hash, error) {
-	if mock.GetBurnerAddressAndSaltFunc == nil {
-		panic("ChainKeeperMock.GetBurnerAddressAndSaltFunc: method is nil but ChainKeeper.GetBurnerAddressAndSalt was just called")
+// GetBurnerAddress calls GetBurnerAddressFunc.
+func (mock *ChainKeeperMock) GetBurnerAddress(ctx github_com_cosmos_cosmos_sdk_types.Context, token evmtypes.ERC20Token, salt evmtypes.Hash, gatewayAddr evmtypes.Address) (evmtypes.Address, error) {
+	if mock.GetBurnerAddressFunc == nil {
+		panic("ChainKeeperMock.GetBurnerAddressFunc: method is nil but ChainKeeper.GetBurnerAddress was just called")
 	}
 	callInfo := struct {
 		Ctx         github_com_cosmos_cosmos_sdk_types.Context
 		Token       evmtypes.ERC20Token
-		Recipient   string
+		Salt        evmtypes.Hash
 		GatewayAddr evmtypes.Address
 	}{
 		Ctx:         ctx,
 		Token:       token,
-		Recipient:   recipient,
+		Salt:        salt,
 		GatewayAddr: gatewayAddr,
 	}
-	mock.lockGetBurnerAddressAndSalt.Lock()
-	mock.calls.GetBurnerAddressAndSalt = append(mock.calls.GetBurnerAddressAndSalt, callInfo)
-	mock.lockGetBurnerAddressAndSalt.Unlock()
-	return mock.GetBurnerAddressAndSaltFunc(ctx, token, recipient, gatewayAddr)
+	mock.lockGetBurnerAddress.Lock()
+	mock.calls.GetBurnerAddress = append(mock.calls.GetBurnerAddress, callInfo)
+	mock.lockGetBurnerAddress.Unlock()
+	return mock.GetBurnerAddressFunc(ctx, token, salt, gatewayAddr)
 }
 
-// GetBurnerAddressAndSaltCalls gets all the calls that were made to GetBurnerAddressAndSalt.
+// GetBurnerAddressCalls gets all the calls that were made to GetBurnerAddress.
 // Check the length with:
-//     len(mockedChainKeeper.GetBurnerAddressAndSaltCalls())
-func (mock *ChainKeeperMock) GetBurnerAddressAndSaltCalls() []struct {
+//     len(mockedChainKeeper.GetBurnerAddressCalls())
+func (mock *ChainKeeperMock) GetBurnerAddressCalls() []struct {
 	Ctx         github_com_cosmos_cosmos_sdk_types.Context
 	Token       evmtypes.ERC20Token
-	Recipient   string
+	Salt        evmtypes.Hash
 	GatewayAddr evmtypes.Address
 } {
 	var calls []struct {
 		Ctx         github_com_cosmos_cosmos_sdk_types.Context
 		Token       evmtypes.ERC20Token
-		Recipient   string
+		Salt        evmtypes.Hash
 		GatewayAddr evmtypes.Address
 	}
-	mock.lockGetBurnerAddressAndSalt.RLock()
-	calls = mock.calls.GetBurnerAddressAndSalt
-	mock.lockGetBurnerAddressAndSalt.RUnlock()
+	mock.lockGetBurnerAddress.RLock()
+	calls = mock.calls.GetBurnerAddress
+	mock.lockGetBurnerAddress.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
## Description

Add a sanity check to verify burner address that is being confirmed

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [x] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
