### PR TITLE
fix(axelarnet): remove axelarnet module address from bank keeper blocked list

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -124,7 +124,7 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/vote"
 	voteKeeper "github.com/axelarnetwork/axelar-core/x/vote/keeper"
 	voteTypes "github.com/axelarnetwork/axelar-core/x/vote/types"
-
+	"github.com/axelarnetwork/utils/maps"
 	// Override with generated statik docs
 	_ "github.com/axelarnetwork/axelar-core/client/docs/statik"
 )
@@ -301,7 +301,14 @@ func NewAxelarApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest
 		appCodec, keys[authtypes.StoreKey], app.getSubspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, maccPerms,
 	)
 	bankK := bankkeeper.NewBaseKeeper(
-		appCodec, keys[banktypes.StoreKey], accountK, app.getSubspace(banktypes.ModuleName), app.ModuleAccountAddrs(),
+		appCodec, keys[banktypes.StoreKey], accountK, app.getSubspace(banktypes.ModuleName),
+		maps.Filter(app.ModuleAccountAddrs(), func(addr string, _ bool) bool {
+			// we do not rely on internal balance tracking for invariance checks in the axelarnet module
+			// (https://github.com/cosmos/cosmos-sdk/issues/12825 for more details on the purpose of the blocked list),
+			// but the module address must be able to use ibc transfers,
+			// so we exclude this address from the blocked list
+			return addr != authtypes.NewModuleAddress(axelarnetTypes.ModuleName).String()
+		}),
 	)
 	stakingK := stakingkeeper.NewKeeper(
 		appCodec, keys[stakingtypes.StoreKey], accountK, bankK, app.getSubspace(stakingtypes.ModuleName),

--- a/app/app.go
+++ b/app/app.go
@@ -125,6 +125,7 @@ import (
 	voteKeeper "github.com/axelarnetwork/axelar-core/x/vote/keeper"
 	voteTypes "github.com/axelarnetwork/axelar-core/x/vote/types"
 	"github.com/axelarnetwork/utils/maps"
+
 	// Override with generated statik docs
 	_ "github.com/axelarnetwork/axelar-core/client/docs/statik"
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/armon/go-metrics v0.4.0
 	github.com/axelarnetwork/tm-events v0.0.0-20221019195821-9a3f03bc6ca6
-	github.com/axelarnetwork/utils v0.0.0-20221109010026-d918beb2a4d1
+	github.com/axelarnetwork/utils v0.0.0-20221116153024-b614f3c8f700
 	github.com/btcsuite/btcd v0.22.1
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0
 	github.com/cosmos/cosmos-sdk v0.45.9

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/axelarnetwork/utils v0.0.0-20221108233636-29d8b6fc05c2 h1:SYPSpvYuTkP
 github.com/axelarnetwork/utils v0.0.0-20221108233636-29d8b6fc05c2/go.mod h1:hgQUlG5EZLS78PSenpdDCrTYZPigjqWC+vt8IjN86Mg=
 github.com/axelarnetwork/utils v0.0.0-20221109010026-d918beb2a4d1 h1:1bJexuozidDDEkSxFHIQqZ83m+/0HCe4zKH4LyLgMxs=
 github.com/axelarnetwork/utils v0.0.0-20221109010026-d918beb2a4d1/go.mod h1:hgQUlG5EZLS78PSenpdDCrTYZPigjqWC+vt8IjN86Mg=
+github.com/axelarnetwork/utils v0.0.0-20221116153024-b614f3c8f700 h1:z6aerfrS3aQsAes8ugmXGVhjzJHO/OXjqHzfejHexQk=
+github.com/axelarnetwork/utils v0.0.0-20221116153024-b614f3c8f700/go.mod h1:hgQUlG5EZLS78PSenpdDCrTYZPigjqWC+vt8IjN86Mg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
The module address is not allowed to send IBC transfers (which the module relies on) as long as it is on the bank keeper's blocked list. On the other hand, the axelarnet module does not need to keep the invariant `actual module balance == expected module balance`, since we never track that balance outside the bank keeper to begin with.