### PR TITLE
fix(vald): introduce errgroup so vald stops when one if its processes fails

### DIFF
--- a/vald/start.go
+++ b/vald/start.go
@@ -3,7 +3,6 @@ package vald
 import (
 	"context"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -26,6 +25,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/tendermint/tendermint/libs/log"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/axelarnetwork/axelar-core/app"
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd/utils"

--- a/vald/start_test.go
+++ b/vald/start_test.go
@@ -27,10 +27,10 @@ func TestPanic(t *testing.T) {
 		}
 
 		go func() {
-			for i := 0; i < 1000; i++ {
+			for i := 0; i < 100; i++ {
 				newBlock()
 			}
-			time.Sleep(2 * time.Millisecond)
+			time.Sleep(5 * time.Millisecond)
 			newBlock()
 		}()
 
@@ -38,7 +38,7 @@ func TestPanic(t *testing.T) {
 		case <-testTimeout.Done():
 			return
 		case <-blockTimeout.Done():
-			assert.Equal(t, 1000, blocksSeen)
+			assert.Equal(t, 100, blocksSeen)
 			panic("no new blocks discovered, is the chain halted?")
 		}
 	})


### PR DESCRIPTION
We replace the job manager with an errgroup so the context all of vald jobs run under gets cancelled as soon as one of the jobs fails. This should allow vald to shut down and log the error instead of simply stalling. In particular, the context is going to get cancelled when there are no new blocks for a configurable length of time