### PR TITLE
Restore "heartbeat_last_block_sent" metric

### DIFF
--- a/x/tss/keeper/msg_server.go
+++ b/x/tss/keeper/msg_server.go
@@ -3,7 +3,10 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/armon/go-metrics"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	multisig "github.com/axelarnetwork/axelar-core/x/multisig/exported"
@@ -50,6 +53,9 @@ func (s msgServer) HeartBeat(c context.Context, req *types.HeartBeatRequest) (*t
 			return nil, fmt.Errorf("operator %s sent heartbeat for unknown key ID %s", participant.String(), keyID)
 		}
 	}
+
+	metrics.MeasureSinceWithLabels([]string{types.ModuleName, "heartbeat_last_block_sent"},
+		time.Unix(ctx.BlockHeight(), 0), []metrics.Label{telemetry.NewLabel("address", s.snapshotter.GetOperator(ctx, req.Sender).String())})
 
 	return &types.HeartBeatResponse{KeygenIllegibility: snapshot.None, SigningIllegibility: snapshot.None}, nil
 }


### PR DESCRIPTION
hi folks, draft pr adding back `heartbeat_last_block_sent` metric to the keeper. i haven't tested this out. feel free to leave feedback on testing + any gaps I may have in my understanding of how telemetry is done within this codebase

<!-- ## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes -->
