### PR TITLE
fix(evm): skip missing-vote penalty when a poll gets no votes (#2375, private:#75)

### DIFF
--- a/x/evm/keeper/vote_handler.go
+++ b/x/evm/keeper/vote_handler.go
@@ -11,6 +11,7 @@ import (
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	vote "github.com/axelarnetwork/axelar-core/x/vote/exported"
 	"github.com/axelarnetwork/utils/funcs"
+	"github.com/axelarnetwork/utils/slices"
 )
 
 var _ vote.VoteHandler = &voteHandler{}
@@ -59,25 +60,29 @@ func (v voteHandler) HandleExpiredPoll(ctx sdk.Context, poll vote.Poll) error {
 	if !ok {
 		return fmt.Errorf("%s is not a registered chain", md.Chain)
 	}
-	// Penalize voters who failed to vote
-	for _, voter := range poll.GetVoters() {
-		hasVoted := poll.HasVoted(voter)
-		if maintainerState, ok := v.nexus.GetChainMaintainerState(ctx, chain, voter); ok {
-			maintainerState.MarkMissingVote(!hasVoted)
-			funcs.MustNoErr(v.nexus.SetChainMaintainerState(ctx, maintainerState))
+	voters := poll.GetVoters()
 
-			v.keeper.Logger(ctx).Debug(fmt.Sprintf("marked voter %s behaviour", voter.String()),
-				"voter", voter.String(),
-				"missing_vote", !hasVoted,
-				"poll", poll.GetID().String(),
-			)
-		}
+	// Penalize voters who failed to vote (skip when nobody voted)
+	if slices.Any(voters, poll.HasVoted) {
+		for _, voter := range voters {
+			hasVoted := poll.HasVoted(voter)
+			if maintainerState, ok := v.nexus.GetChainMaintainerState(ctx, chain, voter); ok {
+				maintainerState.MarkMissingVote(!hasVoted)
+				funcs.MustNoErr(v.nexus.SetChainMaintainerState(ctx, maintainerState))
 
-		if !hasVoted {
-			rewardPool.ClearRewards(voter)
-			v.keeper.Logger(ctx).Debug(fmt.Sprintf("penalized voter %s due to timeout", voter.String()),
-				"voter", voter.String(),
-				"poll", poll.GetID().String())
+				v.keeper.Logger(ctx).Debug(fmt.Sprintf("marked voter %s behaviour", voter.String()),
+					"voter", voter.String(),
+					"missing_vote", !hasVoted,
+					"poll", poll.GetID().String(),
+				)
+			}
+
+			if !hasVoted {
+				rewardPool.ClearRewards(voter)
+				v.keeper.Logger(ctx).Debug(fmt.Sprintf("penalized voter %s due to timeout", voter.String()),
+					"voter", voter.String(),
+					"poll", poll.GetID().String())
+			}
 		}
 	}
 

--- a/x/evm/keeper/vote_handler_test.go
+++ b/x/evm/keeper/vote_handler_test.go
@@ -147,7 +147,7 @@ func TestHandleExpiredPoll(t *testing.T) {
 				return maintainerState, true
 			}
 		}).
-		Then("should clear rewards and mark voters missing vote", func(t *testing.T) {
+		Then("should not penalize any voter because the poll received no votes", func(t *testing.T) {
 			maintainerState.MarkMissingVoteFunc = func(bool) {}
 			n.SetChainMaintainerStateFunc = func(ctx sdk.Context, maintainerState nexus.MaintainerState) error { return nil }
 			rewardPool.ClearRewardsFunc = func(sdk.ValAddress) {}
@@ -155,12 +155,9 @@ func TestHandleExpiredPoll(t *testing.T) {
 			err := handler.HandleExpiredPoll(ctx, poll)
 
 			assert.NoError(t, err)
-			assert.Len(t, maintainerState.MarkMissingVoteCalls(), 10)
-			for _, call := range maintainerState.MarkMissingVoteCalls() {
-				assert.True(t, call.MissingVote)
-			}
-			assert.Len(t, n.SetChainMaintainerStateCalls(), 10)
-			assert.Len(t, rewardPool.ClearRewardsCalls(), 10)
+			assert.Empty(t, maintainerState.MarkMissingVoteCalls())
+			assert.Empty(t, n.SetChainMaintainerStateCalls())
+			assert.Empty(t, rewardPool.ClearRewardsCalls())
 		}).
 		Run(t)
 
@@ -182,13 +179,13 @@ func TestHandleExpiredPoll(t *testing.T) {
 				return nil, false
 			}
 		}).
-		Then("should clear rewards and not mark voters missing vote", func(t *testing.T) {
+		Then("should not clear rewards because the poll received no votes", func(t *testing.T) {
 			rewardPool.ClearRewardsFunc = func(sdk.ValAddress) {}
 
 			err := handler.HandleExpiredPoll(ctx, poll)
 
 			assert.NoError(t, err)
-			assert.Len(t, rewardPool.ClearRewardsCalls(), 10)
+			assert.Empty(t, rewardPool.ClearRewardsCalls())
 		}).
 		Run(t)
 
@@ -222,6 +219,38 @@ func TestHandleExpiredPoll(t *testing.T) {
 				assert.False(t, call.MissingVote)
 			}
 			assert.Len(t, n.SetChainMaintainerStateCalls(), 10)
+		}).
+		Run(t)
+
+	givenVoteHandler.
+		When("only one voter voted for poll", func() {
+			voter := rand.ValAddr()
+			poll = &votemock.PollMock{
+				GetIDFunc:             func() vote.PollID { return vote.PollID(rand.I64Between(10, 100)) },
+				GetRewardPoolNameFunc: func() (string, bool) { return rand.NormalizedStr(3), true },
+				GetMetaDataFunc:       func() (codec.ProtoMarshaler, bool) { return &types.PollMetadata{Chain: exported.Ethereum.Name}, true },
+				GetVotersFunc: func() []sdk.ValAddress {
+					return append(slices.Expand(func(int) sdk.ValAddress { return rand.ValAddr() }, 9), voter)
+				},
+				HasVotedFunc: func(address sdk.ValAddress) bool { return address.Equals(voter) },
+			}
+		}).
+		When("the voters are chain maintainers", func() {
+			maintainerState = &nexusmock.MaintainerStateMock{}
+			n.GetChainMaintainerStateFunc = func(sdk.Context, nexus.Chain, sdk.ValAddress) (nexus.MaintainerState, bool) {
+				return maintainerState, true
+			}
+		}).
+		Then("should penalize the voters that missed because the poll did receive a vote", func(t *testing.T) {
+			maintainerState.MarkMissingVoteFunc = func(bool) {}
+			n.SetChainMaintainerStateFunc = func(sdk.Context, nexus.MaintainerState) error { return nil }
+			rewardPool.ClearRewardsFunc = func(sdk.ValAddress) {}
+
+			err := handler.HandleExpiredPoll(ctx, poll)
+
+			assert.NoError(t, err)
+			assert.Len(t, maintainerState.MarkMissingVoteCalls(), 10)
+			assert.Len(t, rewardPool.ClearRewardsCalls(), 9)
 		}).
 		Run(t)
 }


### PR DESCRIPTION
## Description

`HandleExpiredPoll` walked every voter of an expired poll, marked each one that had not voted as missing, and cleared their rewards. It did this unconditionally, including for a poll that expired with **no votes at all**.

A poll expiring with zero votes says nothing about any individual maintainer: the whole voter set failed to record a vote, which points at a condition affecting all of them rather than at any one maintainer being unavailable. Penalising all of them for it is wrong on its own, and the missing-vote counters feed `x/nexus` deregistration through `ChainMaintainerMissingVoteThreshold`, so a run of such polls can push honest maintainers over the threshold and deregister them together.

## Fix

In `HandleExpiredPoll`, skip the penalty loop entirely when the poll expired with zero votes (`!slices.Any(voters, poll.HasVoted)`). No missing-vote marking, so no deregistration pressure, and no reward clearing.

Partial non-voting, where some voters voted and some did not, is penalised exactly as before. That case does carry per-maintainer signal, so the existing behaviour is right there.

Reward clearing is skipped along with the marking. The reward pool is a per-chain inflation accrual, so leaving it untouched simply means those rewards are released or forfeited on later real polls. There is no double-pay, and it closes the reward-griefing variant of the same problem.