### PR TITLE
chore: remove dead link-deposit CLI commands

### DIFF
--- a/.changeset/remove-link-deposit-cli.md
+++ b/.changeset/remove-link-deposit-cli.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Remove the dead link-deposit CLI commands (`evm link`, `evm confirm-erc20-deposit`, `evm create-burn-tokens`, `axelarnet link`, `axelarnet confirm-deposit`) whose backing Msg RPCs were removed in #2321.

--- a/x/axelarnet/client/cli/tx.go
+++ b/x/axelarnet/client/cli/tx.go
@@ -31,8 +31,6 @@ func GetTxCmd() *cobra.Command {
 	}
 
 	axelarTxCmd.AddCommand(
-		GetCmdLink(),
-		GetCmdConfirmDeposit(),
 		GetCmdExecutePendingTransfersTx(),
 		GetCmdAddCosmosBasedChain(),
 		GetCmdRegisterAsset(),
@@ -43,57 +41,6 @@ func GetTxCmd() *cobra.Command {
 	)
 
 	return axelarTxCmd
-}
-
-// GetCmdLink links a cross chain address to an Axelar chain address
-// Deprecated: link-deposit protocol is being disabled
-func GetCmdLink() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:        "link [recipient chain] [recipient address] [asset]",
-		Short:      "Link a cross chain address to an Axelar address",
-		Deprecated: "link-deposit protocol is being disabled",
-		Args:       cobra.ExactArgs(3),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
-
-			msg := types.NewLinkRequest(clientCtx.GetFromAddress(), args[0], args[1], args[2])
-
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
-		},
-	}
-	flags.AddTxFlagsToCmd(cmd)
-	return cmd
-}
-
-// GetCmdConfirmDeposit returns the cli command to confirm a deposit
-// Deprecated: link-deposit protocol is being disabled
-func GetCmdConfirmDeposit() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:        "confirm-deposit [denom] [burnerAddr]",
-		Short:      "Confirm a deposit to Axelar chain that sent given the asset denomination and the burner address",
-		Deprecated: "link-deposit protocol is being disabled",
-		Args:       cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
-
-			burnerAddr, err := sdk.AccAddressFromBech32(args[1])
-			if err != nil {
-				return err
-			}
-
-			msg := types.NewConfirmDepositRequest(cliCtx.GetFromAddress(), args[0], burnerAddr)
-
-			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
-		},
-	}
-	flags.AddTxFlagsToCmd(cmd)
-	return cmd
 }
 
 // GetCmdExecutePendingTransfersTx returns the cli command to transfer all pending token transfers to Axelar chain

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -36,9 +36,7 @@ func GetTxCmd() *cobra.Command {
 
 	evmTxCmd.AddCommand(
 		GetCmdSetGateway(),
-		GetCmdLink(),
 		GetCmdConfirmERC20TokenDeployment(),
-		GetCmdConfirmERC20Deposit(),
 		GetCmdConfirmTransferOperatorship(),
 		GetCmdCreateConfirmGatewayTx(),
 		GetCmdCreateConfirmGatewayTxs(),
@@ -81,29 +79,6 @@ func GetCmdSetGateway() *cobra.Command {
 	return cmd
 }
 
-// GetCmdLink links a cross chain address to an EVM chain address created by Axelar
-// Deprecated: link-deposit protocol is being disabled
-func GetCmdLink() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:        "link [chain] [recipient chain] [recipient address] [asset name]",
-		Short:      "Link a cross chain address to an EVM chain address created by Axelar",
-		Deprecated: "link-deposit protocol is being disabled",
-		Args:       cobra.ExactArgs(4),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
-
-			msg := types.NewLinkRequest(cliCtx.GetFromAddress(), args[0], args[1], args[2], args[3])
-
-			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
-		},
-	}
-	flags.AddTxFlagsToCmd(cmd)
-	return cmd
-}
-
 // GetCmdConfirmERC20TokenDeployment returns the cli command to confirm a ERC20 token deployment
 func GetCmdConfirmERC20TokenDeployment() *cobra.Command {
 	cmd := &cobra.Command{
@@ -122,33 +97,6 @@ func GetCmdConfirmERC20TokenDeployment() *cobra.Command {
 			asset := types.NewAsset(originChain, originAsset)
 			txID := common.HexToHash(args[3])
 			msg := types.NewConfirmTokenRequest(cliCtx.GetFromAddress(), chain, asset, txID)
-
-			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
-		},
-	}
-	flags.AddTxFlagsToCmd(cmd)
-	return cmd
-}
-
-// GetCmdConfirmERC20Deposit returns the cli command to confirm an ERC20 deposit
-// Deprecated: link-deposit protocol is being disabled
-func GetCmdConfirmERC20Deposit() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:        "confirm-erc20-deposit [chain] [txID] [burnerAddr]",
-		Short:      "Confirm ERC20 deposits in an EVM chain transaction to a burner address",
-		Deprecated: "link-deposit protocol is being disabled",
-		Args:       cobra.ExactArgs(3),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
-
-			chain := args[0]
-			txID := common.HexToHash(args[1])
-			burnerAddr := common.HexToAddress(args[2])
-
-			msg := types.NewConfirmDepositRequest(cliCtx.GetFromAddress(), chain, txID, burnerAddr)
 
 			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 		},

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -41,7 +41,6 @@ func GetTxCmd() *cobra.Command {
 		GetCmdCreateConfirmGatewayTx(),
 		GetCmdCreateConfirmGatewayTxs(),
 		GetCmdCreateDeployToken(),
-		GetCmdCreateBurnTokens(),
 		GetCmdCreateTransferOperatorship(),
 		GetCmdSignCommands(),
 		GetCmdAddChain(),
@@ -222,29 +221,6 @@ func GetCmdCreateDeployToken() *cobra.Command {
 		return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
 	}
 
-	flags.AddTxFlagsToCmd(cmd)
-	return cmd
-}
-
-// GetCmdCreateBurnTokens returns the cli command to create burn commands for all confirmed token deposits in an EVM chain
-// Deprecated: link-deposit protocol is being disabled
-func GetCmdCreateBurnTokens() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:        "create-burn-tokens [chain]",
-		Short:      "Create burn commands for all confirmed token deposits in an EVM chain",
-		Deprecated: "link-deposit protocol is being disabled",
-		Args:       cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
-
-			msg := types.NewCreateBurnTokensRequest(cliCtx.GetFromAddress(), args[0])
-
-			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
-		},
-	}
 	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }


### PR DESCRIPTION
## Description

The link-deposit protocol's `Msg` RPCs were removed from the service in #2321, but the CLI commands that built those messages were left registered.

Removed commands:

- `axelard tx evm link`, `axelard tx evm confirm-erc20-deposit`, `axelard tx evm create-burn-tokens`
- `axelard tx axelarnet link`, `axelard tx axelarnet confirm-deposit`

Part of CPI-386
