### PR TITLE
fix(axelarnet): replace native asset with bond denom for dust amount

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -452,6 +452,7 @@ func initMessageRouter(keepers *KeeperCache) nexusTypes.MessageRouter {
 			axelarbankkeeper.NewBankKeeper(GetKeeper[bankkeeper.BaseKeeper](keepers)),
 			GetKeeper[nexusKeeper.Keeper](keepers),
 			GetKeeper[authkeeper.AccountKeeper](keepers),
+			GetKeeper[stakingkeeper.Keeper](keepers),
 		))
 
 	if IsWasmEnabled() {

--- a/x/axelarnet/keeper/message_route_test.go
+++ b/x/axelarnet/keeper/message_route_test.go
@@ -84,6 +84,7 @@ func TestNewMessageRoute(t *testing.T) {
 		bankK     *mock.BankKeeperMock
 		nexusK    *mock.NexusMock
 		accountK  *mock.AccountKeeperMock
+		stakingK  *mock.StakingKeeperMock
 	)
 
 	givenMessageRoute := Given("the message route", func() {
@@ -93,8 +94,12 @@ func TestNewMessageRoute(t *testing.T) {
 		bankK = &mock.BankKeeperMock{}
 		nexusK = &mock.NexusMock{}
 		accountK = &mock.AccountKeeperMock{}
+		stakingK = &mock.StakingKeeperMock{}
+		stakingK.BondDenomFunc = func(ctx sdk.Context) string {
+			return exported.NativeAsset
+		}
 
-		route = keeper.NewMessageRoute(k, ibcK, feegrantK, bankK, nexusK, accountK)
+		route = keeper.NewMessageRoute(k, ibcK, feegrantK, bankK, nexusK, accountK, stakingK)
 	})
 
 	givenMessageRoute.

--- a/x/axelarnet/types/expected_keepers.go
+++ b/x/axelarnet/types/expected_keepers.go
@@ -124,7 +124,7 @@ type GovKeeper interface {
 	GetProposal(ctx sdk.Context, proposalID uint64) (govtypes.Proposal, bool)
 }
 
-// StakingKeeper provides functionality to the gov module
+// StakingKeeper provides functionality to the staking module
 type StakingKeeper interface {
 	BondDenom(ctx sdk.Context) string
 }

--- a/x/axelarnet/types/expected_keepers.go
+++ b/x/axelarnet/types/expected_keepers.go
@@ -20,7 +20,7 @@ import (
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
 )
 
-//go:generate moq -out ./mock/expected_keepers.go -pkg mock . BaseKeeper Nexus BankKeeper IBCTransferKeeper ChannelKeeper AccountKeeper PortKeeper GovKeeper FeegrantKeeper IBCKeeper
+//go:generate moq -out ./mock/expected_keepers.go -pkg mock . BaseKeeper Nexus BankKeeper IBCTransferKeeper ChannelKeeper AccountKeeper PortKeeper GovKeeper StakingKeeper FeegrantKeeper IBCKeeper
 
 // BaseKeeper is implemented by this module's base keeper
 type BaseKeeper interface {
@@ -122,6 +122,11 @@ type PortKeeper interface {
 // GovKeeper provides functionality to the gov module
 type GovKeeper interface {
 	GetProposal(ctx sdk.Context, proposalID uint64) (govtypes.Proposal, bool)
+}
+
+// StakingKeeper provides functionality to the gov module
+type StakingKeeper interface {
+	BondDenom(ctx sdk.Context) string
 }
 
 // FeegrantKeeper defines the expected feegrant keeper.

--- a/x/axelarnet/types/mock/expected_keepers.go
+++ b/x/axelarnet/types/mock/expected_keepers.go
@@ -3243,6 +3243,72 @@ func (mock *GovKeeperMock) GetProposalCalls() []struct {
 	return calls
 }
 
+// Ensure, that StakingKeeperMock does implement axelarnettypes.StakingKeeper.
+// If this is not the case, regenerate this file with moq.
+var _ axelarnettypes.StakingKeeper = &StakingKeeperMock{}
+
+// StakingKeeperMock is a mock implementation of axelarnettypes.StakingKeeper.
+//
+//	func TestSomethingThatUsesStakingKeeper(t *testing.T) {
+//
+//		// make and configure a mocked axelarnettypes.StakingKeeper
+//		mockedStakingKeeper := &StakingKeeperMock{
+//			BondDenomFunc: func(ctx cosmossdktypes.Context) string {
+//				panic("mock out the BondDenom method")
+//			},
+//		}
+//
+//		// use mockedStakingKeeper in code that requires axelarnettypes.StakingKeeper
+//		// and then make assertions.
+//
+//	}
+type StakingKeeperMock struct {
+	// BondDenomFunc mocks the BondDenom method.
+	BondDenomFunc func(ctx cosmossdktypes.Context) string
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// BondDenom holds details about calls to the BondDenom method.
+		BondDenom []struct {
+			// Ctx is the ctx argument value.
+			Ctx cosmossdktypes.Context
+		}
+	}
+	lockBondDenom sync.RWMutex
+}
+
+// BondDenom calls BondDenomFunc.
+func (mock *StakingKeeperMock) BondDenom(ctx cosmossdktypes.Context) string {
+	if mock.BondDenomFunc == nil {
+		panic("StakingKeeperMock.BondDenomFunc: method is nil but StakingKeeper.BondDenom was just called")
+	}
+	callInfo := struct {
+		Ctx cosmossdktypes.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockBondDenom.Lock()
+	mock.calls.BondDenom = append(mock.calls.BondDenom, callInfo)
+	mock.lockBondDenom.Unlock()
+	return mock.BondDenomFunc(ctx)
+}
+
+// BondDenomCalls gets all the calls that were made to BondDenom.
+// Check the length with:
+//
+//	len(mockedStakingKeeper.BondDenomCalls())
+func (mock *StakingKeeperMock) BondDenomCalls() []struct {
+	Ctx cosmossdktypes.Context
+} {
+	var calls []struct {
+		Ctx cosmossdktypes.Context
+	}
+	mock.lockBondDenom.RLock()
+	calls = mock.calls.BondDenom
+	mock.lockBondDenom.RUnlock()
+	return calls
+}
+
 // Ensure, that FeegrantKeeperMock does implement axelarnettypes.FeegrantKeeper.
 // If this is not the case, regenerate this file with moq.
 var _ axelarnettypes.FeegrantKeeper = &FeegrantKeeperMock{}


### PR DESCRIPTION
## Description

When sending the mandatory dust amount for `GeneralMessage` message types, the denomination should be the one that is actually used for bonding tokens rather the the default native asset. This is because when instantiating an axelar network, the actually bond denom may not be the same as the default denom.

## Todos

- [ ] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
