### PR TITLE
fix(evm): load all existing chain subspaces at startup

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -91,6 +91,7 @@ import (
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
 	tmos "github.com/tendermint/tendermint/libs/os"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
 	"golang.org/x/mod/semver"
 
@@ -376,6 +377,11 @@ func NewAxelarApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest
 	evmK := evmKeeper.NewKeeper(
 		appCodec, keys[evmTypes.StoreKey], app.paramsKeeper,
 	)
+	// we need to ensure that all chain subspaces are loaded at start-up to prevent unexpected consensus failures
+	// when the params keeper is used outside the evm module's context
+	evmK.InitChains(bApp.NewContext(false, tmproto.Header{}).WithGasMeter(sdk.NewInfiniteGasMeter()))
+
+
 	rewardK := rewardKeeper.NewKeeper(
 		appCodec, keys[rewardTypes.StoreKey], app.getSubspace(rewardTypes.ModuleName), bankK, distrK, stakingK,
 	)

--- a/app/app.go
+++ b/app/app.go
@@ -381,7 +381,6 @@ func NewAxelarApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest
 	// when the params keeper is used outside the evm module's context
 	evmK.InitChains(bApp.NewContext(false, tmproto.Header{}).WithGasMeter(sdk.NewInfiniteGasMeter()))
 
-
 	rewardK := rewardKeeper.NewKeeper(
 		appCodec, keys[rewardTypes.StoreKey], app.getSubspace(rewardTypes.ModuleName), bankK, distrK, stakingK,
 	)

--- a/x/evm/keeper/baseKeeper.go
+++ b/x/evm/keeper/baseKeeper.go
@@ -69,3 +69,17 @@ func (k BaseKeeper) getStore(ctx sdk.Context, chain string) utils.KVStore {
 func (k BaseKeeper) HasChain(ctx sdk.Context, chain nexus.ChainName) bool {
 	return k.getBaseStore(ctx).Has(subspacePrefix.AppendStr(strings.ToLower(chain.String())))
 }
+
+func (k BaseKeeper) InitChains(ctx sdk.Context) {
+	iter := k.getBaseStore(ctx).Iterator(subspacePrefix)
+	defer utils.CloseLogError(iter, k.Logger(ctx))
+
+	for ; iter.Valid(); iter.Next() {
+		_, ok := k.ForChain(nexus.ChainName(iter.Key())).(chainKeeper).getSubspace(ctx)
+		if !ok {
+			panic(fmt.Sprintf("subspace for EVM chain %s should exist", string(iter.Key())))
+		}
+
+		k.Logger(ctx).Debug(fmt.Sprintf("loaded evm subspace %s", string(iter.Key())))
+	}
+}

--- a/x/evm/keeper/baseKeeper.go
+++ b/x/evm/keeper/baseKeeper.go
@@ -70,6 +70,7 @@ func (k BaseKeeper) HasChain(ctx sdk.Context, chain nexus.ChainName) bool {
 	return k.getBaseStore(ctx).Has(subspacePrefix.AppendStr(strings.ToLower(chain.String())))
 }
 
+// InitChains initializes all existing EVM chains and their respective param subspaces
 func (k BaseKeeper) InitChains(ctx sdk.Context) {
 	iter := k.getBaseStore(ctx).Iterator(subspacePrefix)
 	defer utils.CloseLogError(iter, k.Logger(ctx))


### PR DESCRIPTION
The params keeper holds existing subspaces in memory. However, EVM chains and their respective subspaces are created dynamically. This change ensures the params keeper is aware of all existing chain subspaces at start-up