### PR TITLE
fix(vald): log errors after cleanup (#1796)

### DIFF
--- a/utils/abci.go
+++ b/utils/abci.go
@@ -22,7 +22,7 @@ func RunCached[T any](c sdk.Context, l Logger, f func(sdk.Context) (T, error)) T
 	defer func() {
 		if r := recover(); r != nil {
 			l.Logger(ctx).Error(fmt.Sprintf("recovered from panic in cached context: %v", r))
-			l.Logger(ctx).Error(errors.Wrap(r, 1).ErrorStack())
+			l.Logger(ctx).Error("%s", errors.Wrap(r, 1).Stack())
 		}
 	}()
 

--- a/utils/abci.go
+++ b/utils/abci.go
@@ -22,7 +22,7 @@ func RunCached[T any](c sdk.Context, l Logger, f func(sdk.Context) (T, error)) T
 	defer func() {
 		if r := recover(); r != nil {
 			l.Logger(ctx).Error(fmt.Sprintf("recovered from panic in cached context: %v", r))
-			l.Logger(ctx).Error("%s", errors.Wrap(r, 1).Stack())
+			l.Logger(ctx).Error(string(errors.Wrap(r, 1).Stack()))
 		}
 	}()
 

--- a/vald/start.go
+++ b/vald/start.go
@@ -251,6 +251,9 @@ func listen(ctx context.Context, clientCtx sdkClient.Context, txf tx.Factory, ax
 		logger.Info("event listener stopped")
 		logger.Info("stopping subscribers...")
 		<-mgr.Done()
+		if err := <-mgr.Errs(); err != nil {
+			logger.Error(err.Error())
+		}
 		logger.Info("subscriptions stopped")
 	})
 

--- a/x/multisig/types/signing_test.go
+++ b/x/multisig/types/signing_test.go
@@ -125,7 +125,7 @@ func TestSigningSession(t *testing.T) {
 			SigningThreshold: utils.NewThreshold(2, 3),
 		}
 		payloadHash := rand.Bytes(exported.HashLength)
-		expiresAt := rand.I64Between(1, 100)
+		expiresAt := rand.I64Between(2, 100) // starts from 2 so CompletedAt can be 1
 		gracePeriod := int64(3)
 		module := rand.NormalizedStr(5)
 


### PR DESCRIPTION
backport #1796 

* fix(vald): log errors after cleanup

* use consistent panic stack trace logging

## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
