### PR TITLE
fix axelard_tx_vesting_create-vesting-account.md

### DIFF
--- a/docs/cli/axelard_tx_vesting_create-vesting-account.md
+++ b/docs/cli/axelard_tx_vesting_create-vesting-account.md
@@ -6,7 +6,7 @@ Create a new vesting account funded with an allocation of tokens.
 
 Create a new vesting account funded with an allocation of tokens. The
 account can either be a delayed or continuous vesting account, which is determined
-by the '--delayed' flag. All vesting accouts created will have their start time
+by the '--delayed' flag. All vesting accounts created will have their start time
 set by the committed block's time. The end_time must be provided as a UNIX epoch
 timestamp.
 


### PR DESCRIPTION
# Pull Request Title
**Fix typo: "accouts" to "accounts" in axelard_tx_vesting_create-vesting-account.md**

## Description
This PR fixes a typo in the `axelard_tx_vesting_create-vesting-account.md` file. The word "accouts" has been corrected to "accounts."
