### PR TITLE
ci: remove binary_file path from axelard builds on r2

### DIFF
--- a/.github/workflows/build-binaries-and-push-to-r2.yaml
+++ b/.github/workflows/build-binaries-and-push-to-r2.yaml
@@ -48,9 +48,9 @@ jobs:
                 commit_hash=$(git rev-parse --short HEAD)
                 echo "Semantic Version of current binary: $semver"
                 cd ..
-                mkdir -p ./binary_file/$commit_hash/
-                sudo mv axelar-core/bin/axelard ./binary_file/$commit_hash/axelard-linux-amd64-$semver
-                echo "binary-directory=./binary_file" >> $GITHUB_OUTPUT
+                mkdir -p ./$commit_hash/
+                sudo mv axelar-core/bin/axelard ./$commit_hash/axelard-linux-amd64-$semver
+                echo "binary-directory=./$commit_hash" >> $GITHUB_OUTPUT
 
             - name: List contents of root directory
               run: ls -la


### PR DESCRIPTION
## Description

AXE-5160

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
