### PR TITLE
fix!: add delimiter to paginated kv store iterator by prefix

### DIFF
--- a/x/evm/keeper/chainKeeper.go
+++ b/x/evm/keeper/chainKeeper.go
@@ -383,7 +383,8 @@ func (k chainKeeper) getConfirmedDeposits(ctx sdk.Context) []types.ERC20Deposit 
 func (k chainKeeper) GetConfirmedDepositsPaginated(ctx sdk.Context, pageRequest *query.PageRequest) ([]types.ERC20Deposit, *query.PageResponse, error) {
 	var deposits []types.ERC20Deposit
 
-	resp, err := query.Paginate(prefix.NewStore(k.getStore(ctx).KVStore, utils.KeyFromStr(confirmedDepositPrefix).AsKey()), pageRequest, func(key []byte, value []byte) error {
+	// TODO: refactor iteration over values using a prefix to avoid collisions
+	resp, err := query.Paginate(prefix.NewStore(k.getStore(ctx).KVStore, append(utils.KeyFromStr(confirmedDepositPrefix).AsKey(), []byte(key.DefaultDelimiter)...)), pageRequest, func(key []byte, value []byte) error {
 		var deposit types.ERC20Deposit
 		k.cdc.MustUnmarshalLengthPrefixed(value, &deposit)
 		deposits = append(deposits, deposit)

--- a/x/nexus/keeper/keeper_test.go
+++ b/x/nexus/keeper/keeper_test.go
@@ -41,6 +41,8 @@ func addressValidator() types.Router {
 			switch chain {
 			case axelarnet.Axelarnet.Name:
 				prefix = "axelar"
+			case "terra-2":
+				prefix = "terra"
 			default:
 				prefix = strings.ToLower(chain.String())
 			}
@@ -308,7 +310,7 @@ func genCosmosAddr(chain string) string {
 	switch strings.ToLower(chain) {
 	case "axelarnet":
 		prefix = "axelar"
-	case "terra":
+	case "terra", "terra-2":
 		prefix = "terra"
 	default:
 		prefix = ""

--- a/x/nexus/keeper/keeper_test.go
+++ b/x/nexus/keeper/keeper_test.go
@@ -41,7 +41,7 @@ func addressValidator() types.Router {
 			switch chain {
 			case axelarnet.Axelarnet.Name:
 				prefix = "axelar"
-			case "terra-2":
+			case "terra", "terra-2":
 				prefix = "terra"
 			default:
 				prefix = strings.ToLower(chain.String())

--- a/x/nexus/keeper/transfer.go
+++ b/x/nexus/keeper/transfer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/axelarnetwork/axelar-core/utils"
 	"github.com/axelarnetwork/axelar-core/utils/events"
+	"github.com/axelarnetwork/axelar-core/utils/key"
 	"github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	"github.com/axelarnetwork/axelar-core/x/nexus/types"
 )
@@ -247,7 +248,8 @@ func (k Keeper) GetTransfersForChainPaginated(ctx sdk.Context, chain exported.Ch
 		return transfers, &query.PageResponse{}, nil
 	}
 
-	resp, err := query.Paginate(prefix.NewStore(k.getStore(ctx).KVStore, getTransferPrefix(chain.Name, state).AsKey()), pageRequest, func(key []byte, value []byte) error {
+	// TODO: refactor iteration over values using a prefix to avoid collisions
+	resp, err := query.Paginate(prefix.NewStore(k.getStore(ctx).KVStore, append(getTransferPrefix(chain.Name, state).AsKey(), []byte(key.DefaultDelimiter)...)), pageRequest, func(key []byte, value []byte) error {
 		var transfer exported.CrossChainTransfer
 		k.cdc.MustUnmarshalLengthPrefixed(value, &transfer)
 


### PR DESCRIPTION
## Description

- Add delimiter to prefix key used by paginated iterator

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
