### PR TITLE
fix(nexus): deliver processing messages in insertion order (#2373, private:#74)

### DIFF
--- a/x/nexus/keeper/general_message.go
+++ b/x/nexus/keeper/general_message.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/axelarnetwork/axelar-core/utils/key"
 	"github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	"github.com/axelarnetwork/axelar-core/x/nexus/types"
+	"github.com/axelarnetwork/utils/convert"
 	"github.com/axelarnetwork/utils/funcs"
 	"github.com/axelarnetwork/utils/slices"
 )
@@ -26,6 +28,22 @@ func getMessageKey(id string) key.Key {
 
 func getProcessingMessageKey(destinationChain exported.ChainName, id string) key.Key {
 	return processingMessagePrefix.Append(key.From(destinationChain)).Append(key.FromStr(id))
+}
+
+// getProcessingMessageOrderKey keys a processing message by insertion sequence (FIFO).
+func getProcessingMessageOrderKey(destinationChain exported.ChainName, seq uint64) key.Key {
+	return processingMessageOrderPrefix.Append(key.From(destinationChain)).Append(key.FromUInt(seq))
+}
+
+// getProcessingMessageSeq returns the order-index sequence recorded for a processing
+// message; ok is false if the message is not indexed.
+func (k Keeper) getProcessingMessageSeq(ctx sdk.Context, destinationChain exported.ChainName, id string) (uint64, bool) {
+	bz := k.getStore(ctx).GetRawNew(getProcessingMessageKey(destinationChain, id))
+	if bz == nil {
+		return 0, false
+	}
+
+	return binary.BigEndian.Uint64(bz), true
 }
 
 // GenerateMessageID generates a unique general message ID, and returns the message ID, current transacation ID and a unique integer nonce
@@ -98,12 +116,24 @@ func (k Keeper) setProcessingMessageID(ctx sdk.Context, m exported.GeneralMessag
 		return fmt.Errorf("general message is not processing")
 	}
 
-	k.getStore(ctx).SetRawNew(getProcessingMessageKey(m.GetDestinationChain(), m.ID), []byte(m.ID))
+	if _, ok := k.getProcessingMessageSeq(ctx, m.GetDestinationChain(), m.ID); ok {
+		return nil
+	}
+
+	seq := utils.NewCounter[uint64](processingMessageSeqKey, k.getStore(ctx)).Incr(ctx)
+	k.getStore(ctx).SetRawNew(getProcessingMessageOrderKey(m.GetDestinationChain(), seq), []byte(m.ID))
+	k.getStore(ctx).SetRawNew(getProcessingMessageKey(m.GetDestinationChain(), m.ID), convert.IntToBytes(seq))
 
 	return nil
 }
 
 func (k Keeper) deleteProcessingMessageID(ctx sdk.Context, m exported.GeneralMessage) {
+	seq, ok := k.getProcessingMessageSeq(ctx, m.GetDestinationChain(), m.ID)
+	if !ok {
+		return
+	}
+
+	k.getStore(ctx).DeleteNew(getProcessingMessageOrderKey(m.GetDestinationChain(), seq))
 	k.getStore(ctx).DeleteNew(getProcessingMessageKey(m.GetDestinationChain(), m.ID))
 }
 
@@ -133,7 +163,7 @@ func (k Keeper) GetProcessingMessages(ctx sdk.Context, chain exported.ChainName,
 		CountTotal: false,
 		Reverse:    false,
 	}
