### PR TITLE
fix(nexus): rebuild processing message index on genesis import

### DIFF
--- a/.changeset/rebuild-nexus-processing-message-index.md
+++ b/.changeset/rebuild-nexus-processing-message-index.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Rebuild the nexus processing-message index from message status on genesis import (the index is not part of serialized genesis state), and reject genesis files with duplicate message IDs.

--- a/x/nexus/keeper/general_message.go
+++ b/x/nexus/keeper/general_message.go
@@ -107,7 +107,6 @@ func (k Keeper) deleteProcessingMessageID(ctx sdk.Context, m exported.GeneralMes
 	k.getStore(ctx).DeleteNew(getProcessingMessageKey(m.GetDestinationChain(), m.ID))
 }
 
-//nolint:unused // TODO: add genesis import/export
 func (k Keeper) getMessages(ctx sdk.Context) (generalMessages []exported.GeneralMessage) {
 	iter := k.getStore(ctx).IteratorNew(generalMessagePrefix)
 	defer utils.CloseLogError(iter, k.Logger(ctx))

--- a/x/nexus/keeper/genesis.go
+++ b/x/nexus/keeper/genesis.go
@@ -74,6 +74,10 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 
 	for _, msg := range genState.Messages {
 		funcs.MustNoErr(k.setMessage(ctx, msg))
+
+		if msg.Is(exported.Processing) {
+			funcs.MustNoErr(k.setProcessingMessageID(ctx, msg))
+		}
 	}
 
 	utils.NewCounter[uint64](messageNonceKey, k.getStore(ctx)).Set(ctx, genState.MessageNonce)

--- a/x/nexus/keeper/genesis.go
+++ b/x/nexus/keeper/genesis.go
@@ -72,7 +72,13 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 		}
 	}
 
+	messageSeen := make(map[string]bool)
 	for _, msg := range genState.Messages {
+		if messageSeen[msg.ID] {
+			panic(fmt.Errorf("message %s already set", msg.ID))
+		}
+		messageSeen[msg.ID] = true
+
 		funcs.MustNoErr(k.setMessage(ctx, msg))
 
 		if msg.Is(exported.Processing) {

--- a/x/nexus/keeper/genesis_test.go
+++ b/x/nexus/keeper/genesis_test.go
@@ -216,6 +216,20 @@ func TestExportGenesisInitGenesis(t *testing.T) {
 	assertChainStatesEqual(t, expected, actual)
 }
 
+func TestInitGenesisPanicsOnDuplicateMessageID(t *testing.T) {
+	ctx, keeper := setup(t)
+	keeper.InitGenesis(ctx, types.DefaultGenesisState())
+
+	id, _, _ := keeper.GenerateMessageID(ctx)
+	msg := getRandomMessage(id)
+
+	genState := types.DefaultGenesisState()
+	genState.Messages = []exported.GeneralMessage{msg, msg}
+
+	ctx, keeper = setup(t)
+	assert.Panics(t, func() { keeper.InitGenesis(ctx, genState) })
+}
+
 func TestInitGenesisRebuildsProcessingMessageIndex(t *testing.T) {
 	ctx, keeper := setup(t)
 	keeper.InitGenesis(ctx, types.DefaultGenesisState())

--- a/x/nexus/keeper/genesis_test.go
+++ b/x/nexus/keeper/genesis_test.go
@@ -215,3 +215,23 @@ func TestExportGenesisInitGenesis(t *testing.T) {
 	assert.NoError(t, actual.Validate())
 	assertChainStatesEqual(t, expected, actual)
 }
+
+func TestInitGenesisRebuildsProcessingMessageIndex(t *testing.T) {
+	ctx, keeper := setup(t)
+	keeper.InitGenesis(ctx, types.DefaultGenesisState())
+
+	id, _, _ := keeper.GenerateMessageID(ctx)
+	msg := getRandomMessage(id)
+	funcs.MustNoErr(keeper.setMessage(ctx, msg))
+	funcs.MustNoErr(keeper.setProcessingMessageID(ctx, msg))
+
+	destChain := msg.GetDestinationChain()
+	assert.Len(t, keeper.GetProcessingMessages(ctx, destChain, 10), 1)
+
+	genState := keeper.ExportGenesis(ctx)
+
+	ctx, keeper = setup(t)
+	keeper.InitGenesis(ctx, genState)
+
+	assert.Len(t, keeper.GetProcessingMessages(ctx, destChain, 10), 1)
+}


### PR DESCRIPTION
Description

`InitGenesis` in `x/nexus` now:
1. Rebuilds the processing-message index from each message's status. A message stored as `PROCESSING` is re-added to the index under `processingMessagePrefix`. That index is not part of serialized genesis state, so it has to be reconstructed on import.
2. Rejects genesis files that contain duplicate message IDs (panics instead of silently overwriting, since `setMessage`/`SetNewValidated` does not reject existing keys).

Before this change a message imported in `PROCESSING` status was written to the store but not re-indexed, so it would never be routed. Rebuilding it makes import correct-by-construction for any genesis that carries processing messages.