### PR TITLE
feat: skip nexus endblocker queue for destinations that require payload (#2378, private:#77)

### DIFF
--- a/.changeset/skip-route-queue-for-payload-required-destinations.md
+++ b/.changeset/skip-route-queue-for-payload-required-destinations.md
@@ -1,5 +1,0 @@
----
-'@axelar-network/axelar-core': patch
----
-
-Stop queueing messages that the nexus EndBlocker can never route. The EndBlocker drains the route-message queue with an empty routing context, so a destination whose route needs the original payload (cosmos chains, via the axelarnet route) failed every time.

--- a/.changeset/skip-route-queue-for-payload-required-destinations.md
+++ b/.changeset/skip-route-queue-for-payload-required-destinations.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Stop queueing messages that the nexus EndBlocker can never route. The EndBlocker drains the route-message queue with an empty routing context, so a destination whose route needs the original payload (cosmos chains, via the axelarnet route) failed every time.

--- a/x/nexus/keeper/general_message.go
+++ b/x/nexus/keeper/general_message.go
@@ -258,6 +258,11 @@ func (k Keeper) EnqueueRouteMessage(ctx sdk.Context, id string) error {
 		return fmt.Errorf("general message has to be approved or failed")
 	}
 
+	if types.RequiresPayload(msg.Recipient.Chain.Module) {
+		k.Logger(ctx).Debug("payload is required for routing messages to a cosmos chain")
+		return nil
+	}
+
 	k.getRouteMessageQueue(ctx).Enqueue(utils.KeyFromBz(getMessageKey(id).Bytes()), &msg)
 
 	return nil

--- a/x/nexus/keeper/general_message_test.go
+++ b/x/nexus/keeper/general_message_test.go
@@ -723,3 +723,141 @@ func TestGetSentMessages(t *testing.T) {
 	assert.Equal(t, dest3Msgs, toMap(consumeSent(chain3.Name, 100)))
 	assert.Equal(t, dest4Msgs, toMap(consumeSent(chain4.Name, 100)))
 }
+
+// TestEnqueueRouteMessagePayloadRequired: a destination whose route needs the original
+// payload can never be routed by the EndBlocker (which routes with an empty RoutingContext)
+func TestEnqueueRouteMessagePayloadRequired(t *testing.T) {
+	// the destination module whose route needs the payload; see types.RequiresPayload
+	const payloadRequiredModule = types.AxelarnetModule
+
+	var (
+		msg    exported.GeneralMessage
+		ctx    sdk.Context
+		keeper nexus.Keeper
+	)
+
+	cfg := app.MakeEncodingConfig()
+	noopRoute := func(_ sdk.Context, _ exported.RoutingContext, _ exported.GeneralMessage) error { return nil }
+
+	givenKeeper := Given("a keeper with a payload-required route", func() {
+		keeper, ctx = setup(cfg, t)
+		keeper.SetMessageRouter(
+			types.NewMessageRouter().
+				AddRoute(evm.Ethereum.Module, noopRoute).
+				AddRoute(payloadRequiredModule, noopRoute),
+		)
+	})
+
+	newApprovedMsgTo := func(destinationModule string) exported.GeneralMessage {
+		destinationChain := nexustestutils.RandomChain()
+		destinationChain.Module = destinationModule
+
+		m := randMsg(exported.Approved)
+		m.Sender = exported.CrossChainAddress{Chain: evm.Ethereum, Address: evmtestutils.RandomAddress().Hex()}
+		m.Recipient = exported.CrossChainAddress{Chain: destinationChain, Address: rand.NormalizedStr(20)}
+		funcs.MustNoErr(keeper.SetNewMessage(ctx, m))
+
+		return m
+	}
+
+	givenKeeper.
+		Branch(
+			When("the destination route requires the payload", func() {
+				msg = newApprovedMsgTo(payloadRequiredModule)
+			}).
+				Then("should enqueue nothing", func(t *testing.T) {
+					// NOTE: reports success without enqueueing -- see EnqueueRouteMessage's doc comment
+					assert.NoError(t, keeper.EnqueueRouteMessage(ctx, msg.ID))
+
+					// nothing was queued, so the EndBlocker has no guaranteed-fail work to do
+					_, ok := keeper.DequeueRouteMessage(ctx)
+					assert.False(t, ok)
+
+					// the message itself is untouched and still deliverable via a RouteMessage tx
+					actual, ok := keeper.GetMessage(ctx, msg.ID)
+					assert.True(t, ok)
+					assert.Equal(t, msg, actual)
+					assert.True(t, actual.Is(exported.Approved))
+				}),
+
+			When("the destination route does not require the payload", func() {
+				msg = newApprovedMsgTo(evm.Ethereum.Module)
+			}).
+				Then("should enqueue as before", func(t *testing.T) {
+					assert.NoError(t, keeper.EnqueueRouteMessage(ctx, msg.ID))
+
+					actual, ok := keeper.DequeueRouteMessage(ctx)
+					assert.True(t, ok)
+					assert.Equal(t, msg, actual)
+				}),
+
+			When("a payload-required message is enqueued alongside a routable one", func() {
+				msg = newApprovedMsgTo(evm.Ethereum.Module)
+				blocked := newApprovedMsgTo(payloadRequiredModule)
+				funcs.MustNoErr(keeper.EnqueueRouteMessage(ctx, blocked.ID)) // skipped, not queued
+				funcs.MustNoErr(keeper.EnqueueRouteMessage(ctx, msg.ID))
+			}).
+				Then("only the routable one occupies the queue", func(t *testing.T) {
+					actual, ok := keeper.DequeueRouteMessage(ctx)
+					assert.True(t, ok)
+					assert.Equal(t, msg.ID, actual.ID)
+
+					_, ok = keeper.DequeueRouteMessage(ctx)
+					assert.False(t, ok)
+				}),
+		).
+		Run(t)
+}
+
+// TestGetProcessingMessagesFIFO verifies delivery order is insertion order, not
+// message-ID order: a low-ID message routed after a high-ID one must not jump it.
+func TestGetProcessingMessagesFIFO(t *testing.T) {
+	cfg := app.MakeEncodingConfig()
+	k, ctx := setup(cfg, t)
+
+	sourceChain := nexustestutils.RandomChain()
+	sourceChain.Module = axelarnet.ModuleName
+	destChain := nexustestutils.RandomChain()
+	destChain.Module = evmtypes.ModuleName
+	k.SetChain(ctx, sourceChain)
+	k.SetChain(ctx, destChain)
+	k.ActivateChain(ctx, sourceChain)
+	k.ActivateChain(ctx, destChain)
+	k.SetMessageRouter(types.NewMessageRouter().AddRoute(destChain.Module,
+		func(_ sdk.Context, _ exported.RoutingContext, _ exported.GeneralMessage) error { return nil }))
+
+	route := func(id string) {
+		msg := exported.GeneralMessage{
+			ID:            id,
+			Sender:        exported.CrossChainAddress{Chain: sourceChain, Address: genCosmosAddr(sourceChain.Name.String())},
+			Recipient:     exported.CrossChainAddress{Chain: destChain, Address: evmtestutils.RandomAddress().Hex()},
+			Status:        exported.Approved,
+			PayloadHash:   crypto.Keccak256Hash(rand.Bytes(32)).Bytes(),
+			SourceTxID:    evmtestutils.RandomHash().Bytes(),
+			SourceTxIndex: 0,
+		}
+		funcs.MustNoErr(k.SetNewMessage(ctx, msg))
+		funcs.MustNoErr(k.RouteMessage(ctx, msg.ID))
+	}
+
+	ids := func(msgs []exported.GeneralMessage) []string {
+		out := make([]string, len(msgs))
+		for i, m := range msgs {
+			out[i] = m.ID
+		}
+		return out
+	}
+
+	// high-ID enters FIRST, low-ID enters SECOND
+	highID := "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff-0"
+	lowID := "0x0000000000000000000000000000000000000000000000000000000000000001-0"
+	route(highID)
+	route(lowID)
+
+	// delivered in insertion order, not ID order
+	assert.Equal(t, []string{highID, lowID}, ids(k.GetProcessingMessages(ctx, destChain.Name, 100)))
+
+	// delete-by-id removes the correct entry and keeps the rest ordered
+	funcs.MustNoErr(k.SetMessageExecuted(ctx, highID))
+	assert.Equal(t, []string{lowID}, ids(k.GetProcessingMessages(ctx, destChain.Name, 100)))
+}

--- a/x/nexus/types/payload_required.go
+++ b/x/nexus/types/payload_required.go
@@ -1,0 +1,10 @@
+package types
+
+// AxelarnetModule is the module name of the axelarnet destination route.
+const AxelarnetModule = "axelarnet"
+
+// RequiresPayload reports whether the route for the given destination module can only deliver a
+// message when the original payload is supplied.
+func RequiresPayload(module string) bool {
+	return module == AxelarnetModule
+}


### PR DESCRIPTION
**Description**

routeQueuedMessages drains the nexus route-message queue by calling RouteMessage with no routing context, so routingCtx.Payload is always nil (x/nexus/abci.go:71-85). The axelarnet route rejects a nil payload unconditionally.

Only the payload hash is stored on chain, so this is structural, not incidental: every message in the queue whose destination is a registered cosmos chain fails 100% of the time (By reverting to confirmed). The evm and wasm routes don't read the payload, so they are unaffected.

Such messages are nonetheless enqueued unconditionally, from two places:

- x/evm/abci.go:282 — routeEventToNexus, on every EVM→cosmos GMP call
- x/nexus/keeper/msg_server.go:329 — RetryFailedMessage, which is ROLE_UNRESTRICTED (proto/axelar/nexus/v1beta1/tx.proto:186)

**Impact**

Not a correctness or fund-safety bug — RunCached rolls the failed attempt back, and delivery still happens normally via the axelarnet RouteMessage msg, which carries the payload. The costs are wasted work:

1. Each such message burns one of nexus's EndBlockerLimit iterations (default 50, x/nexus/types/params.go:42), competing with evm/wasm-destined messages that would actually be routed.
2. RetryFailedMessage is a dead end for these destinations (it can never deliver).
4. Because the failure is guaranteed rather than transient, any funded account can re-queue such messages every block via RetryFailedMessage.

**Suggested fix**

Gate at enqueue time, where the destination module is already available, nothing that cannot be routed should enter the queue. Note that routeEventToNexus's return value flows into processConfirmedEvent inside RunCached, so an error there would roll back the preceding SetNewMessage and mark the confirmed event Failed, breaking EVM→cosmos GMP; the enqueue must skip rather than fail on that path.

When the message enters the default way (Votes -> SetNewMessage): It is approved and is kept approved
When the message enters through RetryFailedMessage: It is failed and is kept failed