### PR TITLE
refactor(utils): use emit event shorthand across the codebase

### DIFF
--- a/x/axelarnet/keeper/msg_server.go
+++ b/x/axelarnet/keeper/msg_server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/query"
 	ibctransfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
 
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/axelarnet/exported"
 	"github.com/axelarnetwork/axelar-core/x/axelarnet/types"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
@@ -187,12 +188,12 @@ func (s msgServer) ExecutePendingTransfers(c context.Context, _ *types.ExecutePe
 			continue
 		}
 
-		funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(
+		events.Emit(ctx,
 			&types.AxelarTransferCompleted{
 				ID:         pendingTransfer.ID,
 				Receipient: pendingTransfer.Recipient.Address,
 				Asset:      pendingTransfer.Asset,
-			}))
+			})
 
 		s.nexus.ArchivePendingTransfer(ctx, pendingTransfer)
 	}
@@ -205,11 +206,11 @@ func (s msgServer) ExecutePendingTransfers(c context.Context, _ *types.ExecutePe
 				continue
 			}
 
-			funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(
+			events.Emit(ctx,
 				&types.FeeCollected{
 					Collector: collector,
 					Fee:       fee,
-				}))
+				})
 
 			s.nexus.SubTransferFee(ctx, fee)
 		}
@@ -393,7 +394,7 @@ func (s msgServer) RetryIBCTransfer(c context.Context, req *types.RetryIBCTransf
 
 	funcs.MustNoErr(s.SetTransferPending(ctx, t.ID))
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(
+	events.Emit(ctx,
 		&types.IBCTransferRetried{
 			ID:         t.ID,
 			Receipient: t.Receiver,
@@ -401,7 +402,7 @@ func (s msgServer) RetryIBCTransfer(c context.Context, req *types.RetryIBCTransf
 			Sequence:   t.Sequence,
 			PortID:     t.PortID,
 			ChannelID:  t.ChannelID,
-		}))
+		})
 
 	return &types.RetryIBCTransferResponse{}, nil
 }

--- a/x/axelarnet/module.go
+++ b/x/axelarnet/module.go
@@ -23,12 +23,12 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/axelarnetwork/axelar-core/utils"
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/axelarnet/client/cli"
 	"github.com/axelarnetwork/axelar-core/x/axelarnet/client/rest"
 	"github.com/axelarnetwork/axelar-core/x/axelarnet/keeper"
 	"github.com/axelarnetwork/axelar-core/x/axelarnet/types"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
-	"github.com/axelarnetwork/utils/funcs"
 )
 
 var (
@@ -323,13 +323,13 @@ func setTransferFailed(ctx sdk.Context, k keeper.Keeper, portID, channelID strin
 		return nil
 	}
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(
+	events.Emit(ctx,
 		&types.IBCTransferFailed{
 			ID:        transferID,
 			Sequence:  seq,
 			PortID:    portID,
 			ChannelID: channelID,
-		}))
+		})
 
 	k.Logger(ctx).Info(fmt.Sprintf("set IBC transfer %d failed", transferID))
 	return k.SetTransferFailed(ctx, transferID)
@@ -341,13 +341,13 @@ func setTransferCompleted(ctx sdk.Context, k keeper.Keeper, portID, channelID st
 		return nil
 	}
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(
+	events.Emit(ctx,
 		&types.IBCTransferCompleted{
 			ID:        transferID,
 			Sequence:  seq,
 			PortID:    portID,
 			ChannelID: channelID,
-		}))
+		})
 
 	k.Logger(ctx).Info(fmt.Sprintf("set IBC transfer %d completed", transferID))
 	return k.SetTransferCompleted(ctx, transferID)

--- a/x/evm/abci.go
+++ b/x/evm/abci.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	abci "github.com/tendermint/tendermint/abci/types"
 
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	"github.com/axelarnetwork/utils/funcs"
@@ -73,7 +74,7 @@ func handleTokenSent(ctx sdk.Context, event types.Event, bk types.BaseKeeper, n 
 		"transferID", transferID.String(),
 	)
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.TokenSent{
+	events.Emit(ctx, &types.TokenSent{
 		Chain:              event.Chain,
 		EventID:            event.GetID(),
 		TransferID:         transferID,
@@ -81,7 +82,7 @@ func handleTokenSent(ctx sdk.Context, event types.Event, bk types.BaseKeeper, n 
 		DestinationChain:   e.DestinationChain,
 		DestinationAddress: e.DestinationAddress,
 		Asset:              amount,
-	}))
+	})
 
 	return true
 }
