### PR TITLE
fix(nexus): add status to chains cli query (#1774)

### DIFF
--- a/docs/cli/axelard_query_nexus_chains.md
+++ b/docs/cli/axelard_query_nexus_chains.md
@@ -9,9 +9,10 @@ axelard query nexus chains [flags]
 ### Options
 
 ```
-      --height int    Use a specific height to query state at (this can error if the node is pruning state)
-  -h, --help          help for chains
-      --node string   <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --height int      Use a specific height to query state at (this can error if the node is pruning state)
+  -h, --help            help for chains
+      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --status string   the chain status [activated|deactivated]
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Description

cherry-pick #1774 
- Add flags to nexus chains CLI query to filter by activated/deactivated status

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
