### PR TITLE
fix(evm): migrate broken burner info key

### DIFF
--- a/x/evm/keeper/chainKeeper.go
+++ b/x/evm/keeper/chainKeeper.go
@@ -34,8 +34,10 @@ var (
 	burnedDepositPrefix         = "burned_deposit"
 	commandBatchPrefix          = "batched_commands"
 	commandPrefix               = "command"
-	burnerAddrPrefix            = "burnerAddr"
-	eventPrefix                 = utils.KeyFromStr("event")
+
+	burnerAddrPrefixDeprecated = "burnerAddr" // Deprecated
+	burnerAddrPrefix           = key.FromUInt[uint](1)
+	eventPrefix                = utils.KeyFromStr("event")
 
 	commandQueueName        = "cmd_queue"
 	confirmedEventQueueName = "confirmed_event_queue"
@@ -97,14 +99,13 @@ func (k chainKeeper) GetMinVoterCount(ctx sdk.Context) int64 {
 // SetBurnerInfo saves the burner info for a given address
 func (k chainKeeper) SetBurnerInfo(ctx sdk.Context, burnerInfo types.BurnerInfo) {
 	funcs.MustNoErr(
-		k.getStore(ctx).SetNewValidated(
-			key.FromStr(burnerAddrPrefix).Append(key.FromStr(burnerInfo.BurnerAddress.Hex())), &burnerInfo))
+		k.getStore(ctx).SetNewValidated(burnerAddrPrefix.Append(key.FromStr(burnerInfo.BurnerAddress.Hex())), &burnerInfo))
 }
 
 // GetBurnerInfo retrieves the burner info for a given address
 func (k chainKeeper) GetBurnerInfo(ctx sdk.Context, burnerAddr types.Address) *types.BurnerInfo {
 	var result types.BurnerInfo
-	if !k.getStore(ctx).GetNew(key.FromStr(burnerAddrPrefix).Append(key.FromStr(burnerAddr.Hex())), &result) {
+	if !k.getStore(ctx).GetNew(burnerAddrPrefix.Append(key.FromStr(burnerAddr.Hex())), &result) {
 		return nil
 	}
 
@@ -112,7 +113,7 @@ func (k chainKeeper) GetBurnerInfo(ctx sdk.Context, burnerAddr types.Address) *t
 }
 
 func (k chainKeeper) getBurnerInfos(ctx sdk.Context) []types.BurnerInfo {
-	iter := k.getStore(ctx).Iterator(utils.LowerCaseKey(burnerAddrPrefix))
+	iter := k.getStore(ctx).IteratorNew(burnerAddrPrefix)
 	defer utils.CloseLogError(iter, k.Logger(ctx))
 
 	var burners []types.BurnerInfo

--- a/x/evm/keeper/migrate.go
+++ b/x/evm/keeper/migrate.go
@@ -45,7 +45,7 @@ func migrateBurnerInfoForChain(ctx sdk.Context, k *BaseKeeper, chain exported.Ch
 		iterBurnerAddr := ck.getStore(ctx).Iterator(utils.KeyFromStr(oldKey))
 
 		if !iterBurnerAddr.Valid() {
-			break
+			return iterBurnerAddr.Close()
 		}
 		var burnerInfo types.BurnerInfo
 		for ; iterBurnerAddr.Valid() && len(keysToDelete) < 1000; iterBurnerAddr.Next() {
@@ -62,11 +62,9 @@ func migrateBurnerInfoForChain(ctx sdk.Context, k *BaseKeeper, chain exported.Ch
 			ck.getStore(ctx).DeleteRaw(burnerKey)
 		}
 
+		ck.Logger(ctx).Debug(fmt.Sprintf("migrated %d burner info keys for chain %s", len(keysToDelete), chain.Name))
 		keysToDelete = keysToDelete[:0]
-
-		ck.Logger(ctx).Debug(fmt.Sprintf("migrated %d burner info keys for chain %s", len(keysToDelete), chain.String()))
 	}
-	return nil
 }
 
 // AlwaysMigrateBytecode migrates contracts bytecode for all evm chains (CRUCIAL, DO NOT DELETE AND ALWAYS REGISTER)

--- a/x/evm/keeper/migrate.go
+++ b/x/evm/keeper/migrate.go
@@ -40,6 +40,7 @@ func migrateBurnerInfoForChain(ctx sdk.Context, k *BaseKeeper, chain exported.Ch
 	}
 
 	// migrate in batches so memory pressure doesn't become too large
+	keysToDelete := make([][]byte, 0, 1000)
 	for {
 		iterBurnerAddr := ck.getStore(ctx).Iterator(utils.KeyFromStr(oldKey))
 
@@ -47,7 +48,6 @@ func migrateBurnerInfoForChain(ctx sdk.Context, k *BaseKeeper, chain exported.Ch
 			break
 		}
 		var burnerInfo types.BurnerInfo
-		keysToDelete := make([][]byte, 0, 1000)
 		for ; iterBurnerAddr.Valid() && len(keysToDelete) < 1000; iterBurnerAddr.Next() {
 			iterBurnerAddr.UnmarshalValue(&burnerInfo)
 			ck.SetBurnerInfo(ctx, burnerInfo)

--- a/x/evm/keeper/migrate.go
+++ b/x/evm/keeper/migrate.go
@@ -25,7 +25,7 @@ func Migrate7To8(k *BaseKeeper, n types.Nexus) func(ctx sdk.Context) error {
 				return err
 			}
 
-			k.Logger(ctx).Info(fmt.Sprintf("migrated all burner info keys for chain %s", chain.String()))
+			k.Logger(ctx).Info(fmt.Sprintf("migrated all burner info keys for chain %s", chain.Name))
 
 		}
 		k.Logger(ctx).Info("burner info keys migration complete")

--- a/x/evm/keeper/migrate.go
+++ b/x/evm/keeper/migrate.go
@@ -62,6 +62,8 @@ func migrateBurnerInfoForChain(ctx sdk.Context, k *BaseKeeper, chain exported.Ch
 			ck.getStore(ctx).DeleteRaw(burnerKey)
 		}
 
+		keysToDelete = keysToDelete[:0]
+
 		ck.Logger(ctx).Debug(fmt.Sprintf("migrated %d burner info keys for chain %s", len(keysToDelete), chain.String()))
 	}
 	return nil

--- a/x/evm/keeper/migrate.go
+++ b/x/evm/keeper/migrate.go
@@ -47,7 +47,7 @@ func migrateBurnerInfoForChain(ctx sdk.Context, k *BaseKeeper, chain exported.Ch
 			break
 		}
 		var burnerInfo types.BurnerInfo
-		var keysToDelete [][]byte
+		keysToDelete := make([][]byte, 0, 1000)
 		for ; iterBurnerAddr.Valid() && len(keysToDelete) < 1000; iterBurnerAddr.Next() {
 			iterBurnerAddr.UnmarshalValue(&burnerInfo)
 			ck.SetBurnerInfo(ctx, burnerInfo)

--- a/x/evm/keeper/migrate_test.go
+++ b/x/evm/keeper/migrate_test.go
@@ -79,8 +79,8 @@ func TestGetMigrationHandler(t *testing.T) {
 		Then("all burner infos have been migrated", func(t *testing.T) {
 			ck := funcs.Must(k.ForChain(ctx, exported.Ethereum.Name))
 
-			for _, info := range burnerInfos {
-				assert.NotNil(t, ck.GetBurnerInfo(ctx, info.BurnerAddress))
+			for i, info := range burnerInfos {
+				assert.Equal(t, &burnerInfos[i], ck.GetBurnerInfo(ctx, info.BurnerAddress))
 			}
 		}).Run(t, 20)
 }

--- a/x/evm/keeper/migrate_test.go
+++ b/x/evm/keeper/migrate_test.go
@@ -1,8 +1,11 @@
 package keeper_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramsKeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	"github.com/stretchr/testify/assert"
@@ -18,34 +21,30 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/evm/types/testutils"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	"github.com/axelarnetwork/utils/funcs"
+	"github.com/axelarnetwork/utils/slices"
 	. "github.com/axelarnetwork/utils/test"
 )
 
 func TestGetMigrationHandler(t *testing.T) {
 	var (
 		ctx         sdk.Context
+		cdc         codec.Codec
+		storekey    = sdk.NewKVStoreKey(types.StoreKey)
 		k           *keeper.BaseKeeper
 		handler     func(ctx sdk.Context) error
 		err         error
-		expectedIDs []types.CommandID
+		burnerInfos []types.BurnerInfo
 	)
-
-	cmdTypes := map[types.CommandType]string{
-		types.COMMAND_TYPE_MINT_TOKEN:                      "mintToken",
-		types.COMMAND_TYPE_DEPLOY_TOKEN:                    "deployToken",
-		types.COMMAND_TYPE_BURN_TOKEN:                      "burnToken",
-		types.COMMAND_TYPE_TRANSFER_OPERATORSHIP:           "transferOperatorship",
-		types.COMMAND_TYPE_APPROVE_CONTRACT_CALL_WITH_MINT: "approveContractCallWithMint",
-		types.COMMAND_TYPE_APPROVE_CONTRACT_CALL:           "approveContractCall",
-	}
 
 	Given("a context", func() {
 		ctx = sdk.NewContext(fake.NewMultiStore(), tmproto.Header{}, false, log.TestingLogger())
 	}).
 		Given("a keeper", func() {
 			encCfg := params.MakeEncodingConfig()
-			pk := paramsKeeper.NewKeeper(encCfg.Codec, encCfg.Amino, sdk.NewKVStoreKey("params"), sdk.NewKVStoreKey("tparams"))
-			k = keeper.NewKeeper(encCfg.Codec, sdk.NewKVStoreKey(types.StoreKey), pk)
+			cdc = encCfg.Codec
+			pk := paramsKeeper.NewKeeper(cdc, encCfg.Amino, sdk.NewKVStoreKey("params"), sdk.NewKVStoreKey("tparams"))
+
+			k = keeper.NewKeeper(cdc, storekey, pk)
 			k.InitChains(ctx)
 			funcs.MustNoErr(k.CreateChain(ctx, types.DefaultParams()[0]))
 		}).
@@ -53,31 +52,22 @@ func TestGetMigrationHandler(t *testing.T) {
 			n := &mock.NexusMock{
 				GetChainsFunc: func(sdk.Context) []nexus.Chain { return []nexus.Chain{exported.Ethereum} },
 			}
-			handler = keeper.Migrate6To7(k, n)
+			handler = keeper.Migrate7To8(k, n)
 		}).
-		Given("there are old commands", func() {
-			ck := funcs.Must(k.ForChain(ctx, exported.Ethereum.Name))
+		Given("there are only old burner infos", func() {
+			burnerInfos = slices.Expand2(testutils.RandomBurnerInfo, 20)
 
-			expectedIDs = []types.CommandID{}
-			for i := 0; i < 3; i++ {
-				cmd := testutils.RandomCommand()
-				cmd.Command = cmdTypes[cmd.Type]
-				cmd.Type = types.COMMAND_TYPE_UNSPECIFIED
-				expectedIDs = append(expectedIDs, cmd.ID)
-				funcs.MustNoErr(ck.EnqueueCommand(ctx, cmd))
+			for i := 0; i < 10; i++ {
+				info := burnerInfos[i]
+				ctx.KVStore(storekey).Set(
+					[]byte(fmt.Sprintf("chain_%s_burnerAddr_%s", strings.ToLower(exported.Ethereum.Name.String()), info.BurnerAddress.Hex())),
+					cdc.MustMarshalLengthPrefixed(&info))
 			}
-
-			_ = funcs.Must(ck.CreateNewBatchToSign(ctx))
-		}).
-		Given("there are commands in the queue", func() {
-			ck := funcs.Must(k.ForChain(ctx, exported.Ethereum.Name))
-
-			for i := 0; i < 2; i++ {
-				cmd := testutils.RandomCommand()
-				cmd.Command = cmdTypes[cmd.Type]
-				cmd.Type = types.COMMAND_TYPE_UNSPECIFIED
-				expectedIDs = append(expectedIDs, cmd.ID)
-				funcs.MustNoErr(ck.EnqueueCommand(ctx, cmd))
+			for i := 10; i < 20; i++ {
+				info := burnerInfos[i]
+				ctx.KVStore(storekey).Set(
+					[]byte(fmt.Sprintf("chain_%s_burneraddr_%s", strings.ToLower(exported.Ethereum.Name.String()), info.BurnerAddress.Hex())),
+					cdc.MustMarshalLengthPrefixed(&info))
 			}
 		}).
 		When("calling migration", func() {
@@ -86,14 +76,11 @@ func TestGetMigrationHandler(t *testing.T) {
 		Then("it succeeds", func(t *testing.T) {
 			assert.NoError(t, err)
 		}).
-		Then("all commands have been migrated", func(t *testing.T) {
+		Then("all burner infos have been migrated", func(t *testing.T) {
 			ck := funcs.Must(k.ForChain(ctx, exported.Ethereum.Name))
 
-			for _, id := range expectedIDs {
-				cmd, ok := ck.GetCommand(ctx, id)
-				assert.True(t, ok)
-
-				assert.NotEqual(t, types.COMMAND_TYPE_UNSPECIFIED, cmd.Type)
+			for _, info := range burnerInfos {
+				assert.NotNil(t, ck.GetBurnerInfo(ctx, info.BurnerAddress))
 			}
 		}).Run(t, 20)
 }

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -160,7 +160,7 @@ func (am AppModule) LegacyQuerierHandler(*codec.LegacyAmino) sdk.Querier {
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterQueryServiceServer(cfg.QueryServer(), keeper.NewGRPCQuerier(am.keeper, am.nexus, am.multisig))
 
-	err := cfg.RegisterMigration(types.ModuleName, 6, keeper.AlwaysMigrateBytecode(am.keeper, am.nexus, keeper.Migrate7To8(am.keeper, am.nexus)))
+	err := cfg.RegisterMigration(types.ModuleName, 7, keeper.AlwaysMigrateBytecode(am.keeper, am.nexus, keeper.Migrate7To8(am.keeper, am.nexus)))
 	if err != nil {
 		panic(err)
 	}

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -160,7 +160,7 @@ func (am AppModule) LegacyQuerierHandler(*codec.LegacyAmino) sdk.Querier {
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterQueryServiceServer(cfg.QueryServer(), keeper.NewGRPCQuerier(am.keeper, am.nexus, am.multisig))
 
-	err := cfg.RegisterMigration(types.ModuleName, 6, keeper.AlwaysMigrateBytecode(am.keeper, am.nexus, keeper.Migrate6To7(am.keeper, am.nexus)))
+	err := cfg.RegisterMigration(types.ModuleName, 6, keeper.AlwaysMigrateBytecode(am.keeper, am.nexus, keeper.Migrate7To8(am.keeper, am.nexus)))
 	if err != nil {
 		panic(err)
 	}
@@ -179,4 +179,4 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 }
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 7 }
+func (AppModule) ConsensusVersion() uint64 { return 8 }


### PR DESCRIPTION
the burner info key has capital letters in it, which is being ignored after the recent evm module refactoring. This means values from before the refactoring aren't found anymore. This migrates the old key scheme to a new one to make them available again.