@@ -134,7 +135,7 @@ func handleContractCall(ctx sdk.Context, event types.Event, bk types.BaseKeeper,
 		"commandID", cmd.ID.Hex(),
 	)
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.ContractCallApproved{
+	events.Emit(ctx, &types.ContractCallApproved{
 		Chain:            event.Chain,
 		EventID:          event.GetID(),
 		CommandID:        cmd.ID,
@@ -142,7 +143,7 @@ func handleContractCall(ctx sdk.Context, event types.Event, bk types.BaseKeeper,
 		DestinationChain: e.DestinationChain,
 		ContractAddress:  e.ContractAddress,
 		PayloadHash:      e.PayloadHash,
-	}))
+	})
 
 	return true
 }
@@ -216,7 +217,7 @@ func handleContractCallWithToken(ctx sdk.Context, event types.Event, bk types.Ba
 		"commandID", cmd.ID.Hex(),
 	)
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.ContractCallWithMintApproved{
+	events.Emit(ctx, &types.ContractCallWithMintApproved{
 		Chain:            event.Chain,
 		EventID:          event.GetID(),
 		CommandID:        cmd.ID,
@@ -225,7 +226,7 @@ func handleContractCallWithToken(ctx sdk.Context, event types.Event, bk types.Ba
 		ContractAddress:  e.ContractAddress,
 		PayloadHash:      e.PayloadHash,
 		Asset:            sdk.NewCoin(asset, sdk.Int(e.Amount)),
-	}))
+	})
 
 	return true
 }

--- a/x/evm/keeper/chainKeeper.go
+++ b/x/evm/keeper/chainKeeper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/axelarnetwork/axelar-core/utils"
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/utils/key"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
 	"github.com/axelarnetwork/utils/funcs"
@@ -891,11 +892,11 @@ func (k chainKeeper) SetConfirmedEvent(ctx sdk.Context, event types.Event) error
 		return fmt.Errorf("unsupported event type %T", event)
 	}
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.EVMEventConfirmed{
+	events.Emit(ctx, &types.EVMEventConfirmed{
 		Chain:   event.Chain,
 		EventID: event.GetID(),
 		Type:    event.GetEventType(),
-	}))
+	})
 
 	return nil
 }
@@ -910,13 +911,12 @@ func (k chainKeeper) SetEventCompleted(ctx sdk.Context, eventID types.EventID) e
 	event.Status = types.EventCompleted
 	k.setEvent(ctx, event)
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(
+	events.Emit(ctx,
 		&types.EVMEventCompleted{
 			Chain:   event.Chain,
 			EventID: event.GetID(),
 			Type:    event.GetEventType(),
-		}),
-	)
+		})
 
 	return nil
 }
@@ -936,13 +936,12 @@ func (k chainKeeper) SetEventFailed(ctx sdk.Context, eventID types.EventID) erro
 		"eventID", event.GetID(),
 	)
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(
+	events.Emit(ctx,
 		&types.EVMEventFailed{
 			Chain:   event.Chain,
 			EventID: event.GetID(),
 			Type:    event.GetEventType(),
-		}),
-	)
+		})
 
 	return nil
 }

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -11,6 +11,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
 	multisig "github.com/axelarnetwork/axelar-core/x/multisig/exported"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
@@ -107,13 +108,13 @@ func (s msgServer) ConfirmGatewayTx(c context.Context, req *types.ConfirmGateway
 		return nil, fmt.Errorf("required confirmation height not found")
 	}
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.ConfirmGatewayTxStarted{
+	events.Emit(ctx, &types.ConfirmGatewayTxStarted{
 		TxID:               req.TxID,
 		Chain:              chain.Name,
 		GatewayAddress:     gatewayAddress,
 		ConfirmationHeight: height,
 		PollParticipants:   pollParticipants,
-	}))
+	})
 
 	return &types.ConfirmGatewayTxResponse{}, nil
 }
