### PR TITLE
fix: reduce maxBitmapSize from 32,768 to 1,024 in nexus maintainer state

### DIFF
--- a/x/nexus/types/types.go
+++ b/x/nexus/types/types.go
@@ -10,7 +10,7 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/nexus/exported"
 )
 
-const maxBitmapSize = 1 << 15 // 32,768
+const maxBitmapSize = 1 << 10 // 1,024
 
 // NewMaintainerState is the constructor for MaintainerState
 func NewMaintainerState(chain exported.ChainName, address sdk.ValAddress) *MaintainerState {


### PR DESCRIPTION
### Description
Reduce memory used to track whether validators haven't voted recently and if they need to get slashed. Currently this is hardcoded at 32k, while validators only need 500. I think it is safe to decrease it to 1,024. This still allows increasing the window by governance up to 1,023 (doubling the current value). This window hasn't changed in the last 4 years, so I think 500 is a good baseline. If we ever want to increase it past 1,023, we will need to bump this value again and release a new binary.

This is around 500MB less ram needed to maintain the state (52 validators, 20 chains).

### Next steps

Given the imminent release, should I wait? Or can I just land? What about the private-repo? Do I also need to land there? Not sure what the process used to be, and if we want to improve it?

Sorry to bombard you with all these reviews!

Part of CPI-182