### PR TITLE
fix(nexus): clear rewards on voluntary maintainer deregistration

### DIFF
--- a/.changeset/clear-rewards-on-maintainer-deregister.md
+++ b/.changeset/clear-rewards-on-maintainer-deregister.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Clear accrued rewards when a chain maintainer voluntarily deregisters, matching the automatic removal path.

--- a/x/nexus/keeper/msg_server.go
+++ b/x/nexus/keeper/msg_server.go
@@ -26,16 +26,18 @@ type msgServer struct {
 	slashing    types.SlashingKeeper
 	staking     types.StakingKeeper
 	axelarnet   types.AxelarnetKeeper
+	reward      types.RewardKeeper
 }
 
 // NewMsgServerImpl returns an implementation of the nexus MsgServiceServer interface for the provided Keeper.
-func NewMsgServerImpl(k types.Nexus, snapshotter types.Snapshotter, slashing types.SlashingKeeper, staking types.StakingKeeper, axelarnet types.AxelarnetKeeper) types.MsgServiceServer {
+func NewMsgServerImpl(k types.Nexus, snapshotter types.Snapshotter, slashing types.SlashingKeeper, staking types.StakingKeeper, axelarnet types.AxelarnetKeeper, reward types.RewardKeeper) types.MsgServiceServer {
 	return msgServer{
 		Nexus:       k,
 		snapshotter: snapshotter,
 		slashing:    slashing,
 		staking:     staking,
 		axelarnet:   axelarnet,
+		reward:      reward,
 	}
 }
 
@@ -134,6 +136,8 @@ func (s msgServer) DeregisterChainMaintainer(c context.Context, req *types.Dereg
 		)
 
 		s.Logger(ctx).Info(fmt.Sprintf("validator %s deregistered maintainer for chain %s", validator.String(), chain.Name))
+
+		s.reward.GetPool(ctx, chain.Name.String()).ClearRewards(validator)
 		if err := s.RemoveChainMaintainer(ctx, chain, validator); err != nil {
 			return nil, err
 		}

--- a/x/nexus/keeper/msg_server_test.go
+++ b/x/nexus/keeper/msg_server_test.go
@@ -1,13 +1,16 @@
 package keeper_test
 
 import (
+	"context"
 	"testing"
 
 	"cosmossdk.io/log"
+	"cosmossdk.io/math"
 	store "cosmossdk.io/store/types"
 	abci "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/axelarnetwork/axelar-core/app/params"
@@ -21,6 +24,9 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/nexus/keeper"
 	"github.com/axelarnetwork/axelar-core/x/nexus/types"
 	"github.com/axelarnetwork/axelar-core/x/nexus/types/mock"
+	rewardkeeper "github.com/axelarnetwork/axelar-core/x/reward/keeper"
+	rewardtypes "github.com/axelarnetwork/axelar-core/x/reward/types"
+	rewardmock "github.com/axelarnetwork/axelar-core/x/reward/types/mock"
 )
 
 func TestMsgServerActivateDeactivateWasm(t *testing.T) {
@@ -182,5 +188,104 @@ func TestRetryFailedMessage(t *testing.T) {
 		dequeuedMsg, ok := k.DequeueRouteMessage(ctx)
 		assert.True(t, ok)
 		assert.Equal(t, msg.ID, dequeuedMsg.ID)
+	})
+}
+
+func TestDeregisterChainMaintainerClearsRewards(t *testing.T) {
+	encCfg := params.MakeEncodingConfig()
+	types.RegisterLegacyAminoCodec(encCfg.Amino)
+	types.RegisterInterfaces(encCfg.InterfaceRegistry)
+
+	chain := evm.Ethereum
+	poolName := chain.Name.String()
+	accrued := sdk.NewCoin("uaxl", math.NewInt(1_000_000))
+
+	type fixture struct {
+		ctx          sdk.Context
+		rewardKeeper rewardkeeper.Keeper
+		banker       *rewardmock.BankerMock
+		validator    sdk.ValAddress
+		register     func()
+		deregister   func()
+	}
+
+	setup := func(t *testing.T) fixture {
+		ctx := sdk.NewContext(fake.NewMultiStore(), abci.Header{}, false, log.NewTestLogger(t))
+		validator := rand.ValAddr()
+		sender := rand.AccAddr()
+
+		// real reward keeper so we exercise the actual reward-pool storage
+		banker := &rewardmock.BankerMock{
+			MintCoinsFunc:                   func(context.Context, string, sdk.Coins) error { return nil },
+			SendCoinsFromModuleToModuleFunc: func(context.Context, string, string, sdk.Coins) error { return nil },
+		}
+		distributor := &rewardmock.DistributorMock{
+			AllocateTokensToValidatorFunc: func(context.Context, stakingtypes.ValidatorI, sdk.DecCoins) error { return nil },
+		}
+		staker := &rewardmock.StakerMock{
+			ValidatorFunc: func(context.Context, sdk.ValAddress) (stakingtypes.ValidatorI, error) {
+				return stakingtypes.Validator{}, nil
+			},
+		}
+		rewardSubspace := paramstypes.NewSubspace(encCfg.Codec, encCfg.Amino, store.NewKVStoreKey("rewardParams"), store.NewKVStoreKey("rewardTParams"), rewardtypes.ModuleName)
+		rewardKeeper := rewardkeeper.NewKeeper(encCfg.Codec, store.NewKVStoreKey(rewardtypes.StoreKey), rewardSubspace, banker, distributor, staker)
+
+		// real nexus keeper so register/deregister mutate actual maintainer state
+		nexusSubspace := paramstypes.NewSubspace(encCfg.Codec, encCfg.Amino, store.NewKVStoreKey("nexusParams"), store.NewKVStoreKey("nexusTParams"), types.ModuleName)
+		nexusKeeper := keeper.NewKeeper(encCfg.Codec, store.NewKVStoreKey(types.StoreKey), nexusSubspace)
+		nexusKeeper.SetChain(ctx, chain)
+
+		snap := &mock.SnapshotterMock{
+			GetOperatorFunc: func(sdk.Context, sdk.AccAddress) sdk.ValAddress { return validator },
+		}
+		staking := &mock.StakingKeeperMock{
+			ValidatorFunc: func(context.Context, sdk.ValAddress) (stakingtypes.ValidatorI, error) {
+				return stakingtypes.Validator{Status: stakingtypes.Bonded}, nil
+			},
+		}
+		ax := &mock.AxelarnetKeeperMock{
+			IsCosmosChainFunc: func(sdk.Context, nexus.ChainName) bool { return false },
+		}
+		msgServer := keeper.NewMsgServerImpl(nexusKeeper, snap, &mock.SlashingKeeperMock{}, staking, ax, rewardKeeper)
+
+		register := func() {
+			t.Helper()
+			_, err := msgServer.RegisterChainMaintainer(sdk.WrapSDKContext(ctx), types.NewRegisterChainMaintainerRequest(sender, chain.Name.String()))
+			assert.NoError(t, err)
+			assert.True(t, nexusKeeper.IsChainMaintainer(ctx, chain, validator))
+		}
+		deregister := func() {
+			t.Helper()
+			_, err := msgServer.DeregisterChainMaintainer(sdk.WrapSDKContext(ctx), types.NewDeregisterChainMaintainerRequest(sender, chain.Name.String()))
+			assert.NoError(t, err)
+			assert.False(t, nexusKeeper.IsChainMaintainer(ctx, chain, validator))
+		}
+
+		return fixture{ctx: ctx, rewardKeeper: rewardKeeper, banker: banker, validator: validator, register: register, deregister: deregister}
+	}
+
+	// control: an accrued reward is releasable while still registered, proving the
+	// seeding/release path works and the exploit assertion below isn't vacuous.
+	t.Run("accrued reward is releasable while still registered", func(t *testing.T) {
+		f := setup(t)
+		f.register()
+		f.rewardKeeper.GetPool(f.ctx, poolName).AddReward(f.validator, accrued)
+
+		assert.NoError(t, f.rewardKeeper.GetPool(f.ctx, poolName).ReleaseRewards(f.validator))
+		assert.Len(t, f.banker.MintCoinsCalls(), 1)
+	})
+
+	// the fix: deregistering clears the accrued balance, so it cannot be preserved
+	// across a re-registration and released later (the reported penalty dodge).
+	t.Run("deregister clears the accrued reward across re-registration", func(t *testing.T) {
+		f := setup(t)
+		f.register()
+		f.rewardKeeper.GetPool(f.ctx, poolName).AddReward(f.validator, accrued)
+
+		f.deregister()
+		f.register()
+
+		assert.NoError(t, f.rewardKeeper.GetPool(f.ctx, poolName).ReleaseRewards(f.validator))
+		assert.Empty(t, f.banker.MintCoinsCalls(), "rewards must be cleared on deregister, not preserved across re-registration")
 	})
 }

