### PR TITLE
fix!: ignore key shares for deactivated chains for unbonding checks

### DIFF
--- a/x/ante/ante.go
+++ b/x/ante/ante.go
@@ -107,6 +107,10 @@ func (d UndelegateDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate boo
 			chains := d.nexus.GetChains(ctx)
 
 			for _, chain := range chains {
+				if !d.nexus.IsChainActivated(ctx, chain) {
+					continue
+				}
+
 				nextKeyID, idFound := d.multiSig.GetNextKeyID(ctx, chain.Name)
 				key, keyFound := d.multiSig.GetKey(ctx, nextKeyID)
 				if idFound && keyFound && !key.GetWeight(valAddress).IsZero() {

--- a/x/ante/types/expected_keepers.go
+++ b/x/ante/types/expected_keepers.go
@@ -22,6 +22,7 @@ type MultiSig interface {
 // Nexus provides access to the nexus functionality
 type Nexus interface {
 	GetChains(ctx sdk.Context) []nexus.Chain
+	IsChainActivated(ctx sdk.Context, chain nexus.Chain) bool
 }
 
 // Snapshotter provides access to the snapshot functionality


### PR DESCRIPTION
## Description

[AXE-1739](https://axelarnetwork.atlassian.net/browse/AXE-1739)

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes


[AXE-1739]: https://axelarnetwork.atlassian.net/browse/AXE-1739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