### PR TITLE
refactor: remove unused new keys

### DIFF
--- a/x/axelarnet/keeper/keeper.go
+++ b/x/axelarnet/keeper/keeper.go
@@ -20,20 +20,16 @@ import (
 )
 
 var (
-	cosmosChainPrefix = key.FromStr("cosmos_chain")  // Deprecated: migrate to cosmosChainPrefixNew
-	feeCollector      = key.FromStr("fee_collector") // Deprecated: migrate to feeCollectorNew
+	cosmosChainPrefix = key.FromStr("cosmos_chain")
+	feeCollector      = key.FromStr("fee_collector")
 
-	transferPrefix       = key.FromStr("ibc_transfer") // Deprecated: migrate to transferPrefixNew
-	ibcTransferQueueName = "route_transfer_queue"      // Deprecated: migrate to ibcTransferQueueNameNew
+	transferPrefix       = key.FromStr("ibc_transfer") 
+	ibcTransferQueueName = "route_transfer_queue"
 
 	_ = key.RegisterStaticKey(types.ModuleName, 2) // failedTransferPrefix is deprecated in v0.23
 
 	seqIDMappingPrefix      = key.RegisterStaticKey(types.ModuleName, 3)
 	ibcPathPrefix           = key.RegisterStaticKey(types.ModuleName, 4)
-	cosmosChainPrefixNew    = key.RegisterStaticKey(types.ModuleName, 5)
-	feeCollectorNew         = key.RegisterStaticKey(types.ModuleName, 6)
-	transferPrefixNew       = key.RegisterStaticKey(types.ModuleName, 7)
-	ibcTransferQueueNameNew = key.RegisterStaticKey(types.ModuleName, 8)
 
 	// reserved values
 	// nonceKey is deprecated in v0.23

--- a/x/axelarnet/keeper/keeper.go
+++ b/x/axelarnet/keeper/keeper.go
@@ -23,13 +23,13 @@ var (
 	cosmosChainPrefix = key.FromStr("cosmos_chain")
 	feeCollector      = key.FromStr("fee_collector")
 
-	transferPrefix       = key.FromStr("ibc_transfer") 
+	transferPrefix       = key.FromStr("ibc_transfer")
 	ibcTransferQueueName = "route_transfer_queue"
 
 	_ = key.RegisterStaticKey(types.ModuleName, 2) // failedTransferPrefix is deprecated in v0.23
 
-	seqIDMappingPrefix      = key.RegisterStaticKey(types.ModuleName, 3)
-	ibcPathPrefix           = key.RegisterStaticKey(types.ModuleName, 4)
+	seqIDMappingPrefix = key.RegisterStaticKey(types.ModuleName, 3)
+	ibcPathPrefix      = key.RegisterStaticKey(types.ModuleName, 4)
 
 	// reserved values
 	// nonceKey is deprecated in v0.23

--- a/x/evm/keeper/baseKeeper.go
+++ b/x/evm/keeper/baseKeeper.go
@@ -16,11 +16,8 @@ import (
 )
 
 var (
-	chainPrefix    = utils.KeyFromStr("chain") // Deprecated: migrate to chainPrefixNew
-	subspacePrefix = "subspace"                // Deprecated: migrate to subspacePrefixNew
-
-	chainPrefixNew    = key.RegisterStaticKey(types.ModuleName, 1)
-	subspacePrefixNew = key.RegisterStaticKey(types.ModuleName, 2)
+	chainPrefix    = utils.KeyFromStr("chain")
+	subspacePrefix = "subspace"
 )
 
 var _ types.BaseKeeper = &BaseKeeper{}

--- a/x/evm/keeper/chainKeeper.go
+++ b/x/evm/keeper/chainKeeper.go
@@ -24,36 +24,22 @@ import (
 )
 
 var (
-	gatewayKey                       = key.FromStr("gateway")                        // Deprecated: migrate to gatewayKeyNew
-	unsignedBatchIDKey               = key.FromStr("unsigned_command_batch_id")      // Deprecated: migrate to unsignedBatchIDKeyNew
-	latestSignedBatchIDKey           = key.FromStr("latest_signed_command_batch_id") // Deprecated: migrate to latestSignedBatchIDKeyNew
-	tokenMetadataByAssetPrefix       = "token_deployment_by_asset"                   // Deprecated: migrate to tokenMetadataByAssetPrefixNew
-	tokenMetadataBySymbolPrefix      = key.FromStr("token_deployment_by_symbol")     // Deprecated: migrate to tokenMetadataBySymbolPrefixNew
-	confirmedDepositPrefixDeprecated = "confirmed_deposit"                           // Deprecated
-	burnedDepositPrefixDeprecated    = "burned_deposit"                              // Deprecated
-	commandBatchPrefix               = "batched_commands"                            // Deprecated: migrate to commandBatchPrefixNew
-	commandPrefix                    = "command"                                     // Deprecated: migrate to commandPrefixNew
-	eventPrefix                      = utils.KeyFromStr("event")                     // Deprecated: migrate to eventPrefixNew
-	confirmedEventQueueName          = "confirmed_event_queue"                       // Deprecated: migrate to confirmedEventQueueNameNew
-	commandQueueName                 = "cmd_queue"                                   // Deprecated: migrate to commandQueueNameNew
+	gatewayKey                       = key.FromStr("gateway")
+	unsignedBatchIDKey               = key.FromStr("unsigned_command_batch_id")
+	latestSignedBatchIDKey           = key.FromStr("latest_signed_command_batch_id")
+	tokenMetadataByAssetPrefix       = "token_deployment_by_asset"
+	tokenMetadataBySymbolPrefix      = key.FromStr("token_deployment_by_symbol")
+	confirmedDepositPrefixDeprecated = "confirmed_deposit" // Deprecated
+	burnedDepositPrefixDeprecated    = "burned_deposit"    // Deprecated
+	commandBatchPrefix               = "batched_commands"
+	commandPrefix                    = "command"
+	eventPrefix                      = utils.KeyFromStr("event")
+	confirmedEventQueueName          = "confirmed_event_queue"
+	commandQueueName                 = "cmd_queue"
 
 	burnerAddrPrefix       = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 1)
 	confirmedDepositPrefix = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 2)
 	burnedDepositPrefix    = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 3)
