### PR TITLE
fix(app): remove wasm store migration

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -530,13 +530,6 @@ func (app *AxelarApp) setUpgradeBehaviour(configurator module.Configurator, keep
 	if upgradeInfo.Name == upgradeName(app.Version()) && !upgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := store.StoreUpgrades{}
 
-		if IsWasmEnabled() {
-			storeUpgrades.Added = append(storeUpgrades.Added, wasm.ModuleName)
-		}
-		if IsIBCWasmHooksEnabled() {
-			storeUpgrades.Added = append(storeUpgrades.Added, ibchookstypes.StoreKey)
-		}
-
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}


### PR DESCRIPTION
## Description

Remove wasm and ibc hooks store addition since they were added in `v0.35`

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
