### PR TITLE
fix(vald): fail health check on stale consensus

### DIFF
--- a/vald/healthcheck.go
+++ b/vald/healthcheck.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
+	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/server"
@@ -27,12 +28,14 @@ const (
 	minBalance = 5000000
 	timeout    = time.Hour
 
-	flagSkipTofnd       = "skip-tofnd"
-	flagSkipBroadcaster = "skip-broadcaster"
-	flagSkipOperator    = "skip-operator"
-	flagOperatorAddr    = "operator-addr"
-	flagTofndHost       = "tofnd-host"
-	flagTofndPort       = "tofnd-port"
+	flagSkipTofnd         = "skip-tofnd"
+	flagSkipBroadcaster   = "skip-broadcaster"
+	flagSkipOperator      = "skip-operator"
+	flagSkipNode          = "skip-node"
+	flagMaxLatestBlockAge = "max-latest-block-age"
+	flagOperatorAddr      = "operator-addr"
+	flagTofndHost         = "tofnd-host"
+	flagTofndPort         = "tofnd-port"
 )
 
 // GetHealthCheckCommand returns the command to execute a node health check
@@ -40,6 +43,8 @@ func GetHealthCheckCommand() *cobra.Command {
 	var skipTofnd bool
 	var skipBroadcaster bool
 	var skipOperator bool
+	var skipNode bool
+	var maxLatestBlockAge time.Duration
 
 	cmd := &cobra.Command{
 		Use: "health-check",
@@ -50,7 +55,8 @@ func GetHealthCheckCommand() *cobra.Command {
 			}
 			serverCtx := server.GetServerContextFromCmd(cmd)
 
-			ok := execCheck(context.Background(), clientCtx, serverCtx, "tofnd", skipTofnd, checkTofnd) &&
+			ok := execCheck(cmd.Context(), clientCtx, serverCtx, "node", skipNode, checkNode(maxLatestBlockAge)) &&
+				execCheck(context.Background(), clientCtx, serverCtx, "tofnd", skipTofnd, checkTofnd) &&
 				execCheck(cmd.Context(), clientCtx, serverCtx, "broadcaster", skipBroadcaster, checkBroadcaster)
 
 			// enforce a non-zero exit code in case health checks fail without printing cobra output
@@ -63,12 +69,20 @@ func GetHealthCheckCommand() *cobra.Command {
 	}
 
 	defaultConf := tssTypes.DefaultConfig()
+	defaultValdConf := config.DefaultValdConfig()
 	cmd.PersistentFlags().String(flagTofndHost, defaultConf.Host, "host name for tss daemon")
 	cmd.PersistentFlags().String(flagTofndPort, defaultConf.Port, "port for tss daemon")
 	cmd.PersistentFlags().String(flagOperatorAddr, "", "operator address")
 	cmd.PersistentFlags().BoolVar(&skipTofnd, flagSkipTofnd, false, "skip tofnd check")
 	cmd.PersistentFlags().BoolVar(&skipBroadcaster, flagSkipBroadcaster, false, "skip broadcaster check")
 	cmd.PersistentFlags().BoolVar(&skipOperator, flagSkipOperator, false, "skip operator check")
+	cmd.PersistentFlags().BoolVar(&skipNode, flagSkipNode, false, "skip consensus node check")
+	cmd.PersistentFlags().DurationVar(
+		&maxLatestBlockAge,
+		flagMaxLatestBlockAge,
+		defaultValdConf.MaxLatestBlockAge,
+		"maximum accepted age of the latest consensus block",
+	)
 
 	flags.AddQueryFlagsToCmd(cmd)
 	return cmd
@@ -90,6 +104,51 @@ func execCheck(ctx context.Context, clientCtx client.Context, serverCtx *server.
 
 	fmt.Printf("%s check: passed\n", name)
 	return true
+}
+
+func checkNode(maxLatestBlockAge time.Duration) checkCmd {
+	return func(ctx context.Context, clientCtx client.Context, _ *server.Context) error {
+		if clientCtx.Client == nil {
+			return fmt.Errorf("consensus RPC client is not configured")
+		}
+
+		status, err := clientCtx.Client.Status(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to query consensus status: %w", err)
+		}
+
+		return validateNodeStatus(status, maxLatestBlockAge, time.Now())
+	}
+}
+
+func validateNodeStatus(status *coretypes.ResultStatus, maxLatestBlockAge time.Duration, now time.Time) error {
+	if maxLatestBlockAge <= 0 {
+		return fmt.Errorf("maximum latest block age must be positive")
+	}
+	if status == nil {
+		return fmt.Errorf("consensus status response is empty")
+	}
+	if status.SyncInfo.CatchingUp {
+		return fmt.Errorf("consensus node is catching up")
+	}
+	if status.SyncInfo.LatestBlockHeight <= 0 {
+		return fmt.Errorf("consensus latest block height is not positive")
+	}
+	if status.SyncInfo.LatestBlockTime.IsZero() {
+		return fmt.Errorf("consensus latest block time is missing")
+	}
+
+	blockAge := now.Sub(status.SyncInfo.LatestBlockTime)
+	if blockAge > maxLatestBlockAge {
+		return fmt.Errorf(
+			"consensus latest block is stale (height %d, age %s, maximum %s)",
+			status.SyncInfo.LatestBlockHeight,
+			blockAge.Round(time.Second),
+			maxLatestBlockAge,
+		)
+	}
+
+	return nil
 }
 
 func checkTofnd(ctx context.Context, _ client.Context, serverCtx *server.Context) error {

--- a/vald/healthcheck_test.go
+++ b/vald/healthcheck_test.go
@@ -1,0 +1,96 @@
+package vald
+
+import (
+	"testing"
+	"time"
+
+	coretypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateNodeStatus(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	freshStatus := func() *coretypes.ResultStatus {
+		return &coretypes.ResultStatus{
+			SyncInfo: coretypes.SyncInfo{
+				LatestBlockHeight: 100,
+				LatestBlockTime:   now.Add(-5 * time.Second),
+			},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		status          *coretypes.ResultStatus
+		maxAge          time.Duration
+		wantErrContains string
+	}{
+		{
+			name:   "fresh node",
+			status: freshStatus(),
+			maxAge: 15 * time.Second,
+		},
+		{
+			name:            "invalid maximum age",
+			status:          freshStatus(),
+			maxAge:          0,
+			wantErrContains: "must be positive",
+		},
+		{
+			name:            "empty status",
+			status:          nil,
+			maxAge:          15 * time.Second,
+			wantErrContains: "response is empty",
+		},
+		{
+			name: "catching up",
+			status: &coretypes.ResultStatus{
+				SyncInfo: coretypes.SyncInfo{
+					LatestBlockHeight: 100,
+					LatestBlockTime:   now.Add(-5 * time.Second),
+					CatchingUp:        true,
+				},
+			},
+			maxAge:          15 * time.Second,
+			wantErrContains: "is catching up",
+		},
+		{
+			name: "missing height",
+			status: &coretypes.ResultStatus{
+				SyncInfo: coretypes.SyncInfo{LatestBlockTime: now},
+			},
+			maxAge:          15 * time.Second,
+			wantErrContains: "height is not positive",
+		},
+		{
+			name: "missing block time",
+			status: &coretypes.ResultStatus{
+				SyncInfo: coretypes.SyncInfo{LatestBlockHeight: 100},
+			},
+			maxAge:          15 * time.Second,
+			wantErrContains: "block time is missing",
+		},
+		{
+			name: "stalled consensus",
+			status: &coretypes.ResultStatus{
+				SyncInfo: coretypes.SyncInfo{
+					LatestBlockHeight: 100,
+					LatestBlockTime:   now.Add(-16 * time.Second),
+				},
+			},
+			maxAge:          15 * time.Second,
+			wantErrContains: "latest block is stale",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNodeStatus(tt.status, tt.maxAge, now)
+			if tt.wantErrContains == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErrContains)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add a consensus-node check to `axelard health-check`.

The existing command checks tofnd and the broadcaster, but it can still report
success when the process remains alive after consensus stops. The new check
queries CometBFT status and fails when the node is catching up, the reported
height or block time is invalid, or the latest block is older than the allowed
threshold.

Fixes #1039.

## Todos

- [x] Unit tests
- [x] Manual tests
- [x] Documentation — CLI help documents both new flags
- [x] Connect epics/issues — fixes #1039
- [x] Tag type of change — fix
- [x] Upgrade handler — not required

## Steps to Test

```bash
go test -count=1 ./vald
go test -count=1 -race ./vald
go test ./... -race
go vet ./...
```

Manual fresh-node check:

```bash
axelard health-check \
  --node <rpc-url> \
  --skip-tofnd \
  --skip-broadcaster \
  --max-latest-block-age 30s
```

## Expected Behaviour

- A fresh, synced node prints `node check: passed`.
- A catching-up or stale node prints `node check: failed (...)` and the command
  exits non-zero.
- `--skip-node` explicitly disables only the new consensus check.

## Other Notes

The default threshold is the existing vald `MaxLatestBlockAge` value (15
seconds). Tofnd, broadcaster, operator, restart, and recovery behaviour are
unchanged.
