### PR TITLE
fix(evm): reuse an already registered chain param subspace (#2381, private:#78)

### DIFF
--- a/.changeset/evm-idempotent-chain-subspace.md
+++ b/.changeset/evm-idempotent-chain-subspace.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Reuse an already registered EVM chain param subspace when creating a chain, instead of panicking on the attempt to register it again

--- a/.changeset/evm-idempotent-chain-subspace.md
+++ b/.changeset/evm-idempotent-chain-subspace.md
@@ -1,5 +1,0 @@
----
-'@axelar-network/axelar-core': patch
----
-
-Reuse an already registered EVM chain param subspace when creating a chain, instead of panicking on the attempt to register it again

--- a/x/evm/keeper/baseKeeper.go
+++ b/x/evm/keeper/baseKeeper.go
@@ -109,6 +109,10 @@ func (k BaseKeeper) forChain(ctx sdk.Context, chain nexus.ChainName) (chainKeepe
 
 func (k BaseKeeper) createSubspace(ctx sdk.Context, chain nexus.ChainName) params.Subspace {
 	chainKey := key.FromStr(types.ModuleName).Append(key.From(chain))
+	if subspace, ok := k.paramsKeeper.GetSubspace(chainKey.String()); ok {
+		return subspace
+	}
+
 	k.Logger(ctx).Debug(fmt.Sprintf("initialized evm subspace %s", chain))
 	return k.paramsKeeper.Subspace(chainKey.String()).WithKeyTable(types.KeyTable())
 }

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -191,6 +191,26 @@ func TestBaseKeeper(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	// the params keeper holds its subspaces in memory, outside of the versioned store, so a subspace
+	// registered by a chain creation whose state writes are discarded (failed tx, simulation) is left
+	// behind. Re-registering it must not panic, otherwise the retry diverges from a restarted node.
+	thenChainCanBeCreatedAfterDiscardedCreation := Then("a chain can be created after a discarded creation registered its subspace", func(t *testing.T) {
+		ps := types.DefaultParams()[0]
+		ps.Chain = nexustestutils.RandomChainName()
+
+		cacheCtx, _ := ctx.CacheContext()
+		assert.NoError(t, keeper.CreateChain(cacheCtx, ps))
+		// cacheCtx is never written, so the state writes are gone but the subspace stays registered
+
+		assert.NotPanics(t, func() {
+			assert.NoError(t, keeper.CreateChain(ctx, ps))
+
+			ck, err := keeper.ForChain(ctx, ps.Chain)
+			assert.NoError(t, err)
+			assert.Equal(t, ps, ck.GetParams(ctx))
+		})
+	})
+
 	thenSecondInitChainsPanics := Then("a second chain initialization panics", func(t *testing.T) {
 		assert.Panics(t, func() {
 			keeper.InitChains(ctx)
@@ -222,6 +242,12 @@ func TestBaseKeeper(t *testing.T) {
 		When2(whenInitChains).
 		Then2(thenCreateExistingChainFails).
 		Then2(thenGetChainKeeperForExistingChain).Run(t)
+
+	givenBaseKeeper.
+		Given2(givenCtx).
+		Given2(givenNoChainsExist).
+		When2(whenInitChains).
+		Then2(thenChainCanBeCreatedAfterDiscardedCreation).Run(t)
 
 	givenBaseKeeper.
 		Given2(givenCtx).


### PR DESCRIPTION
axelarnetwork/axelar-core#2381
https://bugs.immunefi.com/magnus/878/projects/432/reports/86394

**Description**

`createSubspace` registers a new params subspace unconditionally, and `paramsKeeper.Subspace` panics if a subspace with that name is already registered (`x/evm/keeper/baseKeeper.go:110`).

The params keeper holds its subspaces in memory, outside the versioned store, so a subspace registered by a chain creation whose state writes are later discarded — failed tx, simulation, rolled-back cache context — stays registered. A retry of that same chain creation then panics.

**Impact**

The panic is node-local state, not consensus state: a node that has restarted since the discarded attempt has no in-memory registration and would not panic. So the retry diverges between nodes depending on whether they restarted in between.

**Note**

This is the quick fix. I'll look into creating a better fix for v1.6. I think a better solution is that subspaces are also rolled back. But that is more involved.

Part of CPI-456