### PR TITLE
refactor: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/x/evm/abci.go
+++ b/x/evm/abci.go
@@ -1,6 +1,7 @@
 package evm
 
 import (
+	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -21,7 +22,7 @@ import (
 func handleTokenSent(ctx sdk.Context, event types.Event, bk types.BaseKeeper, n types.Nexus) error {
 	e := event.GetEvent().(*types.Event_TokenSent).TokenSent
 	if e == nil {
-		panic(fmt.Errorf("event is nil"))
+		panic(errors.New("event is nil"))
 	}
 
 	sourceChain := funcs.MustOk(n.GetChain(ctx, event.Chain))
@@ -69,7 +70,7 @@ func handleTokenSent(ctx sdk.Context, event types.Event, bk types.BaseKeeper, n 
 func handleContractCall(ctx sdk.Context, event types.Event, bk types.BaseKeeper, n types.Nexus, multisig types.MultisigKeeper) error {
 	e := event.GetContractCall()
 	if e == nil {
-		panic(fmt.Errorf("event is nil"))
+		panic(errors.New("event is nil"))
 	}
 
 	destinationChain := funcs.MustOk(n.GetChain(ctx, e.DestinationChain))
@@ -86,7 +87,7 @@ func handleContractCall(ctx sdk.Context, event types.Event, bk types.BaseKeeper,
 func handleContractCallToEVM(ctx sdk.Context, bk types.BaseKeeper, multisig types.MultisigKeeper, n types.Nexus, destinationChain nexus.ChainName, event types.Event) {
 	e := event.GetContractCall()
 	if e == nil {
-		panic(fmt.Errorf("event is nil"))
+		panic(errors.New("event is nil"))
 	}
 
 	destinationCk := funcs.Must(bk.ForChain(ctx, destinationChain))
@@ -119,7 +120,7 @@ func handleContractCallToEVM(ctx sdk.Context, bk types.BaseKeeper, multisig type
 func handleContractCallWithToken(ctx sdk.Context, event types.Event, bk types.BaseKeeper, n types.Nexus, multisig types.MultisigKeeper) error {
 	e := event.GetContractCallWithToken()
 	if e == nil {
-		panic(fmt.Errorf("event is nil"))
+		panic(errors.New("event is nil"))
 	}
 
 	sourceChain := funcs.MustOk(n.GetChain(ctx, event.Chain))
@@ -149,7 +150,7 @@ func handleContractCallWithToken(ctx sdk.Context, event types.Event, bk types.Ba
 func handleContractCallWithTokenToEVM(ctx sdk.Context, event types.Event, bk types.BaseKeeper, n types.Nexus, multisig types.MultisigKeeper, sourceChain, destinationChain nexus.ChainName, asset string) error {
 	e := event.GetContractCallWithToken()
 	if e == nil {
-		panic(fmt.Errorf("event is nil"))
+		panic(errors.New("event is nil"))
 	}
 
 	destinationCk := funcs.Must(bk.ForChain(ctx, destinationChain))
@@ -228,7 +229,7 @@ func setMessageToNexus(ctx sdk.Context, n types.Nexus, event types.Event, asset 
 
 	case *types.Event_ContractCallWithToken:
 		if asset == nil {
-			return fmt.Errorf("expect asset for ContractCallWithToken")
+			return errors.New("expect asset for ContractCallWithToken")
 		}
 
 		sender := nexus.CrossChainAddress{
@@ -264,7 +265,7 @@ func setMessageToNexus(ctx sdk.Context, n types.Nexus, event types.Event, asset 
 func handleConfirmDeposit(ctx sdk.Context, event types.Event, bk types.BaseKeeper, n types.Nexus) error {
 	e := event.GetEvent().(*types.Event_Transfer).Transfer
 	if e == nil {
-		panic(fmt.Errorf("event is nil"))
+		panic(errors.New("event is nil"))
 	}
 
 	chain := funcs.MustOk(n.GetChain(ctx, event.Chain))
@@ -336,7 +337,7 @@ func handleConfirmDeposit(ctx sdk.Context, event types.Event, bk types.BaseKeepe
 func handleTokenDeployed(ctx sdk.Context, event types.Event, bk types.BaseKeeper, n types.Nexus) error {
 	e := event.GetEvent().(*types.Event_TokenDeployed).TokenDeployed
 	if e == nil {
-		panic(fmt.Errorf("event is nil"))
+		panic(errors.New("event is nil"))
 	}
 
 	chain := funcs.MustOk(n.GetChain(ctx, event.Chain))
@@ -380,7 +381,7 @@ func handleTokenDeployed(ctx sdk.Context, event types.Event, bk types.BaseKeeper
 func handleMultisigTransferKey(ctx sdk.Context, event types.Event, bk types.BaseKeeper, n types.Nexus, multisig types.MultisigKeeper) error {
 	e := event.GetEvent().(*types.Event_MultisigOperatorshipTransferred).MultisigOperatorshipTransferred
 	if e == nil {
-		panic(fmt.Errorf("event is nil"))
+		panic(errors.New("event is nil"))
 	}
 
 	chain := funcs.MustOk(n.GetChain(ctx, event.Chain))
@@ -409,17 +410,17 @@ func handleMultisigTransferKey(ctx sdk.Context, event types.Event, bk types.Base
 	for i, newAddress := range newAddresses {
 		newAddressHex := newAddress.Hex()
 		if addressSeen[newAddressHex] {
-			return fmt.Errorf("duplicate address in new addresses")
+			return errors.New("duplicate address in new addresses")
 		}
 		addressSeen[newAddressHex] = true
 
 		expectedWeight, ok := expectedAddressWeights[newAddressHex]
 		if !ok {
-			return fmt.Errorf("new addresses do not match")
+			return errors.New("new addresses do not match")
 		}
 
 		if !expectedWeight.Equal(newWeights[i]) {
-			return fmt.Errorf("new weights do not match")
+			return errors.New("new weights do not match")
 		}
 	}
 
@@ -473,12 +474,12 @@ func validateEvent(ctx sdk.Context, event types.Event, bk types.BaseKeeper, n ty
 	// skip if destination chain is not registered
 	destinationChain, ok := n.GetChain(ctx, destinationChainName)
 	if !ok {
-		return fmt.Errorf("destination chain not found")
+		return errors.New("destination chain not found")
 	}
 
 	// skip if destination chain is not activated
 	if !n.IsChainActivated(ctx, destinationChain) {
-		return fmt.Errorf("destination chain de-activated")
+		return errors.New("destination chain de-activated")
 	}
 
 	// skip further destination chain keeper checks if it is not an evm chain
@@ -487,17 +488,17 @@ func validateEvent(ctx sdk.Context, event types.Event, bk types.BaseKeeper, n ty
 	}
 
 	if len(contractAddress) != 0 && !common.IsHexAddress(contractAddress) {
-		return fmt.Errorf("invalid contract address")
+		return errors.New("invalid contract address")
 	}
 
 	destinationCk, err := bk.ForChain(ctx, destinationChainName)
 	if err != nil {
-		return fmt.Errorf("destination chain not EVM-compatible")
+		return errors.New("destination chain not EVM-compatible")
 	}
 
 	// skip if destination chain has not got gateway set yet
 	if _, ok := destinationCk.GetGatewayAddress(ctx); !ok {
-		return fmt.Errorf("destination chain gateway not deployed yet")
+		return errors.New("destination chain gateway not deployed yet")
 	}
 
 	return nil
@@ -575,19 +576,19 @@ func validateMessage(ctx sdk.Context, ck types.ChainKeeper, n types.Nexus, m typ
 	// TODO refactor to do these checks earlier so we don't fail in the end blocker
 	_, ok := m.GetCurrentKeyID(ctx, chain.Name)
 	if !ok {
-		return fmt.Errorf("current key not set")
+		return errors.New("current key not set")
 	}
 
 	if !n.IsChainActivated(ctx, chain) {
-		return fmt.Errorf("destination chain de-activated")
+		return errors.New("destination chain de-activated")
 	}
 
 	if _, ok := ck.GetGatewayAddress(ctx); !ok {
-		return fmt.Errorf("destination chain gateway not deployed yet")
+		return errors.New("destination chain gateway not deployed yet")
 	}
 
 	if !common.IsHexAddress(msg.GetDestinationAddress()) {
-		return fmt.Errorf("invalid contract address")
+		return errors.New("invalid contract address")
 	}
 
 	switch msg.Type() {

--- a/x/evm/client/cli/query.go
+++ b/x/evm/client/cli/query.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -113,7 +114,7 @@ func getCmdTokenAddress(queryRoute string) *cobra.Command {
 		case *symbol == "" && *asset != "":
 			bz, _, err = cliCtx.Query(fmt.Sprintf("custom/%s/%s/%s/%s", queryRoute, keeper.QTokenAddressByAsset, args[0], *asset))
 		default:
-			return fmt.Errorf("lookup must be either by asset name or symbol")
+			return errors.New("lookup must be either by asset name or symbol")
 		}
 
 		if err != nil {
@@ -560,7 +561,7 @@ func getCmdTokenInfo() *cobra.Command {
 		}
 
 		if !exactlyOneIsFilled(*symbol, *asset, *address) {
-			return fmt.Errorf("lookup must be either by asset name, symbol, or address")
+			return errors.New("lookup must be either by asset name, symbol, or address")
 		}
 
 		var req types.TokenInfoRequest

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"strconv"
@@ -272,15 +273,15 @@ func GetCmdCreateDeployToken() *cobra.Command {
 		symbol := args[4]
 		decs, err := strconv.ParseUint(args[5], 10, 8)
 		if err != nil {
-			return fmt.Errorf("could not parse decimals")
+			return errors.New("could not parse decimals")
 		}
 		capacity, ok := sdk.NewIntFromString(args[6])
 		if !ok {
-			return fmt.Errorf("could not parse capacity")
+			return errors.New("could not parse capacity")
 		}
 
 		if !common.IsHexAddress(*address) {
-			return fmt.Errorf("could not parse address")
+			return errors.New("could not parse address")
 		}
 
 		mintLimit := args[7]

--- a/x/evm/types/genesis.go
+++ b/x/evm/types/genesis.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -66,7 +67,7 @@ func DefaultChains() []GenesisState_Chain {
 // Validate validates the genesis state
 func (m GenesisState) Validate() error {
 	if !sort.SliceIsSorted(m.Chains, less(m.Chains)) {
-		return getValidateError(0, fmt.Errorf("chains must be sorted by name (in params)"))
+		return getValidateError(0, errors.New("chains must be sorted by name (in params)"))
 	}
 
 	// events should be globally unique across all the chains
@@ -81,19 +82,19 @@ func (m GenesisState) Validate() error {
 			errStr := "gateway is not set"
 
 			if len(chain.Tokens) > 0 {
-				return getValidateError(j, sdkerrors.Wrap(fmt.Errorf("cannot initialize tokens"), errStr))
+				return getValidateError(j, sdkerrors.Wrap(errors.New("cannot initialize tokens"), errStr))
 			}
 
 			if len(chain.ConfirmedDeposits) > 0 {
-				return getValidateError(j, sdkerrors.Wrap(fmt.Errorf("cannot have confirmed deposits"), errStr))
+				return getValidateError(j, sdkerrors.Wrap(errors.New("cannot have confirmed deposits"), errStr))
 			}
 
 			if len(chain.BurnedDeposits) > 0 {
-				return getValidateError(j, sdkerrors.Wrap(fmt.Errorf("cannot have burned deposits"), errStr))
+				return getValidateError(j, sdkerrors.Wrap(errors.New("cannot have burned deposits"), errStr))
 			}
 
 			if len(chain.BurnerInfos) > 0 {
-				return getValidateError(j, sdkerrors.Wrap(fmt.Errorf("cannot have burned deposits"), errStr))
+				return getValidateError(j, sdkerrors.Wrap(errors.New("cannot have burned deposits"), errStr))
 			}
 		}
 

--- a/x/evm/types/msg_confirm_gateway_tx.go
+++ b/x/evm/types/msg_confirm_gateway_tx.go
@@ -1,8 +1,7 @@
 package types
 
 import (
-	"fmt"
-
+	"errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
@@ -40,7 +39,7 @@ func (m ConfirmGatewayTxRequest) ValidateBasic() error {
 	}
 
 	if m.TxID.IsZero() {
-		return fmt.Errorf("invalid tx id")
+		return errors.New("invalid tx id")
 	}
 
 	return nil

--- a/x/evm/types/msg_create_deploy_token.go
+++ b/x/evm/types/msg_create_deploy_token.go
@@ -1,8 +1,7 @@
 package types
 
 import (
-	"fmt"
-
+	"errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
@@ -60,11 +59,11 @@ func (m CreateDeployTokenRequest) ValidateBasic() error {
 	switch m.Address.IsZeroAddress() {
 	case true:
 		if m.Chain.Equals(m.Asset.Chain) {
-			return fmt.Errorf("cannot deploy token on the origin chain")
+			return errors.New("cannot deploy token on the origin chain")
 		}
 	case false:
 		if !m.Chain.Equals(m.Asset.Chain) {
-			return fmt.Errorf("cannot link token on a different chain")
+			return errors.New("cannot link token on a different chain")
 		}
 	}
 

--- a/x/evm/types/types.go
+++ b/x/evm/types/types.go
@@ -796,7 +796,7 @@ func (m TokenDetails) Validate() error {
 	}
 
 	if m.Capacity.IsNil() || m.Capacity.IsNegative() {
-		return fmt.Errorf("token capacity must be a non-negative number")
+		return errors.New("token capacity must be a non-negative number")
 	}
 
 	return nil
@@ -804,7 +804,7 @@ func (m TokenDetails) Validate() error {
 
 func packArguments(chainID sdk.Int, commandIDs []CommandID, commands []CommandType, commandParams [][]byte) ([]byte, error) {
 	if len(commandIDs) != len(commands) || len(commandIDs) != len(commandParams) {
-		return nil, fmt.Errorf("length mismatch for command arguments")
+		return nil, errors.New("length mismatch for command arguments")
 	}
 
 	uint256Type, err := abi.NewType("uint256", "uint256", nil)
@@ -861,7 +861,7 @@ func (m *BurnerInfo) ValidateBasic() error {
 // ValidateBasic does stateless validation of the object
 func (m *ERC20TokenMetadata) ValidateBasic() error {
 	if m.Status == NonExistent {
-		return fmt.Errorf("token status not set")
+		return errors.New("token status not set")
 	}
 
 	if err := sdk.ValidateDenom(m.Asset); err != nil {
@@ -869,7 +869,7 @@ func (m *ERC20TokenMetadata) ValidateBasic() error {
 	}
 
 	if m.ChainID.IsNil() || !m.ChainID.IsPositive() {
-		return fmt.Errorf("chain ID not set")
+		return errors.New("chain ID not set")
 	}
 
 	if err := m.Details.Validate(); err != nil {
@@ -879,7 +879,7 @@ func (m *ERC20TokenMetadata) ValidateBasic() error {
 	switch m.IsExternal {
 	case true:
 		if m.BurnerCode != nil {
-			return fmt.Errorf("burner code for external tokens must be nil")
+			return errors.New("burner code for external tokens must be nil")
 		}
 	case false:
 		if err := validateBurnerCode(m.BurnerCode); err != nil {
@@ -901,7 +901,7 @@ func (m *ERC20Deposit) ValidateBasic() error {
 	}
 
 	if m.Amount.IsZero() {
-		return fmt.Errorf("amount must be >0")
+		return errors.New("amount must be >0")
 	}
 
 	return nil
@@ -929,13 +929,13 @@ func (m Event) ValidateBasic() error {
 	}
 
 	if m.TxID.IsZero() {
-		return fmt.Errorf("invalid tx id")
+		return errors.New("invalid tx id")
 	}
 
 	switch event := m.GetEvent().(type) {
 	case *Event_ContractCall:
 		if event.ContractCall == nil {
-			return fmt.Errorf("missing event ContractCall")
+			return errors.New("missing event ContractCall")
 		}
 
 		if err := event.ContractCall.ValidateBasic(); err != nil {
@@ -943,7 +943,7 @@ func (m Event) ValidateBasic() error {
 		}
 	case *Event_ContractCallWithToken:
 		if event.ContractCallWithToken == nil {
-			return fmt.Errorf("missing event ContractCallWithToken")
+			return errors.New("missing event ContractCallWithToken")
 		}
 
 		if err := event.ContractCallWithToken.ValidateBasic(); err != nil {
@@ -951,7 +951,7 @@ func (m Event) ValidateBasic() error {
 		}
 	case *Event_TokenSent:
 		if event.TokenSent == nil {
-			return fmt.Errorf("missing event TokenSent")
+			return errors.New("missing event TokenSent")
 		}
 
 		if err := event.TokenSent.ValidateBasic(); err != nil {


### PR DESCRIPTION
Replaced fmt.Errorf with errors.New in cases where formatting is not required. This reduces unnecessary function calls, leading to slightly improved performance and cleaner code.