### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/x/permission/exported/types_test.go
+++ b/x/permission/exported/types_test.go
@@ -1,13 +1,13 @@
 package exported_test
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slices"
 
 	"github.com/axelarnetwork/axelar-core/app"
 	"github.com/axelarnetwork/axelar-core/x/permission/exported"

--- a/x/vote/types/types.go
+++ b/x/vote/types/types.go
@@ -1,13 +1,14 @@
 package types
 
 import (
+	"slices"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/axelarnetwork/axelar-core/x/vote/exported"
 )


### PR DESCRIPTION
## Description

Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