@@ -262,7 +263,7 @@ func (s msgServer) ConfirmToken(c context.Context, req *types.ConfirmTokenReques
 		return nil, err
 	}
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.ConfirmTokenStarted{
+	events.Emit(ctx, &types.ConfirmTokenStarted{
 		TxID:               req.TxID,
 		Chain:              chain.Name,
 		GatewayAddress:     funcs.MustOk(keeper.GetGatewayAddress(ctx)),
@@ -270,7 +271,7 @@ func (s msgServer) ConfirmToken(c context.Context, req *types.ConfirmTokenReques
 		TokenDetails:       token.GetDetails(),
 		ConfirmationHeight: funcs.MustOk(keeper.GetRequiredConfirmationHeight(ctx)),
 		PollParticipants:   pollParticipants,
-	}))
+	})
 
 	return &types.ConfirmTokenResponse{}, nil
 }
@@ -318,7 +319,7 @@ func (s msgServer) ConfirmDeposit(c context.Context, req *types.ConfirmDepositRe
 	}
 
 	height, _ := keeper.GetRequiredConfirmationHeight(ctx)
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.ConfirmDepositStarted{
+	events.Emit(ctx, &types.ConfirmDepositStarted{
 		TxID:               req.TxID,
 		Chain:              chain.Name,
 		DepositAddress:     req.BurnerAddress,
@@ -326,7 +327,7 @@ func (s msgServer) ConfirmDeposit(c context.Context, req *types.ConfirmDepositRe
 		ConfirmationHeight: height,
 		PollParticipants:   pollParticipants,
 		Asset:              burnerInfo.Asset,
-	}))
+	})
 
 	return &types.ConfirmDepositResponse{}, nil
 }
@@ -360,7 +361,7 @@ func (s msgServer) ConfirmTransferKey(c context.Context, req *types.ConfirmTrans
 	}
 
 	params := keeper.GetParams(ctx)
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(types.NewConfirmKeyTransferStarted(chain.Name, req.TxID, gatewayAddr, params.ConfirmationHeight, pollParticipants)))
+	events.Emit(ctx, types.NewConfirmKeyTransferStarted(chain.Name, req.TxID, gatewayAddr, params.ConfirmationHeight, pollParticipants))
 
 	return &types.ConfirmTransferKeyResponse{}, nil
 }
@@ -502,13 +503,13 @@ func (s msgServer) CreateBurnTokens(c context.Context, req *types.CreateBurnToke
 			return nil, err
 		}
 
-		funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.BurnCommand{
+		events.Emit(ctx, &types.BurnCommand{
 			Chain:            chain.Name,
 			CommandID:        cmd.ID,
 			DestinationChain: deposit.DestinationChain,
 			DepositAddress:   deposit.BurnerAddress.Hex(),
 			Asset:            token.GetAsset(),
-		}))
+		})
 
 		seen[burnerAddressHex] = true
 	}
@@ -577,14 +578,14 @@ func (s msgServer) CreatePendingTransfers(c context.Context, req *types.CreatePe
 			return nil, err
 		}
 
-		funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.MintCommand{
+		events.Emit(ctx, &types.MintCommand{
 			Chain:              chain.Name,
 			TransferID:         transfer.ID,
 			CommandID:          cmd.ID,
 			DestinationChain:   transfer.Recipient.Chain.Name,
 			DestinationAddress: transfer.Recipient.Address,
 			Asset:              transfer.Asset,
-		}))
+		})
 
 		s.nexus.ArchivePendingTransfer(ctx, transfer)
 	}
@@ -742,7 +743,7 @@ func (s msgServer) AddChain(c context.Context, req *types.AddChainRequest) (*typ
 	s.nexus.SetChain(ctx, chain)
 	s.ForChain(chain.Name).SetParams(ctx, req.Params)
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.ChainAdded{Chain: req.Name}))
+	events.Emit(ctx, &types.ChainAdded{Chain: req.Name})
 
 	return &types.AddChainResponse{}, nil
 }
@@ -779,11 +780,11 @@ func (s msgServer) RetryFailedEvent(c context.Context, req *types.RetryFailedEve
 		"eventID", event.GetID(),
 	)
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.EVMEventRetryFailed{
+	events.Emit(ctx, &types.EVMEventRetryFailed{
 		Chain:   event.Chain,
 		EventID: event.GetID(),
 		Type:    event.GetEventType(),
-	}))
+	})
 
 	return &types.RetryFailedEventResponse{}, nil
 }

