### PR TITLE
fix: update cosign version

### DIFF
--- a/.github/workflows/build-docker-image-and-binaries.yaml
+++ b/.github/workflows/build-docker-image-and-binaries.yaml
@@ -210,7 +210,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v1.13.1'
+          cosign-release: 'v1.13.3'
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/build-docker-image-and-binaries.yaml
+++ b/.github/workflows/build-docker-image-and-binaries.yaml
@@ -226,7 +226,7 @@ jobs:
           SEMVER: ${{ github.event.inputs.tag }}
 
       - name: Sign the images with GitHub OIDC
-        run: cosign sign --oidc-issuer https://token.actions.githubusercontent.com ${TAGS}
+        run: cosign sign -y --oidc-issuer https://token.actions.githubusercontent.com ${TAGS}
         env:
           TAGS: axelarnet/axelar-core:${{ github.event.inputs.tag }}
           COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/build-docker-image-and-binaries.yaml
+++ b/.github/workflows/build-docker-image-and-binaries.yaml
@@ -208,9 +208,9 @@ jobs:
     steps:
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v3.3.0
         with:
-          cosign-release: 'v1.13.3'
+          cosign-release: 'v2.2.2'
 
       - name: Login to DockerHub
         uses: docker/login-action@v1


### PR DESCRIPTION
## Description
Cosign are changing their TUF Trust Root, need to update cosign binary for it work again. 

https://blog.sigstore.dev/tuf-root-update/

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
