### PR TITLE
chore: add 0x prefix to hex encoding

### DIFF
--- a/utils/encoding.go
+++ b/utils/encoding.go
@@ -6,6 +6,11 @@ import (
 )
 
 // Decode a hex string. Hex string can be optionally prefixed with 0x.
+func HexEncode(input []byte) string {
+	return "0x" + hex.EncodeToString(input)
+}
+
+// Decode a hex string. Hex string can be optionally prefixed with 0x.
 func HexDecode(input string) ([]byte, error) {
 	return hex.DecodeString(strings.TrimPrefix(input, "0x"))
 }

--- a/utils/encoding_test.go
+++ b/utils/encoding_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,52 +9,60 @@ import (
 
 func TestHexDecode(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		want    []byte
-		wantErr bool
+		name        string
+		input       string
+		expected    []byte
+		expectedErr bool
 	}{
 		{
-			name:    "empty input",
-			input:   "",
-			want:    []byte{},
-			wantErr: false,
+			name:        "empty input",
+			input:       "",
+			expected:    []byte{},
+			expectedErr: false,
 		},
 		{
-			name:    "valid input with 0x prefix",
-			input:   "0x68656c6c6f",
-			want:    []byte("hello"),
-			wantErr: false,
+			name:        "empty input with 0x prefix",
+			input:       "0x",
+			expected:    []byte{},
+			expectedErr: false,
 		},
 		{
-			name:    "valid input without 0x prefix",
-			input:   "68656c6c6f",
-			want:    []byte("hello"),
-			wantErr: false,
+			name:        "valid input with 0x prefix",
+			input:       "0x68656c6c6f",
+			expected:    []byte("hello"),
+			expectedErr: false,
 		},
 		{
-			name:    "invalid input with odd number of characters",
-			input:   "68656c6c6",
-			want:    nil,
-			wantErr: true,
+			name:        "valid input without 0x prefix",
+			input:       "68656c6c6f",
+			expected:    []byte("hello"),
+			expectedErr: false,
 		},
 		{
-			name:    "invalid input with non-hex characters",
-			input:   "68656c6c6z",
-			want:    nil,
-			wantErr: true,
+			name:        "invalid input with odd number of characters",
+			input:       "68656c6c6",
+			expected:    nil,
+			expectedErr: true,
+		},
+		{
+			name:        "invalid input with non-hex characters",
+			input:       "68656c6c6z",
+			expected:    nil,
+			expectedErr: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := HexDecode(test.input)
-			if test.wantErr {
+			decoded, err := HexDecode(test.input)
+			if test.expectedErr {
 				assert.Error(t, err)
 				return
 			}
+			assert.Equal(t, test.expected, decoded)
 
-			assert.Equal(t, test.want, got)
+			encoded := HexEncode(decoded)
+			assert.Equal(t, "0x"+hex.EncodeToString(decoded), encoded)
 		})
 	}
 }

--- a/vald/sign.go
+++ b/vald/sign.go
@@ -2,7 +2,6 @@ package vald
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -119,9 +118,9 @@ func GetSignCommand() *cobra.Command {
 				signDetails := map[string]string{
 					"key_id":    keyID.String(),
 					"validator": valAddr,
-					"msg_hash":  hex.EncodeToString(hash.Bytes()),
-					"pub_key":   pubKey.String(),
-					"signature": hex.EncodeToString(evmSignature),
+					"msg_hash":  utils.HexEncode(hash.Bytes()),
+					"pub_key":   utils.HexEncode(pubKey),
+					"signature": utils.HexEncode(evmSignature),
 				}
 				fmt.Printf("%s", funcs.Must(json.MarshalIndent(signDetails, "", "  ")))
 


### PR DESCRIPTION
## Description

Add `0x` prefix for hex encoding in vald sign output

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
