### PR TITLE
fix: add extra guards for abi_inflation_guard

### DIFF
--- a/.changeset/abi-inflation-guard-extra-guards.md
+++ b/.changeset/abi-inflation-guard-extra-guards.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Tighten the ABI inflation guard for CosmWasmV1 payloads: lower the inflation budget to 50kb, restrict wasm argument types to an allowlist, and charge for element types of empty dynamic arrays

--- a/x/axelarnet/types/evm_translator.go
+++ b/x/axelarnet/types/evm_translator.go
@@ -31,12 +31,22 @@ const (
 	// - bytes4(2) To CosmWasm Contract with json encoded payload
 	versionSize = 4
 
-	maxArgCost     = 1024 * 1024 // 1MB inflation-cost budget
+	maxArgCost     = 50 * 1024 // 50kb inflation-cost budget
 	maxArgBrackets = 100
 
 	sourceChain   = "source_chain"
 	sourceAddress = "source_address"
 )
+
+var allowedArgTypes = map[string]struct{}{
+	"bool":     {},
+	"address":  {},
+	"string":   {},
+	"bytes":    {},
+	"uint8":    {},
+	"uint64":   {},
+	"string[]": {},
+}
 
 type version [versionSize]byte
 
@@ -242,6 +252,10 @@ func ConstructNativeMessage(gm nexus.GeneralMessage, payload []byte) ([]byte, er
 func buildArguments(argTypes []string) (abi.Arguments, error) {
 	var arguments abi.Arguments
 	for _, typeStr := range argTypes {
+		if _, ok := allowedArgTypes[typeStr]; !ok {
+			return nil, fmt.Errorf("invalid argument type %s", typeStr)
+		}
+
 		argType, err := abi.NewType(typeStr, typeStr, nil)
 		if err != nil {
 			return nil, fmt.Errorf("invalid argument type %s", typeStr)

--- a/x/axelarnet/types/evm_translator_test.go
+++ b/x/axelarnet/types/evm_translator_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"bytes"
 	b64 "encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	fmt "fmt"
@@ -29,16 +30,13 @@ import (
 )
 
 var (
-	boolType              = funcs.Must(abi.NewType("bool", "bool", nil))
-	addressType           = funcs.Must(abi.NewType("address", "address", nil))
-	stringType            = funcs.Must(abi.NewType("string", "string", nil))
-	bytesType             = funcs.Must(abi.NewType("bytes", "bytes", nil))
-	uint8Type             = funcs.Must(abi.NewType("uint8", "uint8", nil))
-	uint64Type            = funcs.Must(abi.NewType("uint64", "uint64", nil))
-	uint64ArrayType       = funcs.Must(abi.NewType("uint64[]", "uint64[]", nil))
-	uint64ArrayNestedType = funcs.Must(abi.NewType("uint64[][]", "uint64[][]", nil))
-	stringArrayType       = funcs.Must(abi.NewType("string[]", "string[]", nil))
-	stringArrayNestedType = funcs.Must(abi.NewType("string[][]", "string[][]", nil))
+	boolType        = funcs.Must(abi.NewType("bool", "bool", nil))
+	addressType     = funcs.Must(abi.NewType("address", "address", nil))
+	stringType      = funcs.Must(abi.NewType("string", "string", nil))
+	bytesType       = funcs.Must(abi.NewType("bytes", "bytes", nil))
+	uint8Type       = funcs.Must(abi.NewType("uint8", "uint8", nil))
+	uint64Type      = funcs.Must(abi.NewType("uint64", "uint64", nil))
+	stringArrayType = funcs.Must(abi.NewType("string[]", "string[]", nil))
 )
 
 func TestTranslateMessage(t *testing.T) {
@@ -66,13 +64,10 @@ func TestConstructWasmMessageV1Large(t *testing.T) {
 	boolTrue := true
 
 	stringArray := slices.Expand2(rand.AccAddr().String, 10)
-	uint64Array := slices.Expand2(func() uint64 { return math.MaxUint64 }, 10)
-	uint64NestedArray := slices.Expand2(func() []uint64 { return uint64Array }, 5)
-	stringNestedArray := slices.Expand2(func() []string { return stringArray }, 5)
 	bz := rand.Bytes(int(rand.I64Between(1, 1000)))
 	hexBzStr := hex.EncodeToString(bz)
 
-	argumentNames := []string{"str", "max_uint256_str", "max_uint8", "max_uint64", "bool_true", "string_array", "uint64_array", "uint64_array_nested", "string_array_nested", "bytes", "hex_string"}
+	argumentNames := []string{"str", "max_uint256_str", "max_uint8", "max_uint64", "bool_true", "string_array", "bytes", "hex_string"}
 
 	payload := funcs.Must(constructABIPayload(
 		methodName,
@@ -84,9 +79,6 @@ func TestConstructWasmMessageV1Large(t *testing.T) {
 			uint64Type,
 			boolType,
 			stringArrayType,
-			uint64ArrayType,
-			uint64ArrayNestedType,
-			stringArrayNestedType,
 			bytesType,
 			stringType},
 		[]interface{}{
@@ -96,9 +88,6 @@ func TestConstructWasmMessageV1Large(t *testing.T) {
 			maxUint64,
 			boolTrue,
 			stringArray,
-			uint64Array,
-			uint64NestedArray,
-			stringNestedArray,
 			bz,
 			hexBzStr,
 		},
@@ -176,26 +165,6 @@ func TestConstructWasmMessageV1Large(t *testing.T) {
 	arrayInterface, _ := executeMsg["string_array"].([]interface{})
 	actualStringArray := slices.Map(arrayInterface, func(t interface{}) string { return t.(string) })
 	assert.Equal(t, stringArray, actualStringArray)
-
-	arrayInterface, _ = executeMsg["uint64_array"].([]interface{})
-	uint64StrArray := slices.Map(arrayInterface, func(t interface{}) string { return t.(json.Number).String() })
-	assert.Equal(t, uint64Array, slices.Map(uint64StrArray, func(t string) uint64 { return funcs.Must(strconv.ParseUint(t, 10, 64)) }))
-
-	arrayInterface, _ = executeMsg["uint64_array_nested"].([]interface{})
-	actualUint64NestedArray := slices.Map(arrayInterface, func(inner interface{}) []uint64 {
-		return slices.Map(inner.([]interface{}), func(t interface{}) uint64 {
-			return funcs.Must(strconv.ParseUint(t.(json.Number).String(), 10, 64))
-		})
-	})
-	assert.Equal(t, uint64NestedArray, actualUint64NestedArray)
-
-	arrayInterface, _ = executeMsg["string_array_nested"].([]interface{})
-	actualStringNestedArray := slices.Map(arrayInterface, func(inner interface{}) []string {
-		return slices.Map(inner.([]interface{}), func(t interface{}) string {
-			return t.(string)
-		})
-	})
-	assert.Equal(t, stringNestedArray, actualStringNestedArray)
 
 	base64BzString, ok := executeMsg["bytes"].(string)
 	assert.True(t, ok)
@@ -278,6 +247,28 @@ func TestConstructWasmMessageV1(t *testing.T) {
 		assert.ErrorContains(t, err, "invalid argument type")
 	})
 
+	t.Run("should return error if arg type is valid abi but not allowlisted", func(t *testing.T) {
+		msg := nexustestutils.RandomMessage()
+		methodArguments := abi.Arguments([]abi.Argument{{Type: uint64Type}})
+		argValues, err := methodArguments.Pack(uint64(1))
+		assert.NoError(t, err)
+
+		schema := abi.Arguments{{Type: stringType}, {Type: stringArrayType}, {Type: stringArrayType}, {Type: bytesType}}
+
+		bz, err := schema.Pack(
+			"method",
+			[]string{"x"},
+			[]string{"uint256[]"},
+			argValues,
+		)
+		assert.NoError(t, err)
+
+		payload := axelartestutils.PackPayloadWithVersion(version, bz)
+
+		_, err = types.TranslateMessage(msg, payload)
+		assert.ErrorContains(t, err, " invalid argument type uint256[]")
+	})
+
 	t.Run("should return error if payload inflates beyond max cost", func(t *testing.T) {
 		msg := nexustestutils.RandomMessage()
 
@@ -319,14 +310,18 @@ func TestConstructWasmMessageV1(t *testing.T) {
 	t.Run("should return error if arg values inflate beyond max cost", func(t *testing.T) {
 		msg := nexustestutils.RandomMessage()
 
-		bigArrayType := "uint256[288230376151711744]"
+		// a string[] whose declared element count alone exceeds the inflation budget
+		const elements = 50*1024/32 + 1
+		argValues := make([]byte, 64+elements)
+		argValues[31] = 32                                    // offset of the array
+		binary.BigEndian.PutUint64(argValues[56:64], elements) // declared element count
 
 		schema := abi.Arguments{{Type: stringType}, {Type: stringArrayType}, {Type: stringArrayType}, {Type: bytesType}}
 		bz, err := schema.Pack(
 			"method",
 			[]string{"x"},
-			[]string{bigArrayType},
-			make([]byte, 32),
+			[]string{"string[]"},
+			argValues,
 		)
 		assert.NoError(t, err)
 

--- a/x/axelarnet/types/evm_translator_test.go
+++ b/x/axelarnet/types/evm_translator_test.go
@@ -313,7 +313,7 @@ func TestConstructWasmMessageV1(t *testing.T) {
 		// a string[] whose declared element count alone exceeds the inflation budget
 		const elements = 50*1024/32 + 1
 		argValues := make([]byte, 64+elements)
-		argValues[31] = 32                                    // offset of the array
+		argValues[31] = 32                                     // offset of the array
 		binary.BigEndian.PutUint64(argValues[56:64], elements) // declared element count
 
 		schema := abi.Arguments{{Type: stringType}, {Type: stringArrayType}, {Type: stringArrayType}, {Type: bytesType}}

--- a/x/evm/types/abi_inflation_guard.go
+++ b/x/evm/types/abi_inflation_guard.go
@@ -30,7 +30,7 @@ func ABIInflationGuard(arguments abi.Arguments, payload []byte, maxCost int) err
 			continue
 		}
 
-		words, err := walk((index+virtualArgs)*32, arg.Type, payload, limit-total)
+		words, err := walk((index+virtualArgs)*32, arg.Type, payload, limit-total, false)
 		if err != nil {
 			return err
 		}
@@ -52,72 +52,98 @@ func ABIInflationGuard(arguments abi.Arguments, payload []byte, maxCost int) err
 }
 
 // walk mirrors go-ethereum's toGoType (github.com/ethereum/go-ethereum/blob/master/accounts/abi/unpack.go#L224)
-func walk(index int, t abi.Type, output []byte, limit int) (int, error) {
-	if index+32 > len(output) {
-		// Changed: generic malformed error.
-		return 0, ErrMalformed
-	}
-
-	var (
-		returnOutput  []byte
-		begin, length int
-		err           error
-	)
-
-	if requiresLengthPrefix(t) {
-		begin, length, err = lengthPrefixPointsTo(index, output)
-		if err != nil {
+func walk(index int, t abi.Type, output []byte, limit int, typeOnly bool) (int, error) {
+	// Changed: added a possibility to walk the type with empty output
+	// needed to get cost of a type that eventually initialise to an empty array, while the type creation is still slow
+	if !typeOnly {
+		if index+32 > len(output) {
 			// Changed: generic malformed error.
 			return 0, ErrMalformed
 		}
-	} else {
-		returnOutput = output[index : index+32]
-	}
 
-	switch t.T {
-	case abi.TupleTy:
-		if isDynamicType(t) {
-			begin, err := tuplePointsTo(index, output)
+		var (
+			returnOutput  []byte
+			begin, length int
+			err           error
+		)
+
+		if requiresLengthPrefix(t) {
+			begin, length, err = lengthPrefixPointsTo(index, output)
 			if err != nil {
 				// Changed: generic malformed error.
 				return 0, ErrMalformed
 			}
-			return walkTuple(t, output[begin:], limit)
+		} else {
+			returnOutput = output[index : index+32]
 		}
-		return walkTuple(t, output[index:], limit)
 
-	case abi.SliceTy:
-		return walkElements(t, output[begin:], 0, length, limit)
-
-	case abi.ArrayTy:
-		if isDynamicType(*t.Elem) {
-			offset := binary.BigEndian.Uint64(returnOutput[len(returnOutput)-8:])
-			if offset > uint64(len(output)) {
-				return 0, ErrMalformed
+		switch t.T {
+		case abi.TupleTy:
+			if isDynamicType(t) {
+				begin, err := tuplePointsTo(index, output)
+				if err != nil {
+					// Changed: generic malformed error.
+					return 0, ErrMalformed
+				}
+				return walkTuple(t, output[begin:], limit, false)
 			}
-			return walkElements(t, output[offset:], 0, t.Size, limit)
+			return walkTuple(t, output[index:], limit, false)
+
+		case abi.SliceTy:
+			return walkElements(t, output[begin:], 0, length, limit, false)
+
+		case abi.ArrayTy:
+			if isDynamicType(*t.Elem) {
+				offset := binary.BigEndian.Uint64(returnOutput[len(returnOutput)-8:])
+				if offset > uint64(len(output)) {
+					return 0, ErrMalformed
+				}
+				return walkElements(t, output[offset:], 0, t.Size, limit, false)
+			}
+			return walkElements(t, output[index:], 0, t.Size, limit, false)
+
+		// Changed: calculate cost instead of returning data.
+		case abi.StringTy, abi.BytesTy:
+			return (length + 31) / 32, nil
+
+		// Changed: calculate cost instead of returning data.
+		case abi.IntTy, abi.UintTy, abi.BoolTy, abi.AddressTy, abi.HashTy, abi.FixedBytesTy, abi.FunctionTy:
+			return 1, nil
+
+		default:
+			return 0, fmt.Errorf("abi: unknown type %d", t.T)
 		}
-		return walkElements(t, output[index:], 0, t.Size, limit)
+	} else {
+		// Changed: mirrors the non-typedOnly version, but now with empty output.
+		// Logic changes in that version should also be reflected here.
+		switch t.T {
+		case abi.TupleTy:
+			return walkTuple(t, output, limit, true)
 
-	// Changed: calculate cost instead of returning data.
-	case abi.StringTy, abi.BytesTy:
-		return (length + 31) / 32, nil
+		case abi.SliceTy:
+			return walkElements(t, output, 0, 0, limit, true)
 
-	// Changed: calculate cost instead of returning data.
-	case abi.IntTy, abi.UintTy, abi.BoolTy, abi.AddressTy, abi.HashTy, abi.FixedBytesTy, abi.FunctionTy:
-		return 1, nil
+		case abi.ArrayTy:
+			return walkElements(t, output, 0, t.Size, limit, true)
 
-	default:
-		return 0, fmt.Errorf("abi: unknown type %d", t.T)
+		case abi.StringTy, abi.BytesTy:
+			return 1, nil // Changed: increased from 0 to 1 to combat multiplication by 0.
+
+		case abi.IntTy, abi.UintTy, abi.BoolTy, abi.AddressTy, abi.HashTy, abi.FixedBytesTy, abi.FunctionTy:
+			return 1, nil
+
+		default:
+			return 0, fmt.Errorf("abi: unknown type %d", t.T)
+		}
 	}
 }
 
 // walkTuple mirrors go-ethereum's forTupleUnpack (github.com/ethereum/go-ethereum/blob/master/accounts/abi/unpack.go#L192)
-func walkTuple(t abi.Type, output []byte, limit int) (int, error) {
+func walkTuple(t abi.Type, output []byte, limit int, typeOnly bool) (int, error) {
 	total, virtualArgs := 0, 0
 	for index, elem := range t.TupleElems {
 		// Changed: get cost instead of marshalledValue back.
-		words, err := walk((index+virtualArgs)*32, *elem, output, limit-total)
+		words, err := walk((index+virtualArgs)*32, *elem, output, limit-total, typeOnly)
 		if err != nil {
 			return 0, err
 		}
@@ -136,7 +162,7 @@ func walkTuple(t abi.Type, output []byte, limit int) (int, error) {
 }
 
 // walkElements mirrors go-ethereum's forEachUnpack (github.com/ethereum/go-ethereum/blob/master/accounts/abi/unpack.go#L152)
-func walkElements(t abi.Type, output []byte, start, size, limit int) (int, error) {
+func walkElements(t abi.Type, output []byte, start, size, limit int, typeOnly bool) (int, error) {
 	if size < 0 {
 		// Changed: generic malformed error.
 		return 0, ErrMalformed
@@ -144,7 +170,8 @@ func walkElements(t abi.Type, output []byte, start, size, limit int) (int, error
 	// Removed: a check that can overflow, but not needed as we do real counting.
 	// Added: shortcut for when item size is zero.
 	if t.T != abi.ArrayTy && size == 0 {
-		return 0, nil
+		// No payload left, but the decoder still materialises the element type
+		return walk(start, *t.Elem, output, limit, true)
 	}
 
 	elem := *t.Elem
@@ -156,7 +183,7 @@ func walkElements(t abi.Type, output []byte, start, size, limit int) (int, error
 		if t.T == abi.ArrayTy && size < 2 {
 			size = 2
 		}
-		each, err := walk(start, elem, output, limit)
+		each, err := walk(start, elem, output, limit, typeOnly)
 		if err != nil {
 			return 0, err
 		}
@@ -180,7 +207,7 @@ func walkElements(t abi.Type, output []byte, start, size, limit int) (int, error
 	// Removed: elemSize calculation. The dynamic type's head is always 32.
 	// As the static type is done above, we can calculate here with 32.
 	for i, j := start, 0; j < size; i, j = i+32, j+1 {
-		words, err := walk(i, elem, output, limit-total)
+		words, err := walk(i, elem, output, limit-total, typeOnly)
 		if err != nil {
 			return 0, err
 		}

--- a/x/evm/types/abi_inflation_guard_test.go
+++ b/x/evm/types/abi_inflation_guard_test.go
@@ -359,11 +359,10 @@ func TestABIInflationGuard(t *testing.T) {
 		assertBoundary(t, args, packed, 3) // 3 static elements
 	})
 
-	t.Run("empty dynamic array never inflates", func(t *testing.T) {
+	t.Run("empty dynamic array costs its element type", func(t *testing.T) {
 		args := argsOf(t, "uint256[]")
 		packed := funcs.Must(args.Pack([]*big.Int{}))
-		assertFits(t, args, packed, maxArgCost)
-		assertFits(t, args, packed, 0) // zero-cost, no reject threshold
+		assertBoundary(t, args, packed, 1)
 	})
 
 	t.Run("fixed array of dynamic elements", func(t *testing.T) {


### PR DESCRIPTION
## Description

Extra guarding for the abi_inflation_guard.

Dynamic tupples with payload size 0 weren't counted, but the type itself was created. So also count those e.g. uint256[1000][1000][1000][1000][1000][1000][] (with the last one having an payload array with zero size)
Only allow string[], string and bytes. Those are the only observed types.
Reduce maxCost to 50kb
~~I reuse the timed guard, as there were no consensus breaking messages from 1.4.0 till 1.4.9. So replays using the any 1.4.x versions will not diverge.~~

merged into v1.4.10: https://github.com/axelarnetwork/axelar-core/commit/f8b7387b0674317bd91112e55e0ed6b964ae4bbc

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
