### PR TITLE
fix(axelarnet)!: get escrow address with IBC denom

### DIFF
--- a/x/axelarnet/keeper/coin.go
+++ b/x/axelarnet/keeper/coin.go
@@ -55,7 +55,7 @@ func (c Coin) Lock(bankK types.BankKeeper, depositAddr sdk.AccAddress) error {
 		}
 
 		// lock tokens in escrow address
-		escrowAddress := types.GetEscrowAddress(c.Denom)
+		escrowAddress := types.GetEscrowAddress(ics20.GetDenom())
 		if err := bankK.SendCoins(
 			c.ctx, depositAddr, escrowAddress, sdk.NewCoins(ics20),
 		); err != nil {


### PR DESCRIPTION
## Description
caught by e2e test, should lock ICS20 token with IBC denom (ibc/{hash}), not the base denom

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
