### PR TITLE
fix: remove duplicate test case in broadcast_test.go

### DIFF
--- a/sdk-utils/broadcast/broadcast_test.go
+++ b/sdk-utils/broadcast/broadcast_test.go
@@ -230,12 +230,6 @@ func TestStatefulBroadcaster(t *testing.T) {
 		Then2(returnErrorWithCode).Run(t)
 
 	givenSetup.
-		When2(sendingMultipleMessages).
-		When2(accountExists).
-		When2(getAccountSequenceMismatch).
-		Then2(returnErrorWithCode).Run(t)
-
-	givenSetup.
 		When2(sendingNoMessages).
 		Then2(returnError).Run(t)
 


### PR DESCRIPTION
Remove duplicated test case for account sequence mismatch scenario


Changes:
- Remove duplicate test case 
- Maintain complete test coverage for account sequence mismatch scenario


Fixes redundant test execution while maintaining the same test coverage.