### PR TITLE
fix: fix copy-paste module-name leftovers in keeper doc comments

### DIFF
--- a/x/axelarnet/keeper/genesis.go
+++ b/x/axelarnet/keeper/genesis.go
@@ -56,7 +56,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 	})
 }
 
-// ExportGenesis returns the reward module's genesis state.
+// ExportGenesis returns the axelarnet module's genesis state.
 func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	collector, _ := k.GetFeeCollector(ctx)
 

--- a/x/axelarnet/keeper/grpc_query.go
+++ b/x/axelarnet/keeper/grpc_query.go
@@ -56,7 +56,7 @@ func (q Querier) PendingIBCTransferCount(c context.Context, _ *types.PendingIBCT
 	return &types.PendingIBCTransferCountResponse{TransfersByChain: counts}, nil
 }
 
-// Params returns the reward module params
+// Params returns the axelarnet module params
 func (q Querier) Params(c context.Context, req *types.ParamsRequest) (*types.ParamsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 

--- a/x/multisig/keeper/grpc_query.go
+++ b/x/multisig/keeper/grpc_query.go
@@ -149,7 +149,7 @@ func (q Querier) KeygenSession(c context.Context, req *types.KeygenSessionReques
 	}, nil
 }
 
-// Params returns the reward module params
+// Params returns the multisig module params
 func (q Querier) Params(c context.Context, req *types.ParamsRequest) (*types.ParamsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 

--- a/x/nexus/keeper/genesis.go
+++ b/x/nexus/keeper/genesis.go
@@ -11,7 +11,7 @@ import (
 	"github.com/axelarnetwork/utils/funcs"
 )
 
-// InitGenesis initializes the reward module's state from a given genesis state.
+// InitGenesis initializes the nexus module's state from a given genesis state.
 func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 	k.SetParams(ctx, genState.Params)
 
@@ -79,7 +79,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 	utils.NewCounter[uint64](messageNonceKey, k.getStore(ctx)).Set(ctx, genState.MessageNonce)
 }
 
-// ExportGenesis returns the reward module's genesis state.
+// ExportGenesis returns the nexus module's genesis state.
 func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	return types.NewGenesisState(
 		k.GetParams(ctx),

--- a/x/nexus/keeper/grpc_query.go
+++ b/x/nexus/keeper/grpc_query.go
@@ -31,7 +31,7 @@ func NewGRPCQuerier(k Keeper, a types.AxelarnetKeeper) Querier {
 	}
 }
 
-// Params returns the reward module params
+// Params returns the nexus module params
 func (q Querier) Params(c context.Context, req *types.ParamsRequest) (*types.ParamsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 

--- a/x/permission/keeper/genesis.go
+++ b/x/permission/keeper/genesis.go
@@ -6,7 +6,7 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/permission/types"
 )
 
-// InitGenesis initializes the reward module's state from a given genesis state.
+// InitGenesis initializes the permission module's state from a given genesis state.
 func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 	k.setParams(ctx, genState.Params)
 
@@ -19,7 +19,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 	}
 }
 
-// ExportGenesis returns the reward module's genesis state.
+// ExportGenesis returns the permission module's genesis state.
 func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	governanceKey, ok := k.GetGovernanceKey(ctx)
 	if !ok {

--- a/x/permission/keeper/grpc_query.go
+++ b/x/permission/keeper/grpc_query.go
@@ -25,7 +25,7 @@ func (k Keeper) GovernanceKey(c context.Context, req *types.QueryGovernanceKeyRe
 	}, nil
 }
 
