### PR TITLE
fix/set corresponding event to completed when nexus msg executed

### DIFF
--- a/x/evm/abci.go
+++ b/x/evm/abci.go
@@ -603,7 +603,6 @@ func validateMessage(ctx sdk.Context, ck types.ChainKeeper, n types.Nexus, m typ
 }
 
 func handleMessage(ctx sdk.Context, ck types.ChainKeeper, chainID sdk.Int, keyID multisig.KeyID, msg nexus.GeneralMessage) {
-
 	cmd := types.NewApproveContractCallCommandGeneric(chainID, keyID, common.HexToAddress(msg.GetDestinationAddress()), common.BytesToHash(msg.PayloadHash), common.BytesToHash(msg.SourceTxID), msg.GetSourceChain(), msg.GetSourceAddress(), msg.SourceTxIndex, msg.ID)
 	funcs.MustNoErr(ck.EnqueueCommand(ctx, cmd))
 
@@ -699,12 +698,10 @@ func handleMessages(ctx sdk.Context, bk types.BaseKeeper, n types.Nexus, m types
 				continue
 			}
 
-			if srcCk, err := bk.ForChain(ctx, msg.GetSourceChain()); err != nil {
+			if srcCk, err := bk.ForChain(ctx, msg.GetSourceChain()); err == nil {
 				eventID := types.NewEventID(types.Hash(common.BytesToHash(msg.SourceTxID)), msg.SourceTxIndex)
 
-				if _, ok := srcCk.GetEvent(ctx, eventID); ok {
-					funcs.MustNoErr(srcCk.SetEventCompleted(ctx, eventID))
-				}
+				funcs.MustNoErr(srcCk.SetEventCompleted(ctx, eventID))
 			}
 
 			funcs.MustNoErr(n.SetMessageExecuted(ctx, msg.ID))

--- a/x/evm/types/types.go
+++ b/x/evm/types/types.go
@@ -919,7 +919,7 @@ func CommandIDsToStrings(commandIDs []CommandID) []string {
 
 // GetID returns an unique ID for the event
 func (m Event) GetID() EventID {
-	return EventID(fmt.Sprintf("%s-%d", m.TxID.Hex(), m.Index))
+	return NewEventID(m.TxID, m.Index)
 }
 
 // ValidateBasic returns an error if the event is invalid
@@ -1190,6 +1190,11 @@ func getType(val interface{}) string {
 
 // EventID ensures a correctly formatted event ID
 type EventID string
+
+// NewEventID returns a new event ID
+func NewEventID(txID Hash, index uint64) EventID {
+	return EventID(fmt.Sprintf("%s-%d", txID.Hex(), index))
+}
 
 // Validate returns an error, if the event ID is not in format of txID-index
 func (id EventID) Validate() error {


### PR DESCRIPTION
- fix(evm)!: set the corresponding event to completed when the nexus general message is executed, if any
- fix nil check

## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
