### PR TITLE
ci: use GitHub App token in release workflows

### DIFF
--- a/.github/workflows/release-create-tag.yaml
+++ b/.github/workflows/release-create-tag.yaml
@@ -14,17 +14,24 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v3
+        id: generate-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           fetch-depth: '0'
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - id: release
         uses: anothrNick/github-tag-action@3840ec22ac98e14d981375e3ae2d8d0392964521 # v1.39.0
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           DEFAULT_BUMP: ${{ github.event.inputs.bumpType }}
           TAG_CONTEXT: branch
           RELEASE_BRANCHES: main,releases.*
@@ -75,7 +82,7 @@ jobs:
       - name: Bump version and push tag
         uses: anothrNick/github-tag-action@3840ec22ac98e14d981375e3ae2d8d0392964521 # v1.39.0
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           DEFAULT_BUMP: ${{ github.event.inputs.bumpType }}
           TAG_CONTEXT: branch
           RELEASE_BRANCHES: main,releases.*


### PR DESCRIPTION
## Description

Replace PAT_TOKEN with a short-lived token generated via the actions/create-github-app-token action. Same pattern as https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/372.
