### PR TITLE
chore(rosetta): rosetta dependency update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -175,4 +175,4 @@ replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v
 replace github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 
 // Temporary replacement for rosetta support
-replace github.com/cosmos/cosmos-sdk => github.com/axelarnetwork/cosmos-sdk v0.45.10-0.20221026063150-7d9818dc359a
+replace github.com/cosmos/cosmos-sdk => github.com/axelarnetwork/cosmos-sdk v0.45.10-0.20230117223801-3d20a4b24917

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/axelarnetwork/cosmos-sdk v0.45.10-0.20221026063150-7d9818dc359a h1:URWy/3sbSgZAMyyVVfeJNe0llIoWV+pbBkdMHS169o0=
-github.com/axelarnetwork/cosmos-sdk v0.45.10-0.20221026063150-7d9818dc359a/go.mod h1:Z5M4TX7PsHNHlF/1XanI2DIpORQ+Q/st7oaeufEjnvU=
+github.com/axelarnetwork/cosmos-sdk v0.45.10-0.20230117223801-3d20a4b24917 h1:FBTrgrXRhCIyDl0I+qwgIBsJv9zOADfyqMyp/b/0DNs=
+github.com/axelarnetwork/cosmos-sdk v0.45.10-0.20230117223801-3d20a4b24917/go.mod h1:Z5M4TX7PsHNHlF/1XanI2DIpORQ+Q/st7oaeufEjnvU=
 github.com/axelarnetwork/tm-events v0.0.0-20221019195821-9a3f03bc6ca6 h1:bNjORqBmAgv3hEwfm4M9nqjGE9XhbvX9n+5ha2QXZYw=
 github.com/axelarnetwork/tm-events v0.0.0-20221019195821-9a3f03bc6ca6/go.mod h1:nRFBzknkN/o4e8FmOrfF8HREzSmSWrAwTrSyJ48N4B8=
 github.com/axelarnetwork/utils v0.0.0-20221213003031-66c703710da3 h1:1K8+r1kLCg5IXjpqRMhKoD/3LTu7QpzNETYECg5Ybjo=


### PR DESCRIPTION
## Description
non consensus breaking, only has changes for rosetta implementation.
replaced with [this commit]( https://github.com/axelarnetwork/cosmos-sdk/commits/v0.45.9-rosetta)

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
