### PR TITLE
fix(reward)!: don't reward validators who have opted out of keygen

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -496,7 +496,7 @@ func NewAxelarApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest
 		nexus.NewAppModule(nexusK, snapK, slashingK, stakingK, axelarnetK, rewardK),
 		evm.NewAppModule(evmK, votingK, nexusK, snapK, stakingK, slashingK, multisigK, logger),
 		axelarnetModule,
-		reward.NewAppModule(rewardK, nexusK, mintK, stakingK, slashingK, tssK, snapK, bankK, bApp.MsgServiceRouter(), bApp.Router()),
+		reward.NewAppModule(rewardK, nexusK, mintK, stakingK, slashingK, multisigK, snapK, bankK, bApp.MsgServiceRouter(), bApp.Router()),
 		permission.NewAppModule(permissionK),
 	)
 

--- a/x/multisig/keeper/keygen.go
+++ b/x/multisig/keeper/keygen.go
@@ -94,8 +94,8 @@ func (k Keeper) KeygenOptIn(ctx sdk.Context, participant sdk.AccAddress) {
 	k.getStore(ctx).DeleteNew(keygenOptOutPrefix.Append(key.FromBz(participant)))
 }
 
-// IsOptOut returns true if the given participant is opted out of future keygens
-func (k Keeper) IsOptOut(ctx sdk.Context, participant sdk.AccAddress) bool {
+// HasOptedOut returns true if the given participant is opted out of future keygens
+func (k Keeper) HasOptedOut(ctx sdk.Context, participant sdk.AccAddress) bool {
 	return k.getStore(ctx).HasNew(keygenOptOutPrefix.Append(key.FromBz(participant)))
 }
 

--- a/x/multisig/keeper/keygen_test.go
+++ b/x/multisig/keeper/keygen_test.go
@@ -20,11 +20,11 @@ func TestKeygenOptOut(t *testing.T) {
 	participant := rand.AccAddr()
 
 	ctx := testutils.NewContext()
-	assert.False(t, k.IsOptOut(ctx, participant))
+	assert.False(t, k.HasOptedOut(ctx, participant))
 	k.KeygenOptOut(ctx, participant)
-	assert.True(t, k.IsOptOut(ctx, participant))
+	assert.True(t, k.HasOptedOut(ctx, participant))
 	k.KeygenOptIn(ctx, participant)
-	assert.False(t, k.IsOptOut(ctx, participant))
+	assert.False(t, k.HasOptedOut(ctx, participant))
 	k.KeygenOptOut(ctx, participant)
-	assert.True(t, k.IsOptOut(ctx, participant))
+	assert.True(t, k.HasOptedOut(ctx, participant))
 }

--- a/x/multisig/keeper/snapshotter.go
+++ b/x/multisig/keeper/snapshotter.go
@@ -58,7 +58,7 @@ func (sc SnapshotCreator) CreateSnapshot(ctx sdk.Context, threshold utils.Thresh
 	isProxyActive := func(v snapshot.ValidatorI) bool {
 		proxy, isActive := sc.snapshotter.GetProxy(ctx, v.GetOperator())
 
-		return isActive && !sc.keygen.IsOptOut(ctx, proxy)
+		return isActive && !sc.keygen.HasOptedOut(ctx, proxy)
 	}
 
 	filter := funcs.And(

--- a/x/multisig/keeper/snapshotter_test.go
+++ b/x/multisig/keeper/snapshotter_test.go
@@ -68,7 +68,7 @@ func TestSnapshotCreator_CreateSnapshot(t *testing.T) {
 				return consAddr.Equals(tombstonedAddr)
 			}}
 
-		keygen = &mock.KeygenParticipatorMock{IsOptOutFunc: func(sdk.Context, sdk.AccAddress) bool {
+		keygen = &mock.KeygenParticipatorMock{HasOptedOutFunc: func(sdk.Context, sdk.AccAddress) bool {
 			return false
 		}}
 

--- a/x/multisig/types/expected_keepers.go
+++ b/x/multisig/types/expected_keepers.go
@@ -31,7 +31,7 @@ type Keeper interface {
 
 // KeygenParticipator can check if a participant opted out of future keygens
 type KeygenParticipator interface {
-	IsOptOut(ctx sdk.Context, participant sdk.AccAddress) bool
+	HasOptedOut(ctx sdk.Context, participant sdk.AccAddress) bool
 }
 
 // Snapshotter provides snapshot keeper functionality

--- a/x/multisig/types/mock/expected_keepers.go
+++ b/x/multisig/types/mock/expected_keepers.go
@@ -1076,8 +1076,8 @@ var _ types.KeygenParticipator = &KeygenParticipatorMock{}
 //
 // 		// make and configure a mocked types.KeygenParticipator
 // 		mockedKeygenParticipator := &KeygenParticipatorMock{
-// 			IsOptOutFunc: func(ctx sdk.Context, participant sdk.AccAddress) bool {
-// 				panic("mock out the IsOptOut method")
+// 			HasOptedOutFunc: func(ctx sdk.Context, participant sdk.AccAddress) bool {
+// 				panic("mock out the HasOptedOut method")
 // 			},
 // 		}
 //
@@ -1086,26 +1086,26 @@ var _ types.KeygenParticipator = &KeygenParticipatorMock{}
 //
 // 	}
 type KeygenParticipatorMock struct {
-	// IsOptOutFunc mocks the IsOptOut method.
-	IsOptOutFunc func(ctx sdk.Context, participant sdk.AccAddress) bool
+	// HasOptedOutFunc mocks the HasOptedOut method.
+	HasOptedOutFunc func(ctx sdk.Context, participant sdk.AccAddress) bool
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// IsOptOut holds details about calls to the IsOptOut method.
-		IsOptOut []struct {
+		// HasOptedOut holds details about calls to the HasOptedOut method.
+		HasOptedOut []struct {
 			// Ctx is the ctx argument value.
 			Ctx sdk.Context
 			// Participant is the participant argument value.
 			Participant sdk.AccAddress
 		}
 	}
-	lockIsOptOut sync.RWMutex
+	lockHasOptedOut sync.RWMutex
 }
 
-// IsOptOut calls IsOptOutFunc.
-func (mock *KeygenParticipatorMock) IsOptOut(ctx sdk.Context, participant sdk.AccAddress) bool {
-	if mock.IsOptOutFunc == nil {
-		panic("KeygenParticipatorMock.IsOptOutFunc: method is nil but KeygenParticipator.IsOptOut was just called")
+// HasOptedOut calls HasOptedOutFunc.
+func (mock *KeygenParticipatorMock) HasOptedOut(ctx sdk.Context, participant sdk.AccAddress) bool {
+	if mock.HasOptedOutFunc == nil {
+		panic("KeygenParticipatorMock.HasOptedOutFunc: method is nil but KeygenParticipator.HasOptedOut was just called")
 	}
 	callInfo := struct {
 		Ctx         sdk.Context
@@ -1114,16 +1114,16 @@ func (mock *KeygenParticipatorMock) IsOptOut(ctx sdk.Context, participant sdk.Ac
 		Ctx:         ctx,
 		Participant: participant,
 	}
-	mock.lockIsOptOut.Lock()
-	mock.calls.IsOptOut = append(mock.calls.IsOptOut, callInfo)
-	mock.lockIsOptOut.Unlock()
-	return mock.IsOptOutFunc(ctx, participant)
+	mock.lockHasOptedOut.Lock()
+	mock.calls.HasOptedOut = append(mock.calls.HasOptedOut, callInfo)
+	mock.lockHasOptedOut.Unlock()
+	return mock.HasOptedOutFunc(ctx, participant)
 }
 
-// IsOptOutCalls gets all the calls that were made to IsOptOut.
+// HasOptedOutCalls gets all the calls that were made to HasOptedOut.
 // Check the length with:
-//     len(mockedKeygenParticipator.IsOptOutCalls())
-func (mock *KeygenParticipatorMock) IsOptOutCalls() []struct {
+//     len(mockedKeygenParticipator.HasOptedOutCalls())
+func (mock *KeygenParticipatorMock) HasOptedOutCalls() []struct {
 	Ctx         sdk.Context
 	Participant sdk.AccAddress
 } {
@@ -1131,8 +1131,8 @@ func (mock *KeygenParticipatorMock) IsOptOutCalls() []struct {
 		Ctx         sdk.Context
 		Participant sdk.AccAddress
 	}
-	mock.lockIsOptOut.RLock()
-	calls = mock.calls.IsOptOut
-	mock.lockIsOptOut.RUnlock()
+	mock.lockHasOptedOut.RLock()
+	calls = mock.calls.HasOptedOut
+	mock.lockHasOptedOut.RUnlock()
 	return calls
 }

--- a/x/reward/abci.go
+++ b/x/reward/abci.go
@@ -72,7 +72,7 @@ func handleKeyMgmtInflation(ctx sdk.Context, k types.Rewarder, m types.Minter, s
 	isProxyActive := func(v snapshot.ValidatorI) bool {
 		proxy, isActive := ss.GetProxy(ctx, v.GetOperator())
 
-		return isActive && !mSig.IsOptOut(ctx, proxy)
+		return isActive && !mSig.HasOptedOut(ctx, proxy)
 	}
 
 	var validators []snapshot.ValidatorI

--- a/x/reward/types/expected_keepers.go
+++ b/x/reward/types/expected_keepers.go
@@ -67,6 +67,7 @@ type Banker interface {
 
 // MultiSig provides mutlisig functionality
 type MultiSig interface {
+	IsOptOut(ctx sdk.Context, participant sdk.AccAddress) bool
 }
 
 // Snapshotter provides snapshot functionality

--- a/x/reward/types/expected_keepers.go
+++ b/x/reward/types/expected_keepers.go
@@ -67,7 +67,7 @@ type Banker interface {
 
 // MultiSig provides mutlisig functionality
 type MultiSig interface {
-	IsOptOut(ctx sdk.Context, participant sdk.AccAddress) bool
+	HasOptedOut(ctx sdk.Context, participant sdk.AccAddress) bool
 }
 
 // Snapshotter provides snapshot functionality


### PR DESCRIPTION
## Description

Validators who have opted out of keygen should be excluded from reward distribution

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
