### PR TITLE
fix(nexus)!: prevent messages from wasm to use nexus registered source chain

### DIFF
--- a/x/nexus/keeper/msg_dispatcher.go
+++ b/x/nexus/keeper/msg_dispatcher.go
@@ -63,9 +63,14 @@ func (m Messenger) routeMsg(ctx sdk.Context, msg exported.WasmMessage) error {
 		return err
 	}
 
+	// Prevent wasm gateway from spoofing a chain name registered in nexus as the source chain
+	if _, ok := m.GetChain(ctx, msg.SourceChain); ok {
+		return fmt.Errorf("wasm source chain %s should not be a registered chain in nexus", msg.SourceChain)
+	}
+
 	destinationChain, ok := m.GetChain(ctx, msg.DestinationChain)
 	if !ok {
-		return fmt.Errorf("recipient chain %s is not a registered chain", msg.DestinationChain)
+		return fmt.Errorf("destination chain %s is not a registered chain in nexus", msg.DestinationChain)
 	}
 
 	// If message already exists, then this is a no-op to avoid causing an error from reverting the whole message batch being routed in Amplifier


### PR DESCRIPTION
[AXE-4844]

## Description

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes


[AXE-4844]: https://axelarnetwork.atlassian.net/browse/AXE-4844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