### PR TITLE
fix(ante)!: ensure ante handlers can deal with no signers in msg

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2,30 +2,30 @@ package app_test
 
 import (
 	"fmt"
-	"github.com/axelarnetwork/axelar-core/app/params"
-	"github.com/axelarnetwork/axelar-core/testutils/fake"
-	"github.com/axelarnetwork/axelar-core/x/nexus/exported"
-	"github.com/axelarnetwork/utils/funcs"
-	"github.com/cosmos/cosmos-sdk/simapp/helpers"
-	"github.com/cosmos/cosmos-sdk/testutil/testdata"
-	abcitypes "github.com/tendermint/tendermint/abci/types"
-	abci "github.com/tendermint/tendermint/proto/tendermint/types"
 	"testing"
 	"time"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/cosmos/cosmos-sdk/simapp/helpers"
+	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/stretchr/testify/assert"
+	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
+	abci "github.com/tendermint/tendermint/proto/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
 	"google.golang.org/grpc/encoding"
 	encproto "google.golang.org/grpc/encoding/proto"
 
 	"github.com/axelarnetwork/axelar-core/app"
+	"github.com/axelarnetwork/axelar-core/app/params"
+	"github.com/axelarnetwork/axelar-core/testutils/fake"
 	multisig "github.com/axelarnetwork/axelar-core/x/multisig/types"
+	"github.com/axelarnetwork/axelar-core/x/nexus/exported"
+	"github.com/axelarnetwork/utils/funcs"
 )
 
 func TestNewAxelarApp(t *testing.T) {

--- a/app/export.go
+++ b/app/export.go
@@ -2,16 +2,16 @@ package app
 
 import (
 	"encoding/json"
-	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
-	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
-	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"log"
 
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )

--- a/app/export.go
+++ b/app/export.go
@@ -2,6 +2,10 @@ package app
 
 import (
 	"encoding/json"
+	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"log"
 
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
@@ -33,7 +37,8 @@ func (app *AxelarApp) ExportAppStateAndValidators(forZeroHeight bool, jailAllowe
 		return servertypes.ExportedApp{}, err
 	}
 
-	validators, err := staking.WriteValidators(ctx, app.stakingKeeper)
+	stakingKeeper := GetKeeper[stakingkeeper.Keeper](app.Keepers)
+	validators, err := staking.WriteValidators(ctx, *stakingKeeper)
 	if err != nil {
 		return servertypes.ExportedApp{}, err
 	}
@@ -66,49 +71,54 @@ func (app *AxelarApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs
 		allowedAddrsMap[addr] = true
 	}
 
+	crisisKeeper := GetKeeper[crisiskeeper.Keeper](app.Keepers)
+	stakingKeeper := GetKeeper[stakingkeeper.Keeper](app.Keepers)
+	distrKeeper := GetKeeper[distrkeeper.Keeper](app.Keepers)
+	slashingKeeper := GetKeeper[slashingkeeper.Keeper](app.Keepers)
+
 	/* Just to be safe, assert the invariants on current state. */
-	app.crisisKeeper.AssertInvariants(ctx)
+	crisisKeeper.AssertInvariants(ctx)
 
 	/* Handle fee distribution state. */
 
 	// withdraw all validator commission
-	app.stakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
-		_, _ = app.distrKeeper.WithdrawValidatorCommission(ctx, val.GetOperator())
+	stakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
+		_, _ = distrKeeper.WithdrawValidatorCommission(ctx, val.GetOperator())
 		return false
 	})
 
 	// withdraw all delegator rewards
-	dels := app.stakingKeeper.GetAllDelegations(ctx)
+	dels := stakingKeeper.GetAllDelegations(ctx)
 	for _, delegation := range dels {
-		_, _ = app.distrKeeper.WithdrawDelegationRewards(ctx, delegation.GetDelegatorAddr(), delegation.GetValidatorAddr())
+		_, _ = distrKeeper.WithdrawDelegationRewards(ctx, delegation.GetDelegatorAddr(), delegation.GetValidatorAddr())
 	}
 
 	// clear validator slash events
-	app.distrKeeper.DeleteAllValidatorSlashEvents(ctx)
+	distrKeeper.DeleteAllValidatorSlashEvents(ctx)
 
 	// clear validator historical rewards
-	app.distrKeeper.DeleteAllValidatorHistoricalRewards(ctx)
+	distrKeeper.DeleteAllValidatorHistoricalRewards(ctx)
 
 	// set context height to zero
 	height := ctx.BlockHeight()
 	ctx = ctx.WithBlockHeight(0)
 
 	// reinitialize all validators