--- a/x/nexus/keeper/msg_server_test.go
+++ b/x/nexus/keeper/msg_server_test.go
@@ -40,7 +40,7 @@ func TestMsgServerActivateDeactivateWasm(t *testing.T) {
 	staking := mock.StakingKeeperMock{}
 	ax := mock.AxelarnetKeeperMock{}
 
-	msgServer := keeper.NewMsgServerImpl(k, &snap, &slashing, &staking, &ax)
+	msgServer := keeper.NewMsgServerImpl(k, &snap, &slashing, &staking, &ax, &mock.RewardKeeperMock{})
 
 	ctx := sdk.NewContext(fake.NewMultiStore(), abci.Header{}, false, log.NewTestLogger(t))
 
@@ -71,7 +71,7 @@ func TestUpdateParams(t *testing.T) {
 		subspace,
 	)
 
-	msgServer := keeper.NewMsgServerImpl(k, &mock.SnapshotterMock{}, &mock.SlashingKeeperMock{}, &mock.StakingKeeperMock{}, &mock.AxelarnetKeeperMock{})
+	msgServer := keeper.NewMsgServerImpl(k, &mock.SnapshotterMock{}, &mock.SlashingKeeperMock{}, &mock.StakingKeeperMock{}, &mock.AxelarnetKeeperMock{}, &mock.RewardKeeperMock{})
 	ctx := sdk.NewContext(fake.NewMultiStore(), abci.Header{}, false, log.NewTestLogger(t))
 
 	p := types.DefaultParams()
@@ -98,7 +98,7 @@ func TestRetryFailedMessage(t *testing.T) {
 	validators.Seal()
 	k.SetAddressValidators(validators)
 
-	msgServer := keeper.NewMsgServerImpl(k, &mock.SnapshotterMock{}, &mock.SlashingKeeperMock{}, &mock.StakingKeeperMock{}, &mock.AxelarnetKeeperMock{})
+	msgServer := keeper.NewMsgServerImpl(k, &mock.SnapshotterMock{}, &mock.SlashingKeeperMock{}, &mock.StakingKeeperMock{}, &mock.AxelarnetKeeperMock{}, &mock.RewardKeeperMock{})
 	ctx := sdk.NewContext(fake.NewMultiStore(), abci.Header{}, false, log.NewTestLogger(t))
 
 	k.SetMessageRouter(types.NewMessageRouter().AddRoute(evm.Ethereum.Module, func(_ sdk.Context, _ nexus.RoutingContext, _ nexus.GeneralMessage) error {

--- a/x/nexus/module.go
+++ b/x/nexus/module.go
@@ -113,7 +113,7 @@ func (AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {
 // RegisterServices registers a GRPC query service to respond to the
 // module-specific GRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	msgServer := keeper.NewMsgServerImpl(am.keeper, am.snapshotter, am.slashing, am.staking, am.axelarnet)
+	msgServer := keeper.NewMsgServerImpl(am.keeper, am.snapshotter, am.slashing, am.staking, am.axelarnet, am.reward)
 	types.RegisterMsgServiceServer(grpc.ServerWithSDKErrors{Server: cfg.MsgServer(), Err: types.ErrNexus, Logger: am.keeper.Logger}, msgServer)
 	types.RegisterQueryServiceServer(cfg.QueryServer(), keeper.NewGRPCQuerier(am.keeper, am.axelarnet))
 


### PR DESCRIPTION
## Description

For every block that a validator is in the maintainer set, it accrues some AXL (as a reward for verifying transactions on source chains). For every correct vote it receives that outstanding balance, and on every incorrect or missed vote the outstanding balance is removed: ClearRewards.

It was possible to dodge the removal of the outstanding balance by deregistering before ClearRewards is called. Afterwards you could register again and keep accruing your outstanding balance. After some time you only have to vote correctly once to receive the full balance.

The fix is to always call ClearRewards upon deregistering. In normal cases these outstanding balances are very small, since they are paid out on every vote.

Fixes CPI-407

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
