### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/build-binaries-and-push-to-r2.yaml
+++ b/.github/workflows/build-binaries-and-push-to-r2.yaml
@@ -32,7 +32,7 @@ jobs:
                 echo "ref=$ref" >> $GITHUB_OUTPUT
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                 fetch-depth: "0"
                 path: axelar-core

--- a/.github/workflows/build-docker-image-and-binaries.yaml
+++ b/.github/workflows/build-docker-image-and-binaries.yaml
@@ -48,7 +48,7 @@ jobs:
           aws s3 ls s3://axelar-releases/axelard/"$SEMVER" && echo "tag already exists, use a new one" && exit 1
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: '0'
           ref: ${{ github.event.inputs.tag }}
@@ -157,7 +157,7 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: '0'
           ref: ${{ github.event.inputs.tag }}

--- a/.github/workflows/build-latest-docker-image.yaml
+++ b/.github/workflows/build-latest-docker-image.yaml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: nelonoel/branch-name@v1.0.1
 

--- a/.github/workflows/check-go-generate.yaml
+++ b/.github/workflows/check-go-generate.yaml
@@ -22,7 +22,7 @@ jobs:
           key: pip-cache
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get Bytecode Version
         id: bytecode_version

--- a/.github/workflows/check-internal-deps.yaml
+++ b/.github/workflows/check-internal-deps.yaml
@@ -15,7 +15,7 @@ jobs:
           go-version: 1.23
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Update internal dependencies
         run: |

--- a/.github/workflows/check-proto-generate.yaml
+++ b/.github/workflows/check-proto-generate.yaml
@@ -13,7 +13,7 @@ jobs:
           go-version: 1.23
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install prereqs
         run: |

--- a/.github/workflows/enforce-evm-migration.yaml
+++ b/.github/workflows/enforce-evm-migration.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: '0'
           ref: ${{ inputs.branch }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
           go-version: 1.23
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install golangci-lint
         run: make prereqs

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -32,7 +32,7 @@ jobs:
           output=json"  > ~/.aws/config
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: '0'
           submodules: recursive

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: '0'
           submodules: recursive

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: '0'
           submodules: recursive

--- a/.github/workflows/take-snapshot.yaml
+++ b/.github/workflows/take-snapshot.yaml
@@ -30,7 +30,7 @@ jobs:
           aws s3 ls s3://axelar-testnet-snapshots/axelartestnet-${{ github.event.inputs.axelard_version }}.tar.lz4 && echo "tag already exists, use a new one" && exit 1
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: '0'
           submodules: recursive

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Golang with cache
         uses: magnetikonline/action-golang-cache@v4

--- a/.github/workflows/testnet-catch-up.yml
+++ b/.github/workflows/testnet-catch-up.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Execute SSH commmands on remote server
       uses: JimCronqvist/action-ssh@master


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0