### PR TITLE
fix: flatten RefundMsgRequest inner through the ante decorators

### DIFF
--- a/.changeset/flatten-refund-msg-inner.md
+++ b/.changeset/flatten-refund-msg-inner.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Flatten a RefundMsgRequest's inner message in the ante handler so it passes through the message ante decorators (RestrictedTx, CheckProxy, etc.), consistent with how authz MsgExec and auxiliary BatchRequest inner messages are handled.

--- a/x/ante/batch.go
+++ b/x/ante/batch.go
@@ -81,6 +81,10 @@ func unpackMsgs(msgs []sdk.Msg) ([]sdk.Msg, error) {
 				return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 			}
 			unpackedMsgs = append(unpackedMsgs, innerMsgs...)
+		case *rewardtypes.RefundMsgRequest:
+			if inner := m.GetInnerMessage(); inner != nil {
+				unpackedMsgs = append(unpackedMsgs, inner)
+			}
 		}
 	}
 

--- a/x/ante/batch_test.go
+++ b/x/ante/batch_test.go
@@ -113,6 +113,28 @@ func TestBatch(t *testing.T) {
 			assert.Equal(t, 2, len(unwrappedMsgs))
 		}).
 		Run(t)
+
+	givenBatchAnteHandler.
+		When("a tx contains a RefundMsgRequest", func() {
+			tx = &mock.FeeTxMock{
+				GetMsgsFunc: func() []sdk.Msg {
+					return []sdk.Msg{
+						rewardtypes.NewRefundMsgRequest(sender, votetypes.NewVoteRequest(sender, vote.PollID(rand.PosI64()), evmTypes.NewVoteEvents(nexus.ChainName(rand.NormalizedStr(3))))),
+					}
+				},
+			}
+		}).
+		Then("should unwrap the refund inner message", func(t *testing.T) {
+			_, err := handler.AnteHandle(sdk.Context{}, tx, false,
+				func(_ sdk.Context, tx sdk.Tx, _ bool) (sdk.Context, error) {
+					unwrappedMsgs = tx.GetMsgs()
+					return sdk.Context{}, nil
+				})
+
+			assert.NoError(t, err)
+			assert.Equal(t, 2, len(unwrappedMsgs))
+		}).
+		Run(t)
 }
 
 func TestBatchRejectsDisallowedNesting(t *testing.T) {

--- a/x/ante/check_refund.go
+++ b/x/ante/check_refund.go
@@ -92,7 +92,23 @@ func isRefundMsgRequest(msg sdk.Msg) bool {
 func (d CheckRefundFeeDecorator) validateRefundQualification(ctx sdk.Context, msgs []sdk.Msg) error {
 	// If we allow txs to be refunded when there are msgs that are not RefundMsgRequests we open the door to slip all kinds of msgs in to get them refunded.
 	// So we need to make sure that all msgs in the batch are refundable, otherwise reject the tx.
+
+	// the ante flattens each RefundMsgRequest's inner message into the tx so the message
+	// decorators can inspect it; those inners are validated through their wrapper, so skip them here
+	refundedInner := make(map[sdk.Msg]struct{})
 	for _, msg := range msgs {
+		if req, ok := msg.(*rewardtypes.RefundMsgRequest); ok {
+			if inner := req.GetInnerMessage(); inner != nil {
+				refundedInner[inner] = struct{}{}
+			}
+		}
+	}
+
+	for _, msg := range msgs {
+		if _, ok := refundedInner[msg]; ok {
+			continue
+		}
+
 		switch msg := msg.(type) {
 		case *rewardtypes.RefundMsgRequest:
 			if !msgRegistered(d.cdc.InterfaceRegistry(), msg.InnerMessage.TypeUrl) {

--- a/x/ante/check_refund.go
+++ b/x/ante/check_refund.go
@@ -89,23 +89,31 @@ func isRefundMsgRequest(msg sdk.Msg) bool {
 	return ok
 }
 
+// refundInnerMsgsSet returns the messages flattened out of RefundMsgRequests, keyed by pointer
+// identity so an identical but separately-submitted message is not mistaken for a refund inner.
+func refundInnerMsgsSet(msgs []sdk.Msg) map[sdk.Msg]struct{} {
+	inners := make(map[sdk.Msg]struct{})
+	for _, msg := range msgs {
+		if req, ok := msg.(*rewardtypes.RefundMsgRequest); ok {
+			if inner := req.GetInnerMessage(); inner != nil {
+				inners[inner] = struct{}{}
+			}
+		}
+	}
+
+	return inners
+}
+
 func (d CheckRefundFeeDecorator) validateRefundQualification(ctx sdk.Context, msgs []sdk.Msg) error {
 	// If we allow txs to be refunded when there are msgs that are not RefundMsgRequests we open the door to slip all kinds of msgs in to get them refunded.
 	// So we need to make sure that all msgs in the batch are refundable, otherwise reject the tx.
 
 	// the ante flattens each RefundMsgRequest's inner message into the tx so the message
 	// decorators can inspect it; those inners are validated through their wrapper, so skip them here
-	refundedInner := make(map[sdk.Msg]struct{})
-	for _, msg := range msgs {
-		if req, ok := msg.(*rewardtypes.RefundMsgRequest); ok {
-			if inner := req.GetInnerMessage(); inner != nil {
-				refundedInner[inner] = struct{}{}
-			}
-		}
-	}
+	refundInnerMsgs := refundInnerMsgsSet(msgs)
 
 	for _, msg := range msgs {
-		if _, ok := refundedInner[msg]; ok {
+		if _, isRefundMsgInner := refundInnerMsgs[msg]; isRefundMsgInner {
 			continue
 		}
 

--- a/x/ante/check_refund_test.go
+++ b/x/ante/check_refund_test.go
@@ -151,6 +151,15 @@ func TestCheckRefundFeeDecorator_AnteHandle(t *testing.T) {
 				&axelarnet.LinkRequest{},
 			},
 		},
+		{
+			label:       "standalone message identical to a refund inner is rejected (skipped by pointer, not value)",
+			succeeds:    false,
+			refundCount: 0,
+			msgs: []sdk.Msg{
+				rewardtypes.NewRefundMsgRequest(sender, &votetypes.VoteRequest{}),
+				&votetypes.VoteRequest{},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
## Description

Follow-up to #2358: a `RefundMsgRequest`'s inner message is dispatched via `routeInnerMsg` without passing through the message ante decorators, unlike authz `MsgExec` and auxiliary `BatchRequest`.

This flattens the `RefundMsgRequest` inner in `unpackMsgs` so it goes through the message ante decorators (`RestrictedTx`, `CheckProxy`, `CheckCommissionRate`, `Undelegate`). `CheckRefundFeeDecorator` skips the flattened inners since they are validated via their wrapper, so refund qualification and fee accounting are unchanged.