--- a/x/evm/keeper/sig_handler.go
+++ b/x/evm/keeper/sig_handler.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/axelarnetwork/axelar-core/utils"
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
 	multisig "github.com/axelarnetwork/axelar-core/x/multisig/exported"
 	"github.com/axelarnetwork/utils/funcs"
@@ -35,7 +36,7 @@ func (s sigHandler) HandleCompleted(ctx sdk.Context, sig utils.ValidatedProtoMar
 
 	funcs.MustNoErr(commandBatch.SetSigned(sig))
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(types.NewCommandBatchSigned(sigMetadata.Chain, sigMetadata.CommandBatchID)))
+	events.Emit(ctx, types.NewCommandBatchSigned(sigMetadata.Chain, sigMetadata.CommandBatchID))
 
 	return nil
 }
@@ -52,7 +53,7 @@ func (s sigHandler) HandleFailed(ctx sdk.Context, moduleMetadata codec.ProtoMars
 		panic(fmt.Errorf("failed to abort command batch %s", hex.EncodeToString(commandBatch.GetID())))
 	}
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(types.NewCommandBatchAborted(sigMetadata.Chain, sigMetadata.CommandBatchID)))
+	events.Emit(ctx, types.NewCommandBatchAborted(sigMetadata.Chain, sigMetadata.CommandBatchID))
 
 	return nil
 }

--- a/x/evm/keeper/vote_handler.go
+++ b/x/evm/keeper/vote_handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/evm/types"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	vote "github.com/axelarnetwork/axelar-core/x/vote/exported"
@@ -33,11 +34,11 @@ func NewVoteHandler(cdc codec.Codec, keeper types.BaseKeeper, nexus types.Nexus,
 
 func (v voteHandler) HandleFailedPoll(ctx sdk.Context, poll vote.Poll) error {
 	md := mustGetMetadata(poll)
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.PollFailed{
+	events.Emit(ctx, &types.PollFailed{
 		TxID:   md.TxID,
 		Chain:  md.Chain,
 		PollID: poll.GetID(),
-	}))
+	})
 
 	return nil
 }
@@ -80,11 +81,11 @@ func (v voteHandler) HandleExpiredPoll(ctx sdk.Context, poll vote.Poll) error {
 		}
 	}
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.PollExpired{
+	events.Emit(ctx, &types.PollExpired{
 		TxID:   md.TxID,
 		Chain:  md.Chain,
 		PollID: poll.GetID(),
-	}))
+	})
 
 	return nil
 }
@@ -142,18 +143,18 @@ func (v voteHandler) HandleCompletedPoll(ctx sdk.Context, poll vote.Poll) error 
 
 	md := mustGetMetadata(poll)
 	if v.IsFalsyResult(voteEvents) {
-		funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.NoEventsConfirmed{
+		events.Emit(ctx, &types.NoEventsConfirmed{
 			TxID:   md.TxID,
 			Chain:  md.Chain,
 			PollID: poll.GetID(),
-		}))
+		})
 	}
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.PollCompleted{
+	events.Emit(ctx, &types.PollCompleted{
 		TxID:   md.TxID,
 		Chain:  md.Chain,
 		PollID: poll.GetID(),
-	}))
+	})
 
 	return nil
 }

--- a/x/multisig/abci.go
+++ b/x/multisig/abci.go
@@ -5,6 +5,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/axelarnetwork/axelar-core/utils"
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/multisig/exported"
 	"github.com/axelarnetwork/axelar-core/x/multisig/types"
 	"github.com/axelarnetwork/utils/funcs"
