### PR TITLE
fix(evm): resolve completed poll chain from metadata (#2376, private:#76)

### DIFF
--- a/x/evm/keeper/vote_handler.go
+++ b/x/evm/keeper/vote_handler.go
@@ -92,10 +92,12 @@ func (v voteHandler) HandleExpiredPoll(ctx sdk.Context, poll vote.Poll) error {
 
 func (v voteHandler) HandleCompletedPoll(ctx sdk.Context, poll vote.Poll) error {
 	voteEvents := poll.GetResult().(*types.VoteEvents)
+	md := mustGetMetadata(poll)
 
-	chain, ok := v.nexus.GetChain(ctx, voteEvents.Chain)
+	// resolve the chain from poll metadata, not the voter-supplied result
+	chain, ok := v.nexus.GetChain(ctx, md.Chain)
 	if !ok {
-		return fmt.Errorf("%s is not a registered chain", voteEvents.Chain)
+		return fmt.Errorf("%s is not a registered chain", md.Chain)
 	}
 
 	rewardPoolName, ok := poll.GetRewardPoolName()
@@ -141,7 +143,6 @@ func (v voteHandler) HandleCompletedPoll(ctx sdk.Context, poll vote.Poll) error 
 		}
 	}
 
-	md := mustGetMetadata(poll)
 	if v.IsFalsyResult(voteEvents) {
 		events.Emit(ctx, &types.NoEventsConfirmed{
 			TxID:   md.TxID,

--- a/x/evm/keeper/vote_handler_test.go
+++ b/x/evm/keeper/vote_handler_test.go
@@ -469,4 +469,38 @@ func TestHandleCompletedPoll(t *testing.T) {
 			assert.Empty(t, rewardPool.ClearRewardsCalls())
 		}).
 		Run(t)
+
+	givenVoteHandler.
+		When("the result names an unregistered chain but the poll metadata chain is registered", func() {
+			n.GetChainFunc = func(_ sdk.Context, chain nexus.ChainName) (nexus.Chain, bool) {
+				if chain != exported.Ethereum.Name {
+					return nexus.Chain{}, false
+				}
+				return nexus.Chain{Name: chain, SupportsForeignAssets: true, Module: types.ModuleName}, true
+			}
+			n.GetChainMaintainerStateFunc = func(sdk.Context, nexus.Chain, sdk.ValAddress) (nexus.MaintainerState, bool) {
+				return &nexusmock.MaintainerStateMock{
+					MarkMissingVoteFunc:   func(bool) {},
+					MarkIncorrectVoteFunc: func(bool) {},
+				}, true
+			}
+
+			poll = &votemock.PollMock{
+				GetIDFunc:             func() vote.PollID { return vote.PollID(rand.I64Between(10, 100)) },
+				GetResultFunc:         func() codec.ProtoMarshaler { return types.NewVoteEvents(nexus.ChainName("nosuchchain")) },
+				GetRewardPoolNameFunc: func() (string, bool) { return rand.NormalizedStr(3), true },
+				GetMetaDataFunc:       func() (codec.ProtoMarshaler, bool) { return &types.PollMetadata{Chain: exported.Ethereum.Name}, true },
+				GetVotersFunc:         func() []sdk.ValAddress { return []sdk.ValAddress{voter} },
+				HasVotedFunc:          func(sdk.ValAddress) bool { return true },
+				HasVotedCorrectlyFunc: func(sdk.ValAddress) bool { return true },
+			}
+		}).
+		Then("should resolve the chain from metadata and not error", func(t *testing.T) {
+			err := handler.HandleCompletedPoll(ctx, poll)
+
+			assert.NoError(t, err)
+			assert.Len(t, rewardPool.ReleaseRewardsCalls(), 1)
+			assert.Equal(t, exported.Ethereum.Name, n.GetChainCalls()[0].Chain)
+		}).
+		Run(t)
 }


### PR DESCRIPTION
CPI-440

## Description

`HandleCompletedPoll` resolved the chain from the voter-supplied vote result (`voteEvents.Chain`) rather than from the poll metadata (`md.Chain`), unlike its sibling `HandleExpiredPoll`, which already used the metadata.

That makes the handler's chain lookup depend on data the handler does not control. If a completed poll's result names a chain that is not registered, the lookup fails and the handler returns an error. The `x/vote` `EndBlocker` runs the handler under `RunCached`, so the error rolls the block's state changes back, including the dequeue of the poll itself. The poll therefore stays at the head of the `ExpiresAt`-ordered queue and is retried, and fails, every block, and every poll queued behind it stops being processed.

## Fix

Resolve the chain from `md.Chain`, matching `HandleExpiredPoll`. Poll metadata is fixed at poll creation and always names a registered chain, so the vote result can no longer drive this path into the error branch.

Added a regression test that pins the metadata chain as the lookup key, so a result naming a different chain does not change which chain is resolved.
