### PR TITLE
[undelegate] compare same types

### DIFF
--- a/x/ante/undelegate.go
+++ b/x/ante/undelegate.go
@@ -40,8 +40,10 @@ func (d UndelegateDecorator) AnteHandle(ctx sdk.Context, msgs []sdk.Msg, simulat
 				return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 			}
 
-			// only restrict a validator from unbonding it's self-delegation
-			if !delegatorAddress.Equals(valAddress) {
+			// Only restrict a validator from unbonding it's self-delegation
+			// Convert validator address to account address for comparison
+			valAccAddress := sdk.AccAddress(valAddress)
+			if !delegatorAddress.Equals(valAccAddress) {
 				continue
 			}
 


### PR DESCRIPTION
## Description

* I don't think? this is currently valid since you are comparing two different types of addresses: `sdk.AccAddress` (delegator address) with a `sdk.ValAddress` (validator address) using `.Equals()`
* While the interfaces are the same... these are different `cosmos1` vs. `cosmosvaloper1`
* Maybe no one has ever successfully exited / undelegated?  Maybe I am misunderstanding?

## Todos

- [ ] Unit tests
  - I don't see any existing unit tests around this code?
- [ ] Manual tests
  - I don't see any manual testing procedure to follow.
- [ ] Documentation
  - I don't see any existing documentation to update.

## Steps to Test

## Expected Behaviour

## Other Notes