-	app.stakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
+	stakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
 		// donate any unwithdrawn outstanding reward fraction tokens to the community pool
-		scraps := app.distrKeeper.GetValidatorOutstandingRewardsCoins(ctx, val.GetOperator())
-		feePool := app.distrKeeper.GetFeePool(ctx)
+		scraps := distrKeeper.GetValidatorOutstandingRewardsCoins(ctx, val.GetOperator())
+		feePool := distrKeeper.GetFeePool(ctx)
 		feePool.CommunityPool = feePool.CommunityPool.Add(scraps...)
-		app.distrKeeper.SetFeePool(ctx, feePool)
+		distrKeeper.SetFeePool(ctx, feePool)
 
-		app.distrKeeper.Hooks().AfterValidatorCreated(ctx, val.GetOperator())
+		distrKeeper.Hooks().AfterValidatorCreated(ctx, val.GetOperator())
 		return false
 	})
 
 	// reinitialize all delegations
 	for _, del := range dels {
-		app.distrKeeper.Hooks().BeforeDelegationCreated(ctx, del.GetDelegatorAddr(), del.GetValidatorAddr())
-		app.distrKeeper.Hooks().AfterDelegationModified(ctx, del.GetDelegatorAddr(), del.GetValidatorAddr())
+		distrKeeper.Hooks().BeforeDelegationCreated(ctx, del.GetDelegatorAddr(), del.GetValidatorAddr())
+		distrKeeper.Hooks().AfterDelegationModified(ctx, del.GetDelegatorAddr(), del.GetValidatorAddr())
 	}
 
 	// reset context height
@@ -117,32 +127,32 @@ func (app *AxelarApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs
 	/* Handle staking state. */
 
 	// iterate through redelegations, reset creation height
-	app.stakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) (stop bool) {
+	stakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) (stop bool) {
 		for i := range red.Entries {
 			red.Entries[i].CreationHeight = 0
 		}
-		app.stakingKeeper.SetRedelegation(ctx, red)
+		stakingKeeper.SetRedelegation(ctx, red)
 		return false
 	})
 
 	// iterate through unbonding delegations, reset creation height
