### PR TITLE
refactor: remove ValidateBasic in cli

### DIFF
--- a/x/axelarnet/client/cli/tx.go
+++ b/x/axelarnet/client/cli/tx.go
@@ -69,9 +69,6 @@ func GetCmdLink() *cobra.Command {
 			}
 
 			msg := types.NewLinkRequest(clientCtx.GetFromAddress(), args[0], args[1], args[2])
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
@@ -98,9 +95,6 @@ func GetCmdConfirmDeposit() *cobra.Command {
 			}
 
 			msg := types.NewConfirmDepositRequest(cliCtx.GetFromAddress(), args[0], burnerAddr)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -122,9 +116,6 @@ func GetCmdExecutePendingTransfersTx() *cobra.Command {
 			}
 
 			msg := types.NewExecutePendingTransfersRequest(cliCtx.GetFromAddress())
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -158,9 +149,6 @@ func GetCmdAddCosmosBasedChain() *cobra.Command {
 		path := args[2]
 
 		msg := types.NewAddCosmosBasedChainRequest(cliCtx.GetFromAddress(), name, addrPrefix, assets, path)
-		if err := msg.ValidateBasic(); err != nil {
-			return err
-		}
 
 		return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 	}
@@ -209,9 +197,6 @@ func GetCmdRegisterAsset() *cobra.Command {
 		}
 
 		msg := types.NewRegisterAssetRequest(cliCtx.GetFromAddress(), chain, nexus.NewAsset(denom, isNativeAsset), limit, window)
-		if err := msg.ValidateBasic(); err != nil {
-			return err
-		}
 
 		return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 	}
@@ -237,9 +222,6 @@ func GetCmdRouteIBCTransfersTx() *cobra.Command {
 			}
 
 			msg := types.NewRouteIBCTransfersRequest(cliCtx.GetFromAddress())
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -264,9 +246,6 @@ func GetCmdRegisterFeeCollector() *cobra.Command {
 				return err
 			}
 			msg := types.NewRegisterFeeCollectorRequest(cliCtx.GetFromAddress(), feeCollector)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -292,9 +271,6 @@ func getRetryIBCTransfer() *cobra.Command {
 			}
 
 			msg := types.NewRetryIBCTransferRequest(cliCtx.GetFromAddress(), nexus.TransferID(transferID))
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -334,9 +310,6 @@ func getGeneralMessage() *cobra.Command {
 			}
 
 			msg := types.NewRouteMessage(cliCtx.GetFromAddress(), feegranterAcc, id, payload)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -393,9 +366,6 @@ func getCmdCallContract() *cobra.Command {
 			}
 
 			msg := types.NewCallContractRequest(clientCtx.GetFromAddress(), args[0], args[1], payload, fee)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
