### PR TITLE
refactor(multisig): replace panic with error

### DIFF
--- a/x/multisig/abci.go
+++ b/x/multisig/abci.go
@@ -2,6 +2,7 @@ package multisig
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/axelarnetwork/axelar-core/utils"
@@ -71,7 +72,9 @@ func handleSignings(ctx sdk.Context, k types.Keeper, rewarder types.Rewarder) {
 			sig := funcs.Must(signing.Result())
 
 			slices.ForEach(sig.GetParticipants(), func(p sdk.ValAddress) { funcs.MustNoErr(pool.ReleaseRewards(p)) })
-			funcs.MustNoErr(k.GetSigRouter().GetHandler(module).HandleCompleted(cachedCtx, &sig, signing.GetMetadata()))
+			if err := k.GetSigRouter().GetHandler(module).HandleCompleted(cachedCtx, &sig, signing.GetMetadata()); err != nil {
+				return nil, sdkerrors.Wrap(err, "failed to handle completed signature")
+			}
 
 			funcs.MustNoErr(cachedCtx.EventManager().EmitTypedEvent(types.NewSigningCompleted(signing.GetID())))
 			k.Logger(cachedCtx).Info("signing session completed",


### PR DESCRIPTION
Panics should be reserved for unexpected behaviour due to implementation errors. In this case, it is sensible to expect the signature handler to return an error when handling a completed signature, so it is better to deal with that error instead of panicking. This does not change the behaviour of the endblocker, both errors and panics are caught by the cached execution environment.