-	app.stakingKeeper.IterateUnbondingDelegations(ctx, func(_ int64, ubd stakingtypes.UnbondingDelegation) (stop bool) {
+	stakingKeeper.IterateUnbondingDelegations(ctx, func(_ int64, ubd stakingtypes.UnbondingDelegation) (stop bool) {
 		for i := range ubd.Entries {
 			ubd.Entries[i].CreationHeight = 0
 		}
-		app.stakingKeeper.SetUnbondingDelegation(ctx, ubd)
+		stakingKeeper.SetUnbondingDelegation(ctx, ubd)
 		return false
 	})
 
 	// Iterate through validators by power descending, reset bond heights, and
 	// update bond intra-tx counters.
-	store := ctx.KVStore(app.keys[stakingtypes.StoreKey])
+	store := ctx.KVStore(app.Keys[stakingtypes.StoreKey])
 	iter := sdk.KVStoreReversePrefixIterator(store, stakingtypes.ValidatorsKey)
 	counter := int16(0)
 
 	for ; iter.Valid(); iter.Next() {
 		addr := sdk.ValAddress(iter.Key()[1:])
-		validator, found := app.stakingKeeper.GetValidator(ctx, addr)
+		validator, found := stakingKeeper.GetValidator(ctx, addr)
 		if !found {
 			panic("expected validator, not found")
 		}
@@ -152,24 +162,24 @@ func (app *AxelarApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs
 			validator.Jailed = true
 		}
 
-		app.stakingKeeper.SetValidator(ctx, validator)
+		stakingKeeper.SetValidator(ctx, validator)
 		counter++
 	}
 
 	_ = iter.Close()
 
-	if _, err := app.stakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx); err != nil {
+	if _, err := stakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx); err != nil {
 		panic(err)
 	}
 
 	/* Handle slashing state. */
 
 	// reset start height on signing infos
-	app.slashingKeeper.IterateValidatorSigningInfos(
+	slashingKeeper.IterateValidatorSigningInfos(
 		ctx,
 		func(addr sdk.ConsAddress, info slashingtypes.ValidatorSigningInfo) (stop bool) {
 			info.StartHeight = 0
-			app.slashingKeeper.SetValidatorSigningInfo(ctx, addr, info)
+			slashingKeeper.SetValidatorSigningInfo(ctx, addr, info)
 			return false
 		},
 	)

--- a/app/wasm_test.go
+++ b/app/wasm_test.go
@@ -2,6 +2,8 @@ package app_test
 
 import (
 	"encoding/json"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	dbm "github.com/tendermint/tm-db"
 	"testing"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
@@ -9,8 +11,6 @@ import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
-	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -255,13 +255,7 @@ func TestNewWasmAppModuleBasicOverride(t *testing.T) {
 }
 
 func TestICSMiddleWare(t *testing.T) {
-	encodingConfig := app.MakeEncodingConfig()
-	appCodec := encodingConfig.Codec
-
 	keys := app.CreateStoreKeys()
-	tkeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
-	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
-	moduleAccountPermissions := app.InitModuleAccountPermissions()
 
 	testCases := []struct {
 		wasm  string
@@ -275,21 +269,23 @@ func TestICSMiddleWare(t *testing.T) {
 		t.Run("wasm_enabled:"+testCase.wasm+"-hooks_enabled:"+testCase.hooks, func(t *testing.T) {
 			app.WasmEnabled, app.IBCWasmHooksEnabled = testCase.wasm, testCase.hooks
 
-			keepers := app.NewKeeperCache()
-			app.SetKeeper(keepers, app.InitParamsKeeper(encodingConfig, keys[paramstypes.StoreKey], tkeys[paramstypes.TStoreKey]))
-			app.SetKeeper(keepers, app.InitAccountKeeper(appCodec, keys, keepers, moduleAccountPermissions))
-			app.SetKeeper(keepers, app.InitBankKeeper(appCodec, keys, keepers, moduleAccountPermissions))
-			app.SetKeeper(keepers, app.InitStakingKeeper(appCodec, keys, keepers))
-			app.SetKeeper(keepers, app.InitCapabilityKeeper(appCodec, keys, memKeys))
-			app.SetKeeper(keepers, app.InitUpgradeKeeper(appCodec, keys, nil, "home", nil))
-			app.SetKeeper(keepers, app.InitIBCKeeper(appCodec, keys, keepers))
-			app.SetKeeper(keepers, app.InitFeegrantKeeper(appCodec, keys, keepers))
-			app.SetKeeper(keepers, app.InitAxelarnetKeeper(appCodec, keys, keepers))
-			app.SetKeeper(keepers, app.InitNexusKeeper(appCodec, keys, keepers))
+			axelarApp := app.NewAxelarApp(
+				log.TestingLogger(),
+				dbm.NewMemDB(),
+				nil,
+				true,
+				nil,
+				"",
+				"",
+				0,
+				app.MakeEncodingConfig(),
+				simapp.EmptyAppOptions{},
+				[]wasm.Option{},
+			)
 
 			// this is the focus of the test, we need to ensure that the hooks and wrapper are correctly set up for each valid wasm/hooks flag combination
 			wasmHooks := app.InitWasmHooks(keys)
-			ics4Wrapper := app.InitICS4Wrapper(keepers, wasmHooks)
+			ics4Wrapper := app.InitICS4Wrapper(axelarApp.Keepers, wasmHooks)
 
 			ctx := sdk.NewContext(fake.NewMultiStore(), tmproto.Header{}, false, log.TestingLogger())
 			packet := &mock.PacketIMock{

--- a/app/wasm_test.go
+++ b/app/wasm_test.go
@@ -2,18 +2,18 @@ package app_test
 
 import (
 	"encoding/json"
-	"github.com/cosmos/cosmos-sdk/simapp"
-	dbm "github.com/tendermint/tm-db"
 	"testing"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	"github.com/cosmos/cosmos-sdk/simapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	dbm "github.com/tendermint/tm-db"
 
 	"github.com/axelarnetwork/axelar-core/app"
 	"github.com/axelarnetwork/axelar-core/app/mock"

--- a/x/ante/check_refund.go
+++ b/x/ante/check_refund.go
@@ -101,7 +101,7 @@ func (d CheckRefundFeeDecorator) validateRefundQualification(ctx sdk.Context, ms
 				return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "signer is not associated with a validator")
 			}
 		default:
-			return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, fmt.Sprintf("message type %T is not refundable", msg))
+			return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, fmt.Sprintf("all messages in a transaction must be refundable, message type %T is not refundable", msg))
 		}
 	}
 

--- a/x/ante/restricted_tx.go
+++ b/x/ante/restricted_tx.go
@@ -24,17 +24,22 @@ func NewRestrictedTx(permission types.Permission) RestrictedTx {
 // AnteHandle fails if the signer is not authorized to send the transaction
 func (d RestrictedTx) AnteHandle(ctx sdk.Context, msgs []sdk.Msg, simulate bool, next MessageAnteHandler) (sdk.Context, error) {
 	for _, msg := range msgs {
-		signer := msg.GetSigners()[0]
-		signerRole := d.permission.GetRole(ctx, signer)
+		signers := msg.GetSigners()
+		var signer sdk.AccAddress
 
+		if len(signers) != 0 {
+			signer = signers[0]
+		}
+
+		signerRole := d.permission.GetRole(ctx, signer)
 		switch permission.GetPermissionRole((msg).(descriptor.Message)) {
 		case permission.ROLE_ACCESS_CONTROL:
 			if permission.ROLE_ACCESS_CONTROL != signerRole {
-				return ctx, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "%s is not authorized to send transaction %T", signer, msg)
+				return ctx, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "signer '%s' is not authorized to send transaction %T", signer, msg)
 			}
 		case permission.ROLE_CHAIN_MANAGEMENT:
 			if permission.ROLE_CHAIN_MANAGEMENT != signerRole {
-				return ctx, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "%s is not authorized to send transaction %T", signer, msg)
+				return ctx, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "signer '%s' is not authorized to send transaction %T", signer, msg)
 			}
 		default:
 			continue

--- a/x/permission/keeper/keeper.go
+++ b/x/permission/keeper/keeper.go
@@ -70,7 +70,7 @@ func (k Keeper) GetRole(ctx sdk.Context, address sdk.AccAddress) exported.Role {
 	if address.Empty() {
 		return exported.ROLE_UNRESTRICTED
 	}
-	
+
 	govAccount, ok := k.getGovAccount(ctx, address)
 	if !ok {
 		return exported.ROLE_UNRESTRICTED

--- a/x/permission/keeper/keeper.go
+++ b/x/permission/keeper/keeper.go
@@ -67,6 +67,10 @@ func (k Keeper) GetGovernanceKey(ctx sdk.Context) (multisig.LegacyAminoPubKey, b
 
 // GetRole returns the role of the given account address
 func (k Keeper) GetRole(ctx sdk.Context, address sdk.AccAddress) exported.Role {
+	if address.Empty() {
+		return exported.ROLE_UNRESTRICTED
+	}
+	
 	govAccount, ok := k.getGovAccount(ctx, address)
 	if !ok {
 		return exported.ROLE_UNRESTRICTED

--- a/x/permission/keeper/keeper_test.go
+++ b/x/permission/keeper/keeper_test.go
@@ -1,0 +1,23 @@
+package keeper_test
+
+import (
+	"github.com/axelarnetwork/axelar-core/app"
+	"github.com/axelarnetwork/axelar-core/testutils/fake"
+	"github.com/axelarnetwork/axelar-core/x/permission/exported"
+	"github.com/axelarnetwork/axelar-core/x/permission/keeper"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/tendermint/libs/log"
+	"testing"
+)
+
+func TestKeeper_GetRole_nil_Address_Return_Unrestricted(t *testing.T) {
+	encCfg := app.MakeEncodingConfig()
+	key := sdk.NewKVStoreKey("permission")
+	subspace := paramstypes.NewSubspace(encCfg.Codec, encCfg.Amino, key, sdk.NewKVStoreKey("trewardKey"), "reward")
+	k := keeper.NewKeeper(encCfg.Codec, key, subspace)
+
+	ctx := sdk.NewContext(fake.NewMultiStore(), sdk.Context{}.BlockHeader(), false, log.TestingLogger())
+	assert.Equal(t, k.GetRole(ctx, nil), exported.ROLE_UNRESTRICTED)
+}

--- a/x/permission/keeper/keeper_test.go
+++ b/x/permission/keeper/keeper_test.go
@@ -1,15 +1,17 @@
 package keeper_test
 
 import (
-	"github.com/axelarnetwork/axelar-core/app"
-	"github.com/axelarnetwork/axelar-core/testutils/fake"
-	"github.com/axelarnetwork/axelar-core/x/permission/exported"
-	"github.com/axelarnetwork/axelar-core/x/permission/keeper"
+	"testing"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/libs/log"
-	"testing"
+
+	"github.com/axelarnetwork/axelar-core/app"
+	"github.com/axelarnetwork/axelar-core/testutils/fake"
+	"github.com/axelarnetwork/axelar-core/x/permission/exported"
+	"github.com/axelarnetwork/axelar-core/x/permission/keeper"
 )
 
 func TestKeeper_GetRole_nil_Address_Return_Unrestricted(t *testing.T) {


### PR DESCRIPTION
The RestrictedTx ante handler assumes that messages always have a signer and panics when there are none. However, messages routed through the nexus gateway do not have signers, so this prevents routing from amplifier to core. With this fix wasm messages are treated as if they had a signer of the lowest access level.