### PR TITLE
fix(nexus)!: consistent message id generation from tx hash

### DIFF
--- a/x/nexus/keeper/general_message.go
+++ b/x/nexus/keeper/general_message.go
@@ -30,9 +30,9 @@ func getSentMessageKey(destinationChain exported.ChainName, id string) key.Key {
 func (k Keeper) GenerateMessageID(ctx sdk.Context) (string, []byte, uint64) {
 	counter := utils.NewCounter[uint64](messageNonceKey, k.getStore(ctx))
 	nonce := counter.Incr(ctx)
-
 	hash := sha256.Sum256(ctx.TxBytes())
-	return fmt.Sprintf("%s-%d", hex.EncodeToString(hash[:]), nonce), hash[:], nonce
+
+	return fmt.Sprintf("0x%s-%d", hex.EncodeToString(hash[:]), nonce), hash[:], nonce
 }
 
 // SetNewMessage sets the given general message. If the messages is approved, adds the message ID to approved messages store


### PR DESCRIPTION
## Description

Make the message id conversion be consistent with event ids in EVM. Specifically, event ids (which are used as message ids) add a `0x` prefix to the tx hash but message ids from cosmos don't.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
