### PR TITLE
feat(axelarnet): add destination callback payload

### DIFF
--- a/x/axelarnet/types/evm_translator.go
+++ b/x/axelarnet/types/evm_translator.go
@@ -29,6 +29,7 @@ const (
 	// - bytes4(0) To Native
 	// - bytes4(1) To CosmWasm Contract
 	// - bytes4(2) To CosmWasm Contract with json encoded payload
+	// - bytes4(3) To CosmWasm Contract with IBC destination callback
 	versionSize = 4
 
 	sourceChain   = "source_chain"
@@ -50,6 +51,17 @@ type contractCall struct {
 // wasm is the json that gets passed to the IBC memo field
 type wasm struct {
 	Wasm contractCall `json:"wasm"`
+}
+
+type destinationCallback struct {
+	Address string `json:"address"`
+}
+
+type destinationCallbackMessage struct {
+	DestCallback  destinationCallback `json:"dest_callback"`
+	SourceChain   string              `json:"source_chain"`
+	SourceAddress string              `json:"source_address"`
+	Payload       json.RawMessage     `json:"payload"`
 }
 
 type message struct {
@@ -82,6 +94,11 @@ func TranslateMessage(msg nexus.GeneralMessage, versionedPayload []byte) ([]byte
 		bz, err = ConstructWasmMessageV2(msg, payload)
 		if err != nil {
 			return nil, errorsmod.Wrap(err, "failed to construct wasm payload")
+		}
+	case CosmWasmDestinationCallbackV1:
+		bz, err = ConstructDestinationCallbackMessageV1(msg, payload)
+		if err != nil {
+			return nil, errorsmod.Wrap(err, "failed to construct destination callback payload")
 		}
 	default:
 		return nil, fmt.Errorf("unknown payload version")
@@ -211,6 +228,31 @@ func ConstructWasmMessageV2(gm nexus.GeneralMessage, payload []byte) ([]byte, er
 	msg = []byte(strings.Replace(string(msg), originalField, replacementField, 1))
 
 	return msg, err
+}
+
+// ConstructDestinationCallbackMessageV1 creates a json serialized IBC destination callback message from json encoded payload
+func ConstructDestinationCallbackMessageV1(gm nexus.GeneralMessage, payload []byte) ([]byte, error) {
+	if !json.Valid(payload) {
+		return nil, fmt.Errorf("invalid json payload")
+	}
+
+	msg, err := json.Marshal(destinationCallbackMessage{
+		DestCallback: destinationCallback{
+			Address: gm.GetDestinationAddress(),
+		},
+		SourceChain:   gm.GetSourceChain().String(),
+		SourceAddress: gm.GetSourceAddress(),
+		Payload:       nil,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	originalField := `"payload":null`
+	replacementField := fmt.Sprintf("\"payload\":%s", string(payload))
+	msg = []byte(strings.Replace(string(msg), originalField, replacementField, 1))
+
+	return msg, nil
 }
 
 // ConstructNativeMessage creates a json serialized cross chain message

--- a/x/axelarnet/types/evm_translator_test.go
+++ b/x/axelarnet/types/evm_translator_test.go
@@ -643,6 +643,80 @@ func TestConstructWasmMessageV2(t *testing.T) {
 	})
 }
 
+func TestConstructDestinationCallbackMessageV1(t *testing.T) {
+	version := types.CosmWasmDestinationCallbackV1
+
+	t.Run("should return error if payload is not valid json", func(t *testing.T) {
+		msg := nexustestutils.RandomMessage()
+		payload := axelartestutils.PackPayloadWithVersion(version, []byte(`{"key": "invalid json with open bracket"`))
+
+		_, err := types.TranslateMessage(msg, payload)
+		assert.ErrorContains(t, err, "invalid json payload")
+	})
+
+	t.Run("should construct destination callback memo without modifying payload", func(t *testing.T) {
+		msg := nexustestutils.RandomMessage()
+		msg.Sender.Chain.Name = "Ethereum"
+		msg.Sender.Address = "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"
+
+		callbackPayload := []byte(`{
+			"float": 4.51930,
+			"nested": {
+				"array": [1, 2, 3, 4],
+				"amount": 100000000000000000000000000000001
+			},
+			"array": [0, -32323, 84739338387784623428752342, -43785623.2342532],
+			"nil": null
+		}`)
+		payload := axelartestutils.PackPayloadWithVersion(version, callbackPayload)
+
+		translatedBz, err := types.TranslateMessage(msg, payload)
+		assert.NoError(t, err)
+
+		var decodedMsg struct {
+			DestCallback struct {
+				Address string `json:"address"`
+			} `json:"dest_callback"`
+			SourceChain   string          `json:"source_chain"`
+			SourceAddress string          `json:"source_address"`
+			Payload       json.RawMessage `json:"payload"`
+		}
+
+		err = json.Unmarshal(translatedBz, &decodedMsg)
+		assert.NoError(t, err)
+
+		assert.Equal(t, msg.GetDestinationAddress(), decodedMsg.DestCallback.Address)
+		assert.Equal(t, msg.GetSourceChain().String(), decodedMsg.SourceChain)
+		assert.Equal(t, msg.GetSourceAddress(), decodedMsg.SourceAddress)
+		assert.Equal(t, string(callbackPayload), string(decodedMsg.Payload))
+
+		var jsonObject map[string]interface{}
+		err = json.Unmarshal(translatedBz, &jsonObject)
+		assert.NoError(t, err)
+
+		destCallback, ok := jsonObject["dest_callback"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.NotContains(t, destCallback, "gas_limit")
+	})
+
+	t.Run("should construct destination callback memo from json string payload", func(t *testing.T) {
+		msg := nexustestutils.RandomMessage()
+		callbackPayload := []byte(`"raw string payload"`)
+		payload := axelartestutils.PackPayloadWithVersion(version, callbackPayload)
+
+		translatedBz, err := types.TranslateMessage(msg, payload)
+		assert.NoError(t, err)
+
+		var decodedMsg struct {
+			Payload json.RawMessage `json:"payload"`
+		}
+
+		err = json.Unmarshal(translatedBz, &decodedMsg)
+		assert.NoError(t, err)
+		assert.Equal(t, string(callbackPayload), string(decodedMsg.Payload))
+	})
+}
+
 func TestConstructNativeV1Message(t *testing.T) {
 	t.Run("should translate native payload", func(t *testing.T) {
 		payloadMsg := rand.Bytes(int(rand.I64Between(1, 50)))

--- a/x/axelarnet/types/types.go
+++ b/x/axelarnet/types/types.go
@@ -242,6 +242,8 @@ const (
 	CosmWasmV1 = "0x00000001"
 	// CosmWasmV2 indicates the payload is json encoded
 	CosmWasmV2 = "0x00000002"
+	// CosmWasmDestinationCallbackV1 indicates the payload is json encoded for IBC destination callbacks
+	CosmWasmDestinationCallbackV1 = "0x00000003"
 )
 
 var (


### PR DESCRIPTION
## Description

Closes #2338.

Adds a new EVM GMP payload version for IBC destination callbacks:

- `CosmWasmDestinationCallbackV1 = 0x00000003`
- translates JSON EVM GMP payloads into ICS20 memo format with `dest_callback.address`
- includes Axelar source metadata as top-level `source_chain` and `source_address`
- preserves the original JSON payload without remarshalling
- keeps the existing `NativeV1`, `CosmWasmV1`, and `CosmWasmV2` payload versions unchanged

The generated memo has the following shape:

```json
{
  "dest_callback": {
    "address": "<destination contract>"
  },
  "source_chain": "<source chain>",
  "source_address": "<source address>",
  "payload": {}
}
```

`gas_limit` is intentionally omitted from `dest_callback`. IBC callbacks middleware treats it as optional, so omitting it lets the destination chain apply its configured chain-wide `maxCallbackGas` instead of hardcoding a value in Axelar.

## Todos

- [x] Unit tests
- [x] Manual tests
- [ ] Documentation
- [x] Connect epics/issues
- [x] Tag type of change
- [ ] Upgrade handler

## Steps to Test

Unit tests:

```bash
env GOCACHE=/tmp/axelar-go-build go test ./x/axelarnet/types
```

Manual test:

Submitted a transaction against a local Gaia-based Cosmos Hub environment and verified that the generated ICS20 memo uses the new `dest_callback` format with the destination contract address, source metadata, and original JSON payload.

Environment:

- Gaia: `v27.2.0`
- Hermes: `v1.13.1`