### PR TITLE
fix(nexus): add status to chains cli query

### DIFF
--- a/docs/cli/axelard_query_nexus_chains.md
+++ b/docs/cli/axelard_query_nexus_chains.md
@@ -9,9 +9,10 @@ axelard query nexus chains [flags]
 ### Options
 
 ```
-      --height int    Use a specific height to query state at (this can error if the node is pruning state)
-  -h, --help          help for chains
-      --node string   <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --height int      Use a specific height to query state at (this can error if the node is pruning state)
+  -h, --help            help for chains
+      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --status string   the chain status [all|activated|deactivated]
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/axelard_query_nexus_chains.md
+++ b/docs/cli/axelard_query_nexus_chains.md
@@ -12,7 +12,7 @@ axelard query nexus chains [flags]
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for chains
       --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
-      --status string   the chain status [all|activated|deactivated]
+      --status string   the chain status [activated|deactivated]
 ```
 
 ### Options inherited from parent commands

--- a/x/nexus/client/cli/query.go
+++ b/x/nexus/client/cli/query.go
@@ -15,6 +15,11 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/nexus/types"
 )
 
+const (
+	activated   = "activated"
+	deactivated = "deactivated"
+)
+
 // GetQueryCmd returns the cli query commands for this module
 func GetQueryCmd(queryRoute string) *cobra.Command {
 	queryCmd := &cobra.Command{
@@ -224,7 +229,7 @@ func getCmdChains() *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 	}
 
-	status := cmd.Flags().String("status", "", "the chain status [all|activated|deactivated]")
+	status := cmd.Flags().String("status", "", fmt.Sprintf("the chain status [%s|%s]", activated, deactivated))
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		clientCtx, err := client.GetClientQueryContext(cmd)
@@ -236,11 +241,11 @@ func getCmdChains() *cobra.Command {
 
 		var chainStatus types.ChainStatus
 		switch *status {
-		case "", "all":
+		case "":
 			chainStatus = types.Unspecified
-		case "activated":
+		case activated:
 			chainStatus = types.Activated
-		case "deactivated":
+		case deactivated:
 			chainStatus = types.Deactivated
 		default:
 			return fmt.Errorf("unrecognized chain status %s", *status)


### PR DESCRIPTION
## Description

- Allow filtering the list of chains by status in nexus CLI query

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
