### PR TITLE
chore(rosetta): port rosetta changes to v0.45.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -194,4 +194,4 @@ replace github.com/rjeczalik/notify => github.com/rjeczalik/notify v0.9.3
 replace github.com/tendermint/tendermint => github.com/cometbft/cometbft v0.34.27
 
 // Temporary replacement for rosetta support
-replace github.com/cosmos/cosmos-sdk => github.com/axelarnetwork/cosmos-sdk v0.45.17-0.20230612175028-3c6cfe382b56
+replace github.com/cosmos/cosmos-sdk => github.com/axelarnetwork/cosmos-sdk v0.45.17-0.20230904150332-37fb903a6c62

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/axelarnetwork/cosmos-sdk v0.45.17-0.20230612175028-3c6cfe382b56 h1:J2b78vj5aNvsODEePoSalvasvc5z0LGTEvzdN+6rhnU=
-github.com/axelarnetwork/cosmos-sdk v0.45.17-0.20230612175028-3c6cfe382b56/go.mod h1:bScuNwWAP0TZJpUf+SHXRU3xGoUPp+X9nAzfeIXts40=
+github.com/axelarnetwork/cosmos-sdk v0.45.17-0.20230904150332-37fb903a6c62 h1:sY5jKknnxAgwLP4PueojJ9RNASDvJWnxdeICXHlezA8=
+github.com/axelarnetwork/cosmos-sdk v0.45.17-0.20230904150332-37fb903a6c62/go.mod h1:bScuNwWAP0TZJpUf+SHXRU3xGoUPp+X9nAzfeIXts40=
 github.com/axelarnetwork/tm-events v0.0.0-20230704201410-3cf91089034b h1:qTbA+WlbMRiPtK5zn5evVfU2XhmIOrOZNIE8VNU1O3Q=
 github.com/axelarnetwork/tm-events v0.0.0-20230704201410-3cf91089034b/go.mod h1:vDpqqxWxMvMIKbF6DN3BkxXAI4UJjolCHvaMGhE/FCI=
 github.com/axelarnetwork/utils v0.0.0-20230706045331-b7aacc1f4a2f h1:Q0Qh79MuZ/PWKzytqU8/4dt+S2QemdYYPXkjwp/i4l0=


### PR DESCRIPTION
## Description
cherry-pick rosetta changes from v0.45.11 to [v0.45.16](https://github.com/axelarnetwork/cosmos-sdk/commits/v0.45.16-rosetta)

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
