### PR TITLE
Fix/typo queuer.go

### DIFF
--- a/utils/queuer.go
+++ b/utils/queuer.go
@@ -42,7 +42,7 @@ type GeneralKVQueue struct {
 	prioritizer func(value codec.ProtoMarshaler) Key
 }
 
-// NewGeneralKVQueue is the contructor for GeneralKVQueue
+// NewGeneralKVQueue is the constructor for GeneralKVQueue
 func NewGeneralKVQueue(name string, store KVStore, logger log.Logger, prioritizer func(value codec.ProtoMarshaler) Key) GeneralKVQueue {
 	return GeneralKVQueue{
 		name:        KeyFromStr(name),


### PR DESCRIPTION
Replaced "contructor" with "constructor" in the comment: "NewGeneralKVQueue is the contructor for GeneralKVQueue."