@@ -32,7 +33,7 @@ func handleKeygens(ctx sdk.Context, k types.Keeper, rewarder types.Rewarder) {
 		slices.ForEach(keygen.GetMissingParticipants(), pool.ClearRewards)
 
 		if keygen.State != exported.Completed {
-			funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(types.NewKeygenExpired(keygen.GetKeyID())))
+			events.Emit(ctx, types.NewKeygenExpired(keygen.GetKeyID()))
 			k.Logger(ctx).Info("keygen session expired",
 				"key_id", keygen.GetKeyID(),
 			)
@@ -59,7 +60,7 @@ func handleSignings(ctx sdk.Context, k types.Keeper, rewarder types.Rewarder) {
 			slices.ForEach(signing.GetMissingParticipants(), pool.ClearRewards)
 
 			if signing.State != exported.Completed {
-				funcs.MustNoErr(cachedCtx.EventManager().EmitTypedEvent(types.NewSigningExpired(signing.GetID())))
+				events.Emit(cachedCtx, types.NewSigningExpired(signing.GetID()))
 				k.Logger(cachedCtx).Info("signing session expired",
 					"sig_id", signing.GetID(),
 				)
@@ -73,7 +74,7 @@ func handleSignings(ctx sdk.Context, k types.Keeper, rewarder types.Rewarder) {
 			slices.ForEach(sig.GetParticipants(), func(p sdk.ValAddress) { funcs.MustNoErr(pool.ReleaseRewards(p)) })
 			funcs.MustNoErr(k.GetSigRouter().GetHandler(module).HandleCompleted(cachedCtx, &sig, signing.GetMetadata()))
 
-			funcs.MustNoErr(cachedCtx.EventManager().EmitTypedEvent(types.NewSigningCompleted(signing.GetID())))
+			events.Emit(cachedCtx, types.NewSigningCompleted(signing.GetID()))
 			k.Logger(cachedCtx).Info("signing session completed",
 				"sig_id", signing.GetID(),
 				"key_id", sig.GetKeyID(),

--- a/x/multisig/keeper/keygen.go
+++ b/x/multisig/keeper/keygen.go
@@ -7,10 +7,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/axelarnetwork/axelar-core/utils"
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/multisig/exported"
 	"github.com/axelarnetwork/axelar-core/x/multisig/types"
 	snapshot "github.com/axelarnetwork/axelar-core/x/snapshot/exported"
-	"github.com/axelarnetwork/utils/funcs"
 	"github.com/axelarnetwork/utils/math"
 	"github.com/axelarnetwork/utils/slices"
 )
@@ -57,7 +57,7 @@ func (k Keeper) SetKey(ctx sdk.Context, key types.Key) {
 	k.setKey(ctx, key)
 
 	participants := key.GetParticipants()
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(types.NewKeygenCompleted(key.ID)))
+	events.Emit(ctx, types.NewKeygenCompleted(key.ID))
 	k.Logger(ctx).Info("setting key",
 		"key_id", key.ID,
 		"participant_count", len(participants),
@@ -99,7 +99,7 @@ func (k Keeper) createKeygenSession(ctx sdk.Context, id exported.KeyID, snapshot
 	k.setKeygenSession(ctx, keygenSession)
 
 	participants := snapshot.GetParticipantAddresses()
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(types.NewKeygenStarted(id, participants)))
+	events.Emit(ctx, types.NewKeygenStarted(id, participants))
 
 	k.Logger(ctx).Info("keygen session started",
 		"key_id", id,

--- a/x/multisig/keeper/msg_server.go
+++ b/x/multisig/keeper/msg_server.go
@@ -7,8 +7,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/multisig/types"
-	"github.com/axelarnetwork/utils/funcs"
 )
 
 var _ types.MsgServiceServer = msgServer{}
@@ -76,7 +76,7 @@ func (s msgServer) SubmitPubKey(c context.Context, req *types.SubmitPubKeyReques
 		"expires_at", keygenSession.ExpiresAt,
 	)
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(types.NewPubKeySubmitted(req.KeyID, participant, req.PubKey)))
+	events.Emit(ctx, types.NewPubKeySubmitted(req.KeyID, participant, req.PubKey))
 
 	return &types.SubmitPubKeyResponse{}, nil
 }
@@ -109,7 +109,7 @@ func (s msgServer) SubmitSignature(c context.Context, req *types.SubmitSignature
 		"expires_at", signingSession.ExpiresAt,
 	)
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(types.NewSignatureSubmitted(req.SigID, participant, req.Signature)))
+	events.Emit(ctx, types.NewSignatureSubmitted(req.SigID, participant, req.Signature))
 
 	return &types.SubmitSignatureResponse{}, nil
 }

--- a/x/multisig/keeper/rotation.go
+++ b/x/multisig/keeper/rotation.go
@@ -7,6 +7,7 @@ import (
 	gogoprototypes "github.com/gogo/protobuf/types"
 
 	"github.com/axelarnetwork/axelar-core/utils"
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/multisig/exported"
 	"github.com/axelarnetwork/axelar-core/x/multisig/types"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
@@ -62,7 +63,7 @@ func (k Keeper) AssignKey(ctx sdk.Context, chainName nexus.ChainName, keyID expo
 	k.setKey(ctx, key)
 	k.setKeyEpoch(ctx, types.NewKeyEpoch(nextRotationCount, chainName, keyID))
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(types.NewKeyAssigned(chainName, keyID)))
+	events.Emit(ctx, types.NewKeyAssigned(chainName, keyID))
 	k.Logger(ctx).Info("new key assigned",
 		"chain", chainName,
 		"keyID", keyID,
@@ -93,7 +94,7 @@ func (k Keeper) RotateKey(ctx sdk.Context, chainName nexus.ChainName) error {
 		k.deactivateKeyAtEpoch(ctx, chainName, keyEpoch.Epoch-params.ActiveEpochCount)
 	}
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(types.NewKeyRotated(chainName, keyEpoch.GetKeyID())))
+	events.Emit(ctx, types.NewKeyRotated(chainName, keyEpoch.GetKeyID()))
 	k.Logger(ctx).Info("new key rotated",
 		"chain", chainName,
 		"keyID", keyEpoch.GetKeyID(),

--- a/x/multisig/keeper/signing.go
+++ b/x/multisig/keeper/signing.go
@@ -9,9 +9,9 @@ import (
 	gogoprototypes "github.com/gogo/protobuf/types"
 
 	"github.com/axelarnetwork/axelar-core/utils"
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/multisig/exported"
 	"github.com/axelarnetwork/axelar-core/x/multisig/types"
-	"github.com/axelarnetwork/utils/funcs"
 	"github.com/axelarnetwork/utils/math"
 	"github.com/axelarnetwork/utils/slices"
 )
@@ -87,7 +87,7 @@ func (k Keeper) Sign(ctx sdk.Context, keyID exported.KeyID, payloadHash exported
 
 	k.setSigningSession(ctx, signingSession)
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(types.NewSigningStarted(signingSession.GetID(), key, payloadHash[:], module)))
+	events.Emit(ctx, types.NewSigningStarted(signingSession.GetID(), key, payloadHash[:], module))
 	k.Logger(ctx).Info("signing session started",
 		"sig_id", signingSession.GetID(),
 		"key_id", key.GetID(),

--- a/x/nexus/keeper/transfer.go
+++ b/x/nexus/keeper/transfer.go
@@ -8,9 +8,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/query"
 
 	"github.com/axelarnetwork/axelar-core/utils"
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	"github.com/axelarnetwork/axelar-core/x/nexus/types"
-	"github.com/axelarnetwork/utils/funcs"
 )
 
 func getTransferPrefix(chain exported.ChainName, state exported.TransferState) utils.Key {
@@ -132,13 +132,13 @@ func (k Keeper) EnqueueTransfer(ctx sdk.Context, senderChain exported.Chain, rec
 
 		transferID := k.setNewTransfer(ctx, recipient, asset, exported.InsufficientAmount)
 
-		funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.InsufficientFee{
+		events.Emit(ctx, &types.InsufficientFee{
 			TransferID:       transferID,
 			RecipientChain:   recipient.Chain.Name,
 			RecipientAddress: recipient.Address,
 			Amount:           asset,
 			Fee:              fee,
-		}))
+		})
 
 		return transferID, nil
 	}
@@ -160,12 +160,12 @@ func (k Keeper) EnqueueTransfer(ctx sdk.Context, senderChain exported.Chain, rec
 
 	transferID := k.setNewTransfer(ctx, recipient, asset, exported.Pending)
 
-	funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&types.FeeDeducted{
+	events.Emit(ctx, &types.FeeDeducted{
 		TransferID:       transferID,
 		RecipientChain:   recipient.Chain.Name,
 		RecipientAddress: recipient.Address,
 		Fee:              fee,
-	}))
+	})
 
 	return transferID, nil
 }

