### PR TITLE
docs(evm): flag commandID derivation as a cross-service invariant

### DIFF
--- a/x/evm/abci.go
+++ b/x/evm/abci.go
@@ -211,6 +211,11 @@ func routeContractCallWithToken(ctx sdk.Context, event types.Event, bk types.Bas
 	return routeEventToNexus(ctx, n, event, &coin)
 }
 
+// routeEventToNexus stores the confirmed event as a nexus general message. The
+// message ID is set to the string event ID ("0x<txHash>-<index>"), which becomes
+// the commandID preimage on the destination chain (see evm/types.NewCommandID).
+// Off-chain express predictors derive the commandID from it, so the format must
+// stay stable; it is not an internal-only field.
 func routeEventToNexus(ctx sdk.Context, n types.Nexus, event types.Event, asset *sdk.Coin) error {
 	sourceChain := funcs.MustOk(n.GetChain(ctx, event.Chain))
 

--- a/x/evm/types/command.go
+++ b/x/evm/types/command.go
@@ -150,6 +150,9 @@ func NewApproveContractCallCommandGeneric(
 	sourceEventIndex uint64,
 	ID string,
 ) Command {
+	// commandID is derived from the message ID; see NewCommandID. Off-chain
+	// services predict this value for express, so changing it is a breaking
+	// protocol change.
 	commandID := NewCommandID([]byte(ID), chainID)
 	return Command{
 		ID:         commandID,
@@ -192,6 +195,9 @@ func NewApproveContractCallWithMintGeneric(
 	message nexus.GeneralMessage,
 	symbol string,
 ) Command {
+	// commandID is derived from the message ID; see NewCommandID. Off-chain
+	// services predict this value for express, so changing it is a breaking
+	// protocol change.
 	commandID := NewCommandID([]byte(message.ID), chainID)
 	contractAddress := common.HexToAddress(message.GetDestinationAddress())
 	payloadHash := common.BytesToHash(message.PayloadHash)

--- a/x/evm/types/command.go
+++ b/x/evm/types/command.go
@@ -150,9 +150,8 @@ func NewApproveContractCallCommandGeneric(
 	sourceEventIndex uint64,
 	ID string,
 ) Command {
-	// commandID is derived from the message ID; see NewCommandID. Off-chain
-	// services predict this value for express, so changing it is a breaking
-	// protocol change.
+	// The bytes passed as data (the message ID) are part of the commandID
+	// protocol invariant that off-chain relayers re-derive. See NewCommandID.
 	commandID := NewCommandID([]byte(ID), chainID)
 	return Command{
 		ID:         commandID,
@@ -195,9 +194,8 @@ func NewApproveContractCallWithMintGeneric(
 	message nexus.GeneralMessage,
 	symbol string,
 ) Command {
-	// commandID is derived from the message ID; see NewCommandID. Off-chain
-	// services predict this value for express, so changing it is a breaking
-	// protocol change.
+	// The bytes passed as data (the message ID) are part of the commandID
+	// protocol invariant that off-chain relayers re-derive. See NewCommandID.
 	commandID := NewCommandID([]byte(message.ID), chainID)
 	contractAddress := common.HexToAddress(message.GetDestinationAddress())
 	payloadHash := common.BytesToHash(message.PayloadHash)

--- a/x/evm/types/types.go
+++ b/x/evm/types/types.go
@@ -682,7 +682,18 @@ const commandIDSize = 32
 // CommandID represents the unique command identifier
 type CommandID [commandIDSize]byte
 
-// NewCommandID is the constructor for CommandID
+// NewCommandID is the constructor for CommandID.
+//
+// PROTOCOL INVARIANT - do not change the inputs or encoding. This value is
+// re-derived off-chain from the source event alone, before the gateway approval
+// exists (the GMP API and the express relayer both predict it). Express
+// reconciliation is keyed solely on this commandID: if the off-chain and
+// on-chain derivations disagree, the express record orphans, the relayer is not
+// reimbursed, and the message is delivered twice.
+//
+// Changing this is a breaking protocol change affecting external services.
+// Making the unit tests pass for a new value is not a fix; the off-chain
+// predictors must match byte-for-byte.
 func NewCommandID(data []byte, chainID math.Int) CommandID {
 	var commandID CommandID
 	copy(commandID[:], crypto.Keccak256(append(data, chainID.BigInt().Bytes()...))[:commandIDSize])
@@ -1137,7 +1148,12 @@ func getType(val interface{}) string {
 // EventID ensures a correctly formatted event ID
 type EventID string
 
-// NewEventID returns a new event ID
+// NewEventID returns a new event ID, formatted as "0x<txHash>-<index>".
+//
+// This is not only a display string: its exact bytes (the "0x" prefix, hex
+// casing, "-" separator, decimal index) are the keccak preimage of the EVM
+// contract-call commandID (see NewCommandID). Changing the format changes every
+// commandID and breaks express reconciliation. Treat as a protocol invariant.
 func NewEventID(txID Hash, index uint64) EventID {
 	return EventID(fmt.Sprintf("%s-%d", txID.Hex(), index))
 }

--- a/x/nexus/keeper/msg_dispatcher.go
+++ b/x/nexus/keeper/msg_dispatcher.go
@@ -70,6 +70,9 @@ func (m Messenger) routeMsg(ctx sdk.Context, msg exported.WasmMessage) error {
 	}
 
 	// If message already exists, then this is a no-op to avoid causing an error from reverting the whole message batch being routed in Amplifier
+	// For wasm/amplifier-origin messages this "<srcChain>-<id>" string is the
+	// commandID preimage on the destination EVM chain (see evm/types.NewCommandID).
+	// Off-chain express predictors must match it; keep the format stable.
 	msgID := fmt.Sprintf("%s-%s", msg.SourceChain, msg.ID)
 	if _, ok := m.GetMessage(ctx, msgID); ok {
 		return nil


### PR DESCRIPTION
## What
Adds comments marking the EVM contract-call commandID derivation, and the inputs that feed it, as a cross-service protocol invariant.

Sites:
- `NewCommandID` and `NewEventID` (`x/evm/types/types.go`)
- the two `NewApproveContractCallCommandGeneric` / `WithMintGeneric` call sites (`x/evm/types/command.go`)
- `routeEventToNexus` (`x/evm/abci.go`)
- the wasm/amplifier-origin message ID (`x/nexus/keeper/msg_dispatcher.go`)

## Why
The emitted commandID is re-derived off-chain by external services (GMP API, express relayer) before the gateway approval exists, and express reconciliation is keyed solely on it. The derivation logic itself is unchanged; the comments make the invariant visible so the emitted value/format is not altered silently (e.g. by routing a path through a different command constructor) without updating the off-chain predictors.

Comments only, no behavior change.