### PR TITLE
fix(utils): panic log formatting

### DIFF
--- a/utils/abci.go
+++ b/utils/abci.go
@@ -22,7 +22,7 @@ func RunCached[T any](c sdk.Context, l Logger, f func(sdk.Context) (T, error)) T
 	defer func() {
 		if r := recover(); r != nil {
 			l.Logger(ctx).Error(fmt.Sprintf("recovered from panic in cached context: %v", r))
-			l.Logger(ctx).Error("%s", errors.Wrap(r, 1).Stack())
+			l.Logger(ctx).Error(fmt.Sprintf("%s", errors.Wrap(r, 1).Stack()))
 		}
 	}()
 

--- a/utils/abci.go
+++ b/utils/abci.go
@@ -22,7 +22,7 @@ func RunCached[T any](c sdk.Context, l Logger, f func(sdk.Context) (T, error)) T
 	defer func() {
 		if r := recover(); r != nil {
 			l.Logger(ctx).Error(fmt.Sprintf("recovered from panic in cached context: %v", r))
-			l.Logger(ctx).Error(fmt.Sprintf("%s", errors.Wrap(r, 1).Stack()))
+			l.Logger(ctx).Error(string(errors.Wrap(r, 1).Stack()))
 		}
 	}()
 


### PR DESCRIPTION
## Description

panic log should format the error string

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