--- a/x/vote/keeper/msg_server.go
+++ b/x/vote/keeper/msg_server.go
@@ -7,9 +7,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	vote "github.com/axelarnetwork/axelar-core/x/vote/exported"
 	"github.com/axelarnetwork/axelar-core/x/vote/types"
-	"github.com/axelarnetwork/utils/funcs"
 )
 
 type msgServer struct {
@@ -43,14 +43,14 @@ func (s msgServer) Vote(c context.Context, req *types.VoteRequest) (*types.VoteR
 	}
 
 	if voteResult != vote.NoVote {
-		funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(
+		events.Emit(ctx,
 			&types.Voted{
 				Module: types.ModuleName,
 				Action: types.AttributeValueVote,
 				Poll:   req.PollID.String(),
 				Voter:  req.Sender.String(),
 				State:  poll.GetState().String(),
-			}))
+			})
 	}
 
 	switch poll.GetState() {

--- a/x/vote/types/vote_router_test.go
+++ b/x/vote/types/vote_router_test.go
@@ -11,9 +11,9 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/axelarnetwork/axelar-core/testutils/fake"
+	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/vote/exported"
 	"github.com/axelarnetwork/axelar-core/x/vote/exported/mock"
-	"github.com/axelarnetwork/utils/funcs"
 	testutils "github.com/axelarnetwork/utils/test"
 )
 