-// Params returns the reward module params
+// Params returns the permission module params
 func (q Keeper) Params(c context.Context, req *types.ParamsRequest) (*types.ParamsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 

--- a/x/permission/keeper/keeper.go
+++ b/x/permission/keeper/keeper.go
@@ -27,7 +27,7 @@ type Keeper struct {
 	params   params.Subspace
 }
 
-// NewKeeper returns a new reward keeper
+// NewKeeper returns a new permission keeper
 func NewKeeper(cdc codec.BinaryCodec, storeKey store.StoreKey, paramSpace params.Subspace) Keeper {
 	return Keeper{
 		cdc:      cdc,

--- a/x/reward/keeper/grpc_query.go
+++ b/x/reward/keeper/grpc_query.go
@@ -13,14 +13,14 @@ import (
 
 var _ types.QueryServiceServer = Querier{}
 
-// Querier implements the grpc queries for the nexus module
+// Querier implements the grpc queries for the reward module
 type Querier struct {
 	keeper Keeper
 	minter mintkeeper.Keeper
 	nexus  types.Nexus
 }
 
-// NewGRPCQuerier creates a new nexus Querier
+// NewGRPCQuerier creates a new reward Querier
 func NewGRPCQuerier(k Keeper, m mintkeeper.Keeper, n types.Nexus) Querier {
 	return Querier{
 		keeper: k,

--- a/x/snapshot/keeper/genesis.go
+++ b/x/snapshot/keeper/genesis.go
@@ -6,7 +6,7 @@ import (
 	"github.com/axelarnetwork/axelar-core/x/snapshot/types"
 )
 
-// InitGenesis initializes the reward module's state from a given genesis state.
+// InitGenesis initializes the snapshot module's state from a given genesis state.
 func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 	k.SetParams(ctx, genState.Params)
 
@@ -15,7 +15,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 	}
 }
 
-// ExportGenesis returns the reward module's genesis state.
+// ExportGenesis returns the snapshot module's genesis state.
 func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	return types.NewGenesisState(
 		k.GetParams(ctx),

--- a/x/snapshot/keeper/grpc_query.go
+++ b/x/snapshot/keeper/grpc_query.go
@@ -11,19 +11,19 @@ import (
 
 var _ types.QueryServiceServer = Querier{}
 
-// Querier implements the grpc queries for the nexus module
+// Querier implements the grpc queries for the snapshot module
 type Querier struct {
 	keeper Keeper
 }
 
-// NewGRPCQuerier creates a new nexus Querier
+// NewGRPCQuerier creates a new snapshot Querier
 func NewGRPCQuerier(k Keeper) Querier {
 	return Querier{
 		keeper: k,
 	}
 }
 
-// Params returns the reward module params
+// Params returns the snapshot module params
 func (q Querier) Params(c context.Context, _ *types.ParamsRequest) (*types.ParamsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 

--- a/x/vote/keeper/grpc_query.go
+++ b/x/vote/keeper/grpc_query.go
@@ -10,19 +10,19 @@ import (
 
 var _ types.QueryServiceServer = Querier{}
 
-// Querier implements the grpc queries for the nexus module
+// Querier implements the grpc queries for the vote module
 type Querier struct {
 	keeper Keeper
 }
 
-// NewGRPCQuerier creates a new nexus Querier
+// NewGRPCQuerier creates a new vote Querier
 func NewGRPCQuerier(k Keeper) Querier {
 	return Querier{
 		keeper: k,
 	}
 }
 
-// Params returns the reward module params
+// Params returns the vote module params
 func (q Querier) Params(c context.Context, req *types.ParamsRequest) (*types.ParamsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 

--- a/x/vote/keeper/keeper.go
+++ b/x/vote/keeper/keeper.go
@@ -61,14 +61,14 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
-// GetParams returns the total set of reward parameters.
+// GetParams returns the total set of vote parameters.
 func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
 	k.paramSpace.GetParamSet(ctx, &params)
 
 	return params
 }
 
-// SetParams sets the total set of reward parameters.
+// SetParams sets the total set of vote parameters.
 func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramSpace.SetParamSet(ctx, &params)
 }
@@ -113,7 +113,7 @@ func (k *Keeper) SetVoteRouter(router types.VoteRouter) {
 	k.voteRouter.Seal()
 }
 
-// GetVoteRouter returns the nexus router. If no router was set, it returns a (sealed) router with no handlers
+// GetVoteRouter returns the vote router. If no router was set, it returns a (sealed) router with no handlers
 func (k Keeper) GetVoteRouter() types.VoteRouter {
 	if k.voteRouter == nil {
 		k.SetVoteRouter(types.NewRouter())


### PR DESCRIPTION
Several modules under `x/` were scaffolded by copying from existing modules
(primarily `reward`, and a few from `nexus`). The copies left doc-comments
referencing the *source* module instead of the module they now live in. This
PR corrects those comments.