-
-	gatewayKeyNew                  = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 4)
-	unsignedBatchIDKeyNew          = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 5)
-	latestSignedBatchIDKeyNew      = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 6)
-	tokenMetadataByAssetPrefixNew  = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 7)
-	tokenMetadataBySymbolPrefixNew = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 8)
-	confirmedDepositPrefixNew      = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 9)
-	burnedDepositPrefixNew         = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 10)
-	commandBatchPrefixNew          = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 11)
-	commandPrefixNew               = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 12)
-	burnerAddrPrefixNew            = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 13)
-	eventPrefixNew                 = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 14)
-	commandQueueNameNew            = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 15)
-	confirmedEventQueueNameNew     = key.RegisterStaticKey(types.ModuleName+types.ChainNamespace, 16)
 )
 
 var _ types.ChainKeeper = chainKeeper{}

--- a/x/multisig/keeper/keeper.go
+++ b/x/multisig/keeper/keeper.go
@@ -14,24 +14,16 @@ import (
 )
 
 var (
-	keygenPrefix           = utils.KeyFromInt(1)   // Deprecated: migrate to keygenPrefixNew
-	signingPrefix          = utils.KeyFromInt(2)   // Deprecated: migrate to signingPrefixNew
-	keyPrefix              = utils.KeyFromInt(3)   // Deprecated: migrate to keyPrefixNew
-	expiryKeygenPrefix     = utils.KeyFromInt(4)   // Deprecated: migrate to expiryKeygenPrefixNew
-	expirySigningPrefix    = utils.KeyFromInt(5)   // Deprecated: migrate to expirySigningPrefixNew
-	keyEpochPrefix         = utils.KeyFromInt(6)   // Deprecated: migrate to keyEpochPrefixNew
-	keyRotationCountPrefix = utils.KeyFromInt(7)   // Deprecated: migrate to keyRotationCountPrefixNew
-	signingSessionCountKey = utils.KeyFromInt(100) // Deprecated: migrate to signingSessionCountKeyNew
+	keygenPrefix           = utils.KeyFromInt(1)
+	signingPrefix          = utils.KeyFromInt(2)
+	keyPrefix              = utils.KeyFromInt(3)
+	expiryKeygenPrefix     = utils.KeyFromInt(4)
+	expirySigningPrefix    = utils.KeyFromInt(5)
+	keyEpochPrefix         = utils.KeyFromInt(6)
+	keyRotationCountPrefix = utils.KeyFromInt(7)
+	signingSessionCountKey = utils.KeyFromInt(100)
 
-	keygenPrefixNew           = key.RegisterStaticKey(types.ModuleName, 1)
-	signingPrefixNew          = key.RegisterStaticKey(types.ModuleName, 2)
-	keyPrefixNew              = key.RegisterStaticKey(types.ModuleName, 3)
-	expiryKeygenPrefixNew     = key.RegisterStaticKey(types.ModuleName, 4)
-	expirySigningPrefixNew    = key.RegisterStaticKey(types.ModuleName, 5)
-	keyEpochPrefixNew         = key.RegisterStaticKey(types.ModuleName, 6)
-	keyRotationCountPrefixNew = key.RegisterStaticKey(types.ModuleName, 7)
 	keygenOptOutPrefix        = key.RegisterStaticKey(types.ModuleName, 8)
-	signingSessionCountKeyNew = key.RegisterStaticKey(types.ModuleName, 100)
 )
 
 var _ types.Keeper = &Keeper{}

--- a/x/multisig/keeper/keeper.go
+++ b/x/multisig/keeper/keeper.go
@@ -23,7 +23,7 @@ var (
 	keyRotationCountPrefix = utils.KeyFromInt(7)
 	signingSessionCountKey = utils.KeyFromInt(100)
 
-	keygenOptOutPrefix        = key.RegisterStaticKey(types.ModuleName, 8)
+	keygenOptOutPrefix = key.RegisterStaticKey(types.ModuleName, 8)
 )
 
 var _ types.Keeper = &Keeper{}

--- a/x/nexus/keeper/keeper.go
+++ b/x/nexus/keeper/keeper.go
@@ -16,25 +16,17 @@ import (
 var (
 	nonceKey = utils.KeyFromStr("nonce")
 
-	chainPrefix              = utils.KeyFromStr("chain")              // Deprecated: migrate to chainPrefixNew
-	chainStatePrefix         = utils.KeyFromStr("state")              // Deprecated: migrate to chainStatePrefixNew
-	chainByNativeAssetPrefix = utils.KeyFromStr("native_asset_chain") // Deprecated: migrate to chainByNativeAssetPrefixNew
-	linkedAddressesPrefix    = utils.KeyFromStr("linked_addresses")   // Deprecated: migrate to linkedAddressesPrefixNew
-	transferPrefix           = utils.KeyFromStr("transfer")           // Deprecated: migrate to transferPrefixNew
-	transferFee              = utils.KeyFromStr("fee")                // Deprecated: migrate to transferFeeNew
-	assetFeePrefix           = utils.KeyFromStr("asset_fee")          // Deprecated: migrate to assetFeePrefixNew
+	chainPrefix              = utils.KeyFromStr("chain")
+	chainStatePrefix         = utils.KeyFromStr("state")
+	chainByNativeAssetPrefix = utils.KeyFromStr("native_asset_chain")
+	linkedAddressesPrefix    = utils.KeyFromStr("linked_addresses")
+	transferPrefix           = utils.KeyFromStr("transfer")
+	transferFee              = utils.KeyFromStr("fee")
+	assetFeePrefix           = utils.KeyFromStr("asset_fee")
 
 	chainMaintainerStatePrefix = key.RegisterStaticKey(types.ModuleName, 1)
 	rateLimitPrefix            = key.RegisterStaticKey(types.ModuleName, 2)
 	transferEpochPrefix        = key.RegisterStaticKey(types.ModuleName, 3)
-
-	chainPrefixNew              = key.RegisterStaticKey(types.ModuleName, 4)
-	chainStatePrefixNew         = key.RegisterStaticKey(types.ModuleName, 5)
-	chainByNativeAssetPrefixNew = key.RegisterStaticKey(types.ModuleName, 6)
-	linkedAddressesPrefixNew    = key.RegisterStaticKey(types.ModuleName, 7)
-	transferPrefixNew           = key.RegisterStaticKey(types.ModuleName, 8)
-	transferFeeNew              = key.RegisterStaticKey(types.ModuleName, 9)
-	assetFeePrefixNew           = key.RegisterStaticKey(types.ModuleName, 10)
 
 	// temporary
 	// TODO: add description about what temporary means

--- a/x/permission/keeper/keeper.go
+++ b/x/permission/keeper/keeper.go
@@ -10,17 +10,13 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/axelarnetwork/axelar-core/utils"
-	"github.com/axelarnetwork/axelar-core/utils/key"
 	"github.com/axelarnetwork/axelar-core/x/permission/exported"
 	"github.com/axelarnetwork/axelar-core/x/permission/types"
 )
 
 var (
-	governanceKey = utils.KeyFromStr("governance") // Deprecated: migrate to governanceKeyNew
-	accountPrefix = utils.KeyFromStr("account")    // Deprecated: migrate to accountPrefixNew
-
-	governanceKeyNew = key.RegisterStaticKey(types.ModuleName, 1)
-	accountPrefixNew = key.RegisterStaticKey(types.ModuleName, 2)
+	governanceKey = utils.KeyFromStr("governance")
+	accountPrefix = utils.KeyFromStr("account")
 )
 
 // Keeper provides access to all state changes regarding the gov module

--- a/x/reward/keeper/keeper.go
+++ b/x/reward/keeper/keeper.go
@@ -17,11 +17,8 @@ import (
 )
 
 var (
-	poolNamePrefix      = "pool"   // Deprecated: migrate to poolNamePrefixNew
-	pendingRefundPrefix = "refund" // Deprecated: migrate to pendingRefundPrefixNew
-
-	poolNamePrefixNew      = key.RegisterStaticKey(types.ModuleName, 1)
-	pendingRefundPrefixNew = key.RegisterStaticKey(types.ModuleName, 2)
+	poolNamePrefix      = "pool"
+	pendingRefundPrefix = "refund"
 )
 
 var _ types.Rewarder = Keeper{}

--- a/x/snapshot/keeper/keeper.go
+++ b/x/snapshot/keeper/keeper.go
@@ -11,19 +11,13 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/axelarnetwork/axelar-core/utils"
-	"github.com/axelarnetwork/axelar-core/utils/key"
 	"github.com/axelarnetwork/axelar-core/x/snapshot/exported"
 	"github.com/axelarnetwork/axelar-core/x/snapshot/types"
 )
 
 const (
-	operatorPrefix = "operator_" // Deprecated: migrate to operatorPrefixNew
-	proxyPrefix    = "proxy_"    // Deprecated: migrate to proxyPrefixNew
-)
-
-var (
-	operatorPrefixNew = key.RegisterStaticKey(types.ModuleName, 1)
-	proxyPrefixNew    = key.RegisterStaticKey(types.ModuleName, 2)
+	operatorPrefix = "operator_"
+	proxyPrefix    = "proxy_"
 )
 
 // Keeper represents the snapshot keeper

--- a/x/vote/keeper/keeper.go
+++ b/x/vote/keeper/keeper.go
@@ -22,15 +22,10 @@ import (
 )
 
 var (
-	pollPrefix    = "poll"               // Deprecated: migrate to pollPrefixNew
-	votesPrefix   = "votes"              // Deprecated: migrate to votesPrefixNew
-	countKey      = "count"              // Deprecated: migrate to countKeyNew
-	pollQueueName = "pending_poll_queue" // Deprecated: migrate to pollQueueNameNew
-
-	pollPrefixNew    = key.RegisterStaticKey(types.ModuleName, 1)
-	votesPrefixNew   = key.RegisterStaticKey(types.ModuleName, 2)
-	countKeyNew      = key.RegisterStaticKey(types.ModuleName, 3)
-	pollQueueNameNew = key.RegisterStaticKey(types.ModuleName, 4)
+	pollPrefix    = "poll"
+	votesPrefix   = "votes"
+	countKey      = "count"
+	pollQueueName = "pending_poll_queue"
 )
 
 const (


### PR DESCRIPTION
We decided to hold off on the key migrations, so this cleans up the as of new unused new keys in the keepers