-	keyPrefix := append(processingMessagePrefix.Append(key.From(chain)).Bytes(), []byte(key.DefaultDelimiter)...)
+	keyPrefix := append(processingMessageOrderPrefix.Append(key.From(chain)).Bytes(), []byte(key.DefaultDelimiter)...)
 
 	// it's unexpected to get a retrieval/iterator error from IAVL db
 	funcs.Must(query.Paginate(prefix.NewStore(k.getStore(ctx).KVStore, keyPrefix), pageRequest, func(key []byte, value []byte) error {

--- a/x/nexus/keeper/general_message_internal_test.go
+++ b/x/nexus/keeper/general_message_internal_test.go
@@ -1,0 +1,52 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	evm "github.com/axelarnetwork/axelar-core/x/evm/exported"
+	"github.com/axelarnetwork/axelar-core/x/nexus/exported"
+	"github.com/axelarnetwork/utils/funcs"
+)
+
+// TestSetProcessingMessageIDRetryGoesToBack verifies that a message which fails and is
+// retried re-enters the queue at the back, keeping delivery order FIFO (scheduled later
+// => executed later). A second setProcessingMessageID call while still queued is a no-op.
+func TestSetProcessingMessageIDRetryGoesToBack(t *testing.T) {
+	ctx, k := setup(t)
+
+	route := func() exported.GeneralMessage {
+		id, _, _ := k.GenerateMessageID(ctx)
+		m := getRandomMessage(id) // Status == Processing
+		funcs.MustNoErr(k.setMessage(ctx, m))
+		funcs.MustNoErr(k.setProcessingMessageID(ctx, m))
+		return m
+	}
+
+	ids := func() []string {
+		got := k.GetProcessingMessages(ctx, evm.Ethereum.Name, 100)
+		out := make([]string, len(got))
+		for i, m := range got {
+			out[i] = m.ID
+		}
+		return out
+	}
+
+	first := route()
+	second := route()
+
+	// re-queuing an already-queued message keeps its slot
+	funcs.MustNoErr(k.setProcessingMessageID(ctx, first))
+	assert.Equal(t, []string{first.ID, second.ID}, ids())
+
+	// first fails, then is retried (re-enters processing)
+	funcs.MustNoErr(k.SetMessageFailed(ctx, first.ID))
+	retried, _ := k.GetMessage(ctx, first.ID)
+	retried.Status = exported.Processing
+	funcs.MustNoErr(k.setMessage(ctx, retried))
+	funcs.MustNoErr(k.setProcessingMessageID(ctx, retried))
+
+	// the retry re-entered at the back, so it is now delivered after second
+	assert.Equal(t, []string{second.ID, first.ID}, ids())
+}

--- a/x/nexus/keeper/general_message_test.go
+++ b/x/nexus/keeper/general_message_test.go
@@ -723,3 +723,56 @@ func TestGetSentMessages(t *testing.T) {
 	assert.Equal(t, dest3Msgs, toMap(consumeSent(chain3.Name, 100)))
 	assert.Equal(t, dest4Msgs, toMap(consumeSent(chain4.Name, 100)))
 }
+
+// TestGetProcessingMessagesFIFO verifies delivery order is insertion order, not
+// message-ID order: a low-ID message routed after a high-ID one must not jump it.
+func TestGetProcessingMessagesFIFO(t *testing.T) {
+	cfg := app.MakeEncodingConfig()
+	k, ctx := setup(cfg, t)
+
+	sourceChain := nexustestutils.RandomChain()
+	sourceChain.Module = axelarnet.ModuleName
+	destChain := nexustestutils.RandomChain()
+	destChain.Module = evmtypes.ModuleName
+	k.SetChain(ctx, sourceChain)
+	k.SetChain(ctx, destChain)
+	k.ActivateChain(ctx, sourceChain)
+	k.ActivateChain(ctx, destChain)
+	k.SetMessageRouter(types.NewMessageRouter().AddRoute(destChain.Module,
+		func(_ sdk.Context, _ exported.RoutingContext, _ exported.GeneralMessage) error { return nil }))
+
+	route := func(id string) {
+		msg := exported.GeneralMessage{
+			ID:            id,
+			Sender:        exported.CrossChainAddress{Chain: sourceChain, Address: genCosmosAddr(sourceChain.Name.String())},
+			Recipient:     exported.CrossChainAddress{Chain: destChain, Address: evmtestutils.RandomAddress().Hex()},
+			Status:        exported.Approved,
+			PayloadHash:   crypto.Keccak256Hash(rand.Bytes(32)).Bytes(),
+			SourceTxID:    evmtestutils.RandomHash().Bytes(),
+			SourceTxIndex: 0,
+		}
+		funcs.MustNoErr(k.SetNewMessage(ctx, msg))
+		funcs.MustNoErr(k.RouteMessage(ctx, msg.ID))
+	}
+
+	ids := func(msgs []exported.GeneralMessage) []string {
+		out := make([]string, len(msgs))
+		for i, m := range msgs {
+			out[i] = m.ID
+		}
+		return out
+	}
+
+	// high-ID enters FIRST, low-ID enters SECOND
+	highID := "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff-0"
+	lowID := "0x0000000000000000000000000000000000000000000000000000000000000001-0"
+	route(highID)
+	route(lowID)
+
+	// delivered in insertion order, not ID order
+	assert.Equal(t, []string{highID, lowID}, ids(k.GetProcessingMessages(ctx, destChain.Name, 100)))
+
+	// delete-by-id removes the correct entry and keeps the rest ordered
+	funcs.MustNoErr(k.SetMessageExecuted(ctx, highID))
+	assert.Equal(t, []string{lowID}, ids(k.GetProcessingMessages(ctx, destChain.Name, 100)))
+}

--- a/x/nexus/keeper/genesis.go
+++ b/x/nexus/keeper/genesis.go
@@ -74,6 +74,11 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 
 	for _, msg := range genState.Messages {
 		funcs.MustNoErr(k.setMessage(ctx, msg))
+
+		// rebuild the FIFO processing index (setMessage only writes the record)
+		if msg.Is(exported.Processing) {
+			funcs.MustNoErr(k.setProcessingMessageID(ctx, msg))
+		}
 	}
 
 	utils.NewCounter[uint64](messageNonceKey, k.getStore(ctx)).Set(ctx, genState.MessageNonce)

--- a/x/nexus/keeper/genesis_test.go
+++ b/x/nexus/keeper/genesis_test.go
@@ -215,3 +215,24 @@ func TestExportGenesisInitGenesis(t *testing.T) {
 	assert.NoError(t, actual.Validate())
 	assertChainStatesEqual(t, expected, actual)
 }
+
+// TestInitGenesisRebuildsProcessingIndex verifies that importing a processing
+// message rebuilds the FIFO order index (setMessage alone only writes the record),
+// so the message is returned by GetProcessingMessages after import.
+func TestInitGenesisRebuildsProcessingIndex(t *testing.T) {
+	ctx, keeper := setup(t)
+
+	id, _, _ := keeper.GenerateMessageID(ctx)
+	msg := getRandomMessage(id) // Status == Processing
+
+	genState := types.DefaultGenesisState()
+	genState.Messages = []exported.GeneralMessage{msg}
+
+	keeper.InitGenesis(ctx, genState)
+
+	got := keeper.GetProcessingMessages(ctx, msg.GetDestinationChain(), 100)
+	assert.Len(t, got, 1)
+	if len(got) == 1 {
+		assert.Equal(t, msg.ID, got[0].ID)
+	}
+}

--- a/x/nexus/keeper/keeper.go
+++ b/x/nexus/keeper/keeper.go
@@ -26,14 +26,16 @@ var (
 	transferFee              = utils.KeyFromStr("fee")
 	assetFeePrefix           = utils.KeyFromStr("asset_fee")
 
-	chainMaintainerStatePrefix = key.RegisterStaticKey(types.ModuleName, 1)
-	_                          = key.RegisterStaticKey(types.ModuleName, 2) // retired
-	_                          = key.RegisterStaticKey(types.ModuleName, 3) // retired
-	generalMessagePrefix       = key.RegisterStaticKey(types.ModuleName, 4)
-	processingMessagePrefix    = key.RegisterStaticKey(types.ModuleName, 5)
-	messageNonceKey            = key.RegisterStaticKey(types.ModuleName, 6)
-	wasmActivation             = key.RegisterStaticKey(types.ModuleName, 7)
-	_                          = key.RegisterStaticKey(types.ModuleName, 8) // retired
+	chainMaintainerStatePrefix   = key.RegisterStaticKey(types.ModuleName, 1)
+	_                            = key.RegisterStaticKey(types.ModuleName, 2) // retired
+	_                            = key.RegisterStaticKey(types.ModuleName, 3) // retired
+	generalMessagePrefix         = key.RegisterStaticKey(types.ModuleName, 4)
+	processingMessagePrefix      = key.RegisterStaticKey(types.ModuleName, 5)
+	messageNonceKey              = key.RegisterStaticKey(types.ModuleName, 6)
+	wasmActivation               = key.RegisterStaticKey(types.ModuleName, 7)
+	_                            = key.RegisterStaticKey(types.ModuleName, 8) // retired
+	processingMessageOrderPrefix = key.RegisterStaticKey(types.ModuleName, 9)
+	processingMessageSeqKey      = key.RegisterStaticKey(types.ModuleName, 10)
 
 	// temporary
 	// TODO: add description about what temporary means

--- a/x/nexus/keeper/migrate.go
+++ b/x/nexus/keeper/migrate.go
@@ -3,14 +3,47 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/axelarnetwork/axelar-core/utils"
+	"github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	"github.com/axelarnetwork/axelar-core/x/nexus/types"
+	"github.com/axelarnetwork/utils/funcs"
 )
 
 // Migrate8to9 returns the handler that performs in-place store migrations
 func Migrate8to9(k Keeper) func(ctx sdk.Context) error {
 	return func(ctx sdk.Context) error {
 		shrinkMaintainerStateBitmaps(ctx, k)
+		rebuildProcessingMessageIndex(ctx, k)
 		return nil
+	}
+}
+
+// rebuildProcessingMessageIndex clears the old processing index and re-indexes the
+// currently-processing messages under the new FIFO order index. It walks the (small)
+// processing index, not the all-time message store; the pre-migration value is the
+// message id. All old entries are deleted so no pre-migration format lingers under the
+// shared prefix; the backlog has no arrival-order data, so it is re-sequenced in id
+// order this once.
+func rebuildProcessingMessageIndex(ctx sdk.Context, k Keeper) {
+	kvStore := k.getStore(ctx)
+
+	var msgs []exported.GeneralMessage
+	var oldKeys [][]byte
+	iter := kvStore.IteratorNew(processingMessagePrefix)
+	for ; iter.Valid(); iter.Next() {
+		oldKeys = append(oldKeys, append([]byte(nil), iter.Key()...))
+		if m, ok := k.GetMessage(ctx, string(iter.Value())); ok && m.Is(exported.Processing) {
+			msgs = append(msgs, m)
+		}
+	}
+	utils.CloseLogError(iter, k.Logger(ctx))
+
+	for _, oldKey := range oldKeys {
+		kvStore.DeleteRaw(oldKey)
+	}
+
+	for _, m := range msgs {
+		funcs.MustNoErr(k.setProcessingMessageID(ctx, m))
 	}
 }
 

--- a/x/nexus/keeper/migrate_internal_test.go
+++ b/x/nexus/keeper/migrate_internal_test.go
@@ -1,0 +1,37 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/axelarnetwork/utils/funcs"
+)
+
+// TestMigrate8to9RebuildsProcessingIndex plants a processing message in the old
+// layout (a message record plus a membership entry whose value is the id, with no
+// order entry) and verifies Migrate8to9 re-indexes it so GetProcessingMessages
+// returns it.
+func TestMigrate8to9RebuildsProcessingIndex(t *testing.T) {
+	ctx, k := setup(t)
+
+	id, _, _ := k.GenerateMessageID(ctx)
+	msg := getRandomMessage(id) // Status == Processing
+	funcs.MustNoErr(k.setMessage(ctx, msg))
+	// old layout: membership value is the id, no order entry
+	k.getStore(ctx).SetRawNew(getProcessingMessageKey(msg.GetDestinationChain(), msg.ID), []byte(msg.ID))
+	// a stale old-layout entry with no live message must be purged, not carried over
+	staleKey := getProcessingMessageKey(msg.GetDestinationChain(), "0xstale-0")
+	k.getStore(ctx).SetRawNew(staleKey, []byte("0xstale-0"))
+
+	assert.Empty(t, k.GetProcessingMessages(ctx, msg.GetDestinationChain(), 100))
+
+	funcs.MustNoErr(Migrate8to9(k)(ctx))
+
+	got := k.GetProcessingMessages(ctx, msg.GetDestinationChain(), 100)
+	assert.Len(t, got, 1)
+	if len(got) == 1 {
+		assert.Equal(t, msg.ID, got[0].ID)
+	}
+	assert.Nil(t, k.getStore(ctx).GetRawNew(staleKey), "stale old-layout entry should be purged")
+}


### PR DESCRIPTION
CPI-436

## Description

`GetProcessingMessages` drained the EVM delivery queue in raw message-ID order, ascending and un-hashed, capped at `EndBlockerLimit` per block.

An EVM message ID is `0x<source-tx-hash>-<logIndex>`, which is a property of the source transaction and not of when the message arrived. So the delivery order was unrelated to arrival order, and messages with low-sorting IDs were served ahead of messages that had been waiting longer. With enough low-sorting messages queued for a destination chain, the per-block cap is filled by those every block and the messages sorting above them are never reached, so their gateway commands are never enqueued and funds bound for that chain stay stuck.

There is no recovery path for a message in that state: it stays `Processing`, which is not retryable.

Hashing the index key does not help, since the ID is not derived from anything the chain controls. The ordering has to be arrival-based.

## Fix

Order the processing set by a monotonic insertion sequence instead of by ID.

- New order index `processingMessageOrderPrefix | destChain | seq -> id`, iterated ascending by `GetProcessingMessages`. The delivery loop itself is unchanged.
- The existing `processingMessagePrefix | destChain | id` entry is repurposed into a reverse index (`id -> seq`), so delete-by-id stays O(1). The set is deleted out of order (IBC acks, wasm routing, delivery), so a plain FIFO queue does not fit.
- New counter under `processingMessageSeqKey` hands out the sequence numbers.

Message IDs, command IDs and express are untouched.

## Migration and genesis

Folded into the existing, not-yet-executed `Migrate8to9`, so there is no version bump. The migration rebuilds the current processing index under the new order index. The in-flight backlog has no arrival data from before the upgrade, so it is re-sequenced by ID once and is FIFO from then on.

Genesis import now rebuilds the index as well, which it did not do at all before.