### PR TITLE
fix: use buildx imagetools to push manifest instead of docker manifes…

### DIFF
--- a/.github/workflows/build-docker-image-and-binaries.yaml
+++ b/.github/workflows/build-docker-image-and-binaries.yaml
@@ -198,17 +198,11 @@ jobs:
 
       - name: Create multiarch manifest
         run: |
-          docker manifest create axelarnet/axelar-core:${SEMVER} \
-          axelarnet/axelar-core-linux-arm64:${SEMVER} \
-          axelarnet/axelar-core-linux-amd64:${SEMVER} \
-          axelarnet/axelar-core-linux-armv6:${SEMVER} \
-          axelarnet/axelar-core-linux-armv7:${SEMVER}
-        env:
-          SEMVER: ${{ github.event.inputs.tag }}
-
-      - name: push manifest
-        run: |
-          docker manifest push axelarnet/axelar-core:${SEMVER}
+          docker buildx imagetools create -t axelarnet/axelar-core:${SEMVER} \
+            axelarnet/axelar-core-linux-arm64:${SEMVER} \
+            axelarnet/axelar-core-linux-amd64:${SEMVER} \
+            axelarnet/axelar-core-linux-armv6:${SEMVER} \
+            axelarnet/axelar-core-linux-armv7:${SEMVER}
         env:
           SEMVER: ${{ github.event.inputs.tag }}
 


### PR DESCRIPTION
…t (#1879)

## Description

cherry pick docker build fix #1879 

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
