### PR TITLE
fix(nexus): add missing amount field to nexus fee event

### DIFF
--- a/x/nexus/keeper/transfer.go
+++ b/x/nexus/keeper/transfer.go
@@ -164,6 +164,7 @@ func (k Keeper) EnqueueTransfer(ctx sdk.Context, senderChain exported.Chain, rec
 		TransferID:       transferID,
 		RecipientChain:   recipient.Chain.Name,
 		RecipientAddress: recipient.Address,
+		Amount:           asset,
 		Fee:              fee,
 	}))
 


### PR DESCRIPTION
## Description

Add missing `amount` field to nexus `FeeDeducted` event, identified [here](https://github.com/axelarnetwork/axelar-core/pull/1771#discussion_r986593664).

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