@@ -44,28 +44,28 @@ func TestVoteRouter(t *testing.T) {
 		handler.HandleResultFunc = func(ctx sdk.Context, _ codec.ProtoMarshaler) error {
 			ctx.KVStore(storeKey).Set([]byte("key1"), []byte("value"))
 
-			funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&Voted{}))
+			events.Emit(ctx, &Voted{})
 			return nil
 		}
 
 		handler.HandleFailedPollFunc = func(ctx sdk.Context, _ exported.Poll) error {
 			ctx.KVStore(storeKey).Set([]byte("key2"), []byte("value"))
 
-			funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&Voted{}))
+			events.Emit(ctx, &Voted{})
 			return nil
 		}
 
 		handler.HandleExpiredPollFunc = func(ctx sdk.Context, _ exported.Poll) error {
 			ctx.KVStore(storeKey).Set([]byte("key3"), []byte("value"))
 
-			funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&Voted{}))
+			events.Emit(ctx, &Voted{})
 			return nil
 		}
 
 		handler.HandleCompletedPollFunc = func(ctx sdk.Context, _ exported.Poll) error {
 			ctx.KVStore(storeKey).Set([]byte("key4"), []byte("value"))
 
-			funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&Voted{}))
+			events.Emit(ctx, &Voted{})
 			return nil
 		}
 	}).
@@ -86,28 +86,28 @@ func TestVoteRouter(t *testing.T) {
 		handler.HandleResultFunc = func(ctx sdk.Context, _ codec.ProtoMarshaler) error {
 			ctx.KVStore(storeKey).Set([]byte("key1"), []byte("value"))
 
-			funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&Voted{}))
+			events.Emit(ctx, &Voted{})
 			return fmt.Errorf("some error")
 		}
 
 		handler.HandleFailedPollFunc = func(ctx sdk.Context, _ exported.Poll) error {
 			ctx.KVStore(storeKey).Set([]byte("key2"), []byte("value"))
 
-			funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&Voted{}))
+			events.Emit(ctx, &Voted{})
 			return fmt.Errorf("some error")
 		}
 
 		handler.HandleExpiredPollFunc = func(ctx sdk.Context, _ exported.Poll) error {
 			ctx.KVStore(storeKey).Set([]byte("key3"), []byte("value"))
 
-			funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&Voted{}))
+			events.Emit(ctx, &Voted{})
 			return fmt.Errorf("some error")
 		}
 
 		handler.HandleCompletedPollFunc = func(ctx sdk.Context, _ exported.Poll) error {
 			ctx.KVStore(storeKey).Set([]byte("key4"), []byte("value"))
 
-			funcs.MustNoErr(ctx.EventManager().EmitTypedEvent(&Voted{}))
+			events.Emit(ctx, &Voted{})
 			return fmt.Errorf("some error")
 		}
 	}).


### PR DESCRIPTION
This replaces all uses of `EmitTypedEvent` in the codebase with the shorthand from #1776