### PR TITLE
chore!: update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,9 @@ replace github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
 replace github.com/rjeczalik/notify => github.com/rjeczalik/notify v0.9.3
 
 // use cometbft
-replace github.com/tendermint/tendermint => github.com/cometbft/cometbft v0.34.31
+replace github.com/tendermint/tendermint => github.com/axelarnetwork/cometbft v0.34.32-0.20250205201135-f2813762d7f7
 
 // Temporary replacement for rosetta support
 replace github.com/cosmos/cosmos-sdk => github.com/axelarnetwork/cosmos-sdk v0.45.17-0.20241216210753-523fb865146c
+
+replace github.com/CosmWasm/wasmd => github.com/axelarnetwork/wasmd v0.34.2-0.20250204232001-5afc4d484c69

--- a/go.sum
+++ b/go.sum
@@ -621,8 +621,6 @@ github.com/ChainSafe/go-schnorrkel v1.0.0 h1:3aDA67lAykLaG1y3AOjs88dMxC88PgUuHRr
 github.com/ChainSafe/go-schnorrkel v1.0.0/go.mod h1:dpzHYVxLZcp8pjlV+O+UR8K0Hp/z7vcchBSbMBEhCw4=
 github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
 github.com/CloudyKit/jet/v3 v3.0.0/go.mod h1:HKQPgSJmdK8hdoAbKUUWajkHyHo4RaU5rMdUywE7VMo=
-github.com/CosmWasm/wasmd v0.34.1 h1:4pALn+N9F8ItxEG+aHX5IsTbf0Z8wcRf8Mz4I/ExW98=
-github.com/CosmWasm/wasmd v0.34.1/go.mod h1:MPhNbLmIHWxTVJZwdV/4QMslehW3Xpd1aPtLwEa2Lrk=
 github.com/CosmWasm/wasmvm v1.5.8 h1:vrmAvDuXcNqw7XqDiVDIyopo9gNdkcvRLFTC8+wBb/A=
 github.com/CosmWasm/wasmvm v1.5.8/go.mod h1:2qaMB5ISmYXtpkJR2jy8xxx5Ti8sntOEf1cUgolb4QI=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
@@ -696,12 +694,16 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
+github.com/axelarnetwork/cometbft v0.34.32-0.20250205201135-f2813762d7f7 h1:otGPjMsmuAIvJ++VqycbJKyVWEGEVFhil/pBetskqA8=
+github.com/axelarnetwork/cometbft v0.34.32-0.20250205201135-f2813762d7f7/go.mod h1:myvkihZD8eg9jKE3WFaugkNoL5nvEqlP7Jbjg98pCek=
 github.com/axelarnetwork/cosmos-sdk v0.45.17-0.20241216210753-523fb865146c h1:VD4Iz9AT2dihqqktW6Y4aRe1bRHPR+A4wqcOw+zxW1Q=
 github.com/axelarnetwork/cosmos-sdk v0.45.17-0.20241216210753-523fb865146c/go.mod h1:bScuNwWAP0TZJpUf+SHXRU3xGoUPp+X9nAzfeIXts40=
 github.com/axelarnetwork/tm-events v0.0.0-20230704201410-3cf91089034b h1:qTbA+WlbMRiPtK5zn5evVfU2XhmIOrOZNIE8VNU1O3Q=
 github.com/axelarnetwork/tm-events v0.0.0-20230704201410-3cf91089034b/go.mod h1:vDpqqxWxMvMIKbF6DN3BkxXAI4UJjolCHvaMGhE/FCI=
 github.com/axelarnetwork/utils v0.0.0-20230706045331-b7aacc1f4a2f h1:Q0Qh79MuZ/PWKzytqU8/4dt+S2QemdYYPXkjwp/i4l0=
 github.com/axelarnetwork/utils v0.0.0-20230706045331-b7aacc1f4a2f/go.mod h1:7N7/Qo5WOm8HnwCtWvQs7T5QQLwVoLU/v+KkMLrvxiA=
+github.com/axelarnetwork/wasmd v0.34.2-0.20250204232001-5afc4d484c69 h1:KtIVuYfsqcdfza2M1C/doGdITg77LP0dC40ZSHqpruE=
+github.com/axelarnetwork/wasmd v0.34.2-0.20250204232001-5afc4d484c69/go.mod h1:MPhNbLmIHWxTVJZwdV/4QMslehW3Xpd1aPtLwEa2Lrk=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -792,8 +794,6 @@ github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcju
 github.com/coinbase/kryptology v1.8.0/go.mod h1:RYXOAPdzOGUe3qlSFkMGn58i3xUA8hmxYHksuq+8ciI=
 github.com/coinbase/rosetta-sdk-go v0.7.9 h1:lqllBjMnazTjIqYrOGv8h8jxjg9+hJazIGZr9ZvoCcA=
 github.com/coinbase/rosetta-sdk-go v0.7.9/go.mod h1:0/knutI7XGVqXmmH4OQD8OckFrbQ8yMsUZTG7FXCR2M=
-github.com/cometbft/cometbft v0.34.31 h1:DyjxPU8Gua6vhu7NY6zSxSXi/3QtiPoiKWnYfyqo3PA=
-github.com/cometbft/cometbft v0.34.31/go.mod h1:myvkihZD8eg9jKE3WFaugkNoL5nvEqlP7Jbjg98pCek=
 github.com/cometbft/cometbft-db v0.7.0 h1:uBjbrBx4QzU0zOEnU8KxoDl18dMNgDh+zZRUE0ucsbo=
 github.com/cometbft/cometbft-db v0.7.0/go.mod h1:yiKJIm2WKrt6x8Cyxtq9YTEcIMPcEe4XPxhgX59Fzf0=
 github.com/confio/ics23/go v0.9.1 h1:3MV46eeWwO3xCauKyAtuAdJYMyPnnchW4iLr2bTw6/U=


### PR DESCRIPTION
## Description
This pr updates wasmd and combet bft deps.
- wasmd pointed to [commit ](https://github.com/axelarnetwork/wasmd/commits/releases/v0.34.x/) contains CWA-2024-005 fix based on v0.34.1.
- combet bft upgraded to include [fixes](https://github.com/axelarnetwork/cometbft/commits/releases/v0.34.x/) for [ASA-2025-002](https://github.com/cometbft/cometbft/security/advisories/GHSA-r3r4-g7hq-pq4f) and [sanity check for proposed blocks size](https://github.com/cometbft/cometbft/pull/1408), based on v0.34.31.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
