### PR TITLE
fix: use previous cosign version

### DIFF
--- a/.github/workflows/build-docker-image-and-binaries.yaml
+++ b/.github/workflows/build-docker-image-and-binaries.yaml
@@ -189,6 +189,8 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.13.1'
 
       - name: Login to DockerHub
         uses: docker/login-action@v1


### PR DESCRIPTION
## Description

Pin the previous version of `cosign`. The new version is breaking, and we should fix the cmd and test it out before updating to it.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
