### PR TITLE
fix: allow an empty payload for Cosmos -> EVM

### DIFF
--- a/x/axelarnet/keeper/msg_server_test.go
+++ b/x/axelarnet/keeper/msg_server_test.go
@@ -976,7 +976,7 @@ func TestAddCosmosBasedChain(t *testing.T) {
 		Run(t, repeats)
 }
 
-func TestExecuteMessage(t *testing.T) {
+func TestRouteMessage(t *testing.T) {
 	var (
 		server types.MsgServiceServer
 		k      keeper.Keeper

--- a/x/axelarnet/types/msg_route_message.go
+++ b/x/axelarnet/types/msg_route_message.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
@@ -36,10 +34,6 @@ func (m RouteMessageRequest) ValidateBasic() error {
 
 	if err := utils.ValidateString(m.ID); err != nil {
 		return sdkerrors.Wrap(err, "invalid general message id")
-	}
-
-	if len(m.Payload) == 0 {
-		return fmt.Errorf("invalid payload")
 	}
 
 	return nil

--- a/x/axelarnet/types/msg_route_message_test.go
+++ b/x/axelarnet/types/msg_route_message_test.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/axelarnetwork/axelar-core/testutils/rand"
+)
+
+func TestRouteMessageRequest_ValidateBasic(t *testing.T) {
+	t.Run("invalid sender", func(t *testing.T) {
+		message := NewRouteMessage(nil, rand.NormalizedStr(5), []byte(rand.NormalizedStr(10)))
+		assert.Error(t, message.ValidateBasic())
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		sender := rand.AccAddr()
+		message := NewRouteMessage(sender, "", []byte(rand.NormalizedStr(10)))
+		assert.Error(t, message.ValidateBasic())
+	})
+
+	t.Run("correct message", func(t *testing.T) {
+		sender := rand.AccAddr()
+		id := rand.NormalizedStr(5)
+		payload := rand.BytesBetween(0, 10)
+		message := NewRouteMessage(sender, id, payload)
+		assert.NoError(t, message.ValidateBasic())
+	})
+
+	t.Run("allow empty payload", func(t *testing.T) {
+		sender := rand.AccAddr()
+		id := rand.NormalizedStr(5)
+		message := NewRouteMessage(sender, id, []byte{})
+		assert.NoError(t, message.ValidateBasic())
+	})
+}


### PR DESCRIPTION
## Description

We already an empty payload for EVM -> EVM message passing. This can be useful for basic transfers via GMP where no payload is needed. Currently, user needs to add a dummy payload to get around this, which seems more confusing.

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