@@ -470,9 +440,6 @@ IMPORTANT: The payload field must be base64 encoded.
 
 			msg, err := govtypes.NewMsgSubmitProposal(&proposal, deposit, clientCtx.GetFromAddress())
 			if err != nil {
-				return err
-			}
-			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
 

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -73,9 +73,6 @@ func GetCmdSetGateway() *cobra.Command {
 			}
 
 			msg := types.NewSetGatewayRequest(cliCtx.GetFromAddress(), chain, types.Address(common.HexToAddress(addressHex)))
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -98,9 +95,6 @@ func GetCmdLink() *cobra.Command {
 			}
 
 			msg := types.NewLinkRequest(cliCtx.GetFromAddress(), args[0], args[1], args[2], args[3])
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -127,9 +121,6 @@ func GetCmdConfirmERC20TokenDeployment() *cobra.Command {
 			asset := types.NewAsset(originChain, originAsset)
 			txID := common.HexToHash(args[3])
 			msg := types.NewConfirmTokenRequest(cliCtx.GetFromAddress(), chain, asset, txID)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -155,9 +146,6 @@ func GetCmdConfirmERC20Deposit() *cobra.Command {
 			burnerAddr := common.HexToAddress(args[2])
 
 			msg := types.NewConfirmDepositRequest(cliCtx.GetFromAddress(), chain, txID, burnerAddr)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -181,9 +169,6 @@ func GetCmdConfirmTransferOperatorship() *cobra.Command {
 			chain := args[0]
 			txID := common.HexToHash(args[1])
 			msg := types.NewConfirmTransferKeyRequest(cliCtx.GetFromAddress(), chain, txID)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -210,9 +195,6 @@ func GetCmdCreateConfirmGatewayTx() *cobra.Command {
 			txID := types.Hash(common.HexToHash(args[1]))
 
 			msg := types.NewConfirmGatewayTxRequest(cliCtx.GetFromAddress(), chain, txID)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -239,9 +221,6 @@ func GetCmdCreateConfirmGatewayTxs() *cobra.Command {
 			})
 
 			msg := types.NewConfirmGatewayTxsRequest(cliCtx.GetFromAddress(), chain, txIDs)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -263,9 +242,6 @@ func GetCmdCreatePendingTransfers() *cobra.Command {
 			}
 
 			msg := types.NewCreatePendingTransfersRequest(cliCtx.GetFromAddress(), args[0])
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -312,9 +288,6 @@ func GetCmdCreateDeployToken() *cobra.Command {
 		asset := types.NewAsset(originChain, originAsset)
 		tokenDetails := types.NewTokenDetails(tokenName, symbol, uint8(decs), capacity)
 		msg := types.NewCreateDeployTokenRequest(cliCtx.GetFromAddress(), chain, asset, tokenDetails, types.Address(common.HexToAddress(*address)), mintLimit)
-		if err = msg.ValidateBasic(); err != nil {
-			return err
-		}
 
 		return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 	}
@@ -336,9 +309,6 @@ func GetCmdCreateBurnTokens() *cobra.Command {
 			}
 
 			msg := types.NewCreateBurnTokensRequest(cliCtx.GetFromAddress(), args[0])
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -360,9 +330,6 @@ func GetCmdCreateTransferOperatorship() *cobra.Command {
 			}
 
 			msg := types.NewCreateTransferOperatorshipRequest(cliCtx.GetFromAddress(), args[0], args[1])
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -384,9 +351,6 @@ func GetCmdSignCommands() *cobra.Command {
 			}
 
 			msg := types.NewSignCommandsRequest(cliCtx.GetFromAddress(), args[0])
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -423,9 +387,6 @@ func GetCmdAddChain() *cobra.Command {
 			}
 
 			msg := types.NewAddChainRequest(cliCtx.GetFromAddress(), name, chainConf.Params)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -447,9 +408,6 @@ func GetCmdRetryFailedEvent() *cobra.Command {
 			}
 
 			msg := types.NewRetryFailedEventRequest(cliCtx.GetFromAddress(), args[0], args[1])
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},

--- a/x/multisig/client/cli/tx.go
+++ b/x/multisig/client/cli/tx.go
@@ -56,9 +56,6 @@ func getCmdRotateKey() *cobra.Command {
 			keyID := exported.KeyID(args[1])
 
 			msg := types.NewRotateKeyRequest(clientCtx.FromAddress, chain, keyID)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
@@ -106,9 +103,6 @@ func getCmdStart() *cobra.Command {
 		}
 
 		msg := types.NewStartKeygenRequest(cliCtx.FromAddress, exported.KeyID(*keyID))
-		if err := msg.ValidateBasic(); err != nil {
-			return err
-		}
 
 		return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 	}
@@ -130,9 +124,6 @@ func getCmdOptOut() *cobra.Command {
 			}
 
 			msg := &types.KeygenOptOutRequest{Sender: clientCtx.FromAddress}
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
@@ -155,9 +146,6 @@ func getCmdOptIn() *cobra.Command {
 			}
 
 			msg := &types.KeygenOptInRequest{Sender: clientCtx.FromAddress}
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},

--- a/x/nexus/client/cli/tx.go
+++ b/x/nexus/client/cli/tx.go
@@ -51,10 +51,6 @@ func GetCmdRegisterChainMaintainer() *cobra.Command {
 
 			msg := types.NewRegisterChainMaintainerRequest(cliCtx.GetFromAddress(), args...)
 
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
-
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
 	}
@@ -76,10 +72,6 @@ func GetCmdDeregisterChainMaintainer() *cobra.Command {
 			}
 
 			msg := types.NewDeregisterChainMaintainerRequest(cliCtx.GetFromAddress(), args...)
-
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -103,10 +95,6 @@ func GetCmdActivateChain() *cobra.Command {
 
 			msg := types.NewActivateChainRequest(cliCtx.GetFromAddress(), args...)
 
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
-
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
 	}
@@ -128,10 +116,6 @@ func GetCmdDeactivateChain() *cobra.Command {
 			}
 
 			msg := types.NewDeactivateChainRequest(cliCtx.GetFromAddress(), args...)
-
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -169,10 +153,6 @@ func GetCmdRegisterAssetFee() *cobra.Command {
 
 			msg := types.NewRegisterAssetFeeRequest(cliCtx.GetFromAddress(), feeInfo)
 
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
-
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
 	}
@@ -204,9 +184,6 @@ func GetCmdSetTransferRateLimit() *cobra.Command {
 			}
 
 			msg := types.NewSetTransferRateLimitRequest(cliCtx.GetFromAddress(), exported.ChainName(args[0]), limit, window)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},

--- a/x/permission/client/cli/tx.go
+++ b/x/permission/client/cli/tx.go
@@ -64,9 +64,6 @@ func GetCmdUpdateGovernanceKey() *cobra.Command {
 		}
 
 		msg := types.NewUpdateGovernanceKeyRequest(clientCtx.GetFromAddress(), threshold, pubKeys...)
-		if err := msg.ValidateBasic(); err != nil {
-			return err
-		}
 
 		return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 	}
@@ -91,9 +88,6 @@ func GetCmdRegisterController() *cobra.Command {
 				return err
 			}
 			msg := types.NewRegisterControllerRequest(cliCtx.GetFromAddress(), controller)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},
@@ -118,9 +112,6 @@ func GetCmdDeregisterController() *cobra.Command {
 				return err
 			}
 			msg := types.NewDeregisterControllerRequest(cliCtx.GetFromAddress(), controller)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},


### PR DESCRIPTION
## Description
The `ValidateBasic` function has been called in the `GenerateOrBroadcastTxWithFactory` function, so we no longer need to add the `ValidateBasic` function when writing Cli. Related PRs can be viewed at: https://github.com/cosmos/cosmos-sdk/pull/9236#discussion_r623803504

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
