### PR TITLE
chore(deps): bump rosetta fork to axelar-core-v1.5.x-compatible

### DIFF
--- a/.changeset/bump-rosetta-v1.5-compatible.md
+++ b/.changeset/bump-rosetta-v1.5-compatible.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Bump the github.com/cosmos/rosetta fork to the axelar-core-v1.5.x-compatible branch (commit c9ce423) for compatibility with the v1.5 cosmos-sdk v0.53 / ibc-go v10 stack.

--- a/go.mod
+++ b/go.mod
@@ -95,8 +95,8 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.15.0 // indirect
-	github.com/bytedance/sonic/loader v0.5.0 // indirect
+	github.com/bytedance/sonic v1.15.2 // indirect
+	github.com/bytedance/sonic/loader v0.5.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
@@ -277,7 +277,8 @@ replace github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 replace github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 
 // patches contained in this:
-// https://github.com/axelarnetwork/rosetta/compare/release/v0.50.x...axelarnetwork:rosetta:9a97032c7833b130909b98818c7a6fc74f7223fb
-replace github.com/cosmos/rosetta => github.com/axelarnetwork/rosetta v0.50.13-0.20260408131525-9a97032c7833
+// https://github.com/axelarnetwork/rosetta/tree/axelar-core-v1.5.x-compatible
+// https://github.com/axelarnetwork/rosetta/compare/release/v0.50.x...axelarnetwork:rosetta:c9ce4236beef4596f3fefb8e7a35c5758ebe38e7
+replace github.com/cosmos/rosetta => github.com/axelarnetwork/rosetta v0.50.13-0.20260714134245-c9ce4236beef
 
 replace github.com/cosmos/cosmos-sdk => github.com/axelarnetwork/cosmos-sdk v0.53.7-0.20260609180346-f4253ddb9b33

--- a/go.sum
+++ b/go.sum
@@ -754,8 +754,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxq
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
 github.com/axelarnetwork/cosmos-sdk v0.53.7-0.20260609180346-f4253ddb9b33 h1:1n3h2sbHwS4ezFGTuBu5jxJnI0JbmmkQraCgjsxmVPg=
 github.com/axelarnetwork/cosmos-sdk v0.53.7-0.20260609180346-f4253ddb9b33/go.mod h1:N6YuprhAabInbT3YGumGDKONbvPX5dNro7RjHvkQoKE=
-github.com/axelarnetwork/rosetta v0.50.13-0.20260408131525-9a97032c7833 h1:S4nOlXG5blBsH+68wjPyoUouaXdVANz+l18DvtUR0xc=
-github.com/axelarnetwork/rosetta v0.50.13-0.20260408131525-9a97032c7833/go.mod h1:w80RJd4oW5r6t89rajdZGJbI0mucZ1CSZdi+YeSTKow=
+github.com/axelarnetwork/rosetta v0.50.13-0.20260714134245-c9ce4236beef h1:rN32Y7m0/UJiPYgwRUP1ms63X68q+wb76HKDSHirohw=
+github.com/axelarnetwork/rosetta v0.50.13-0.20260714134245-c9ce4236beef/go.mod h1:97R1+QA1t4u4gACmI9uj7rG6QbimaHl2VHZ1daAepo0=
 github.com/axelarnetwork/tm-events v0.0.0-20251121130841-4c4b590f0d06 h1:R7rrsY44+AJB7iQTttGFBeiL2gSalycC/LWVRUyvbos=
 github.com/axelarnetwork/tm-events v0.0.0-20251121130841-4c4b590f0d06/go.mod h1:a00OM9xc7190Tx+B4QoX+cAf8xvN1V1KtqGkNrljQuI=
 github.com/axelarnetwork/utils v0.0.0-20251121135440-7d92b8abb3a7 h1:KDhg2z/fUmOhZgUyjJp8XV3N3x56Ts2zXRYo63LDnYw=
@@ -809,10 +809,10 @@ github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
-github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
-github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
-github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.2 h1:90H+rcF/FwLXwfB1cudOLq/je83n683Utf4Cbp0xHCo=
+github.com/bytedance/sonic v1.15.2/go.mod h1:mT2NbXunuaEbnZ+mRIX/vYqKISmgEuHFDI4UzmKx2SA=
+github.com/bytedance/sonic/loader v0.5.1 h1:Ygpfa9zwRCCKSlrp5bBP/b/Xzc3VxsAW+5NIYXrOOpI=
+github.com/bytedance/sonic/loader v0.5.1/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=


### PR DESCRIPTION
## Description

Bump the rosetta version to the v1.5.x compatible branch.

Fixes CPI-418

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change
- [ ] Upgrade handler

## Steps to Test

## Expected Behaviour

## Other Notes
