### PR TITLE
fix(vald): use decode hooks in health check

### DIFF
--- a/vald/healthcheck.go
+++ b/vald/healthcheck.go
@@ -93,9 +93,9 @@ func execCheck(ctx context.Context, clientCtx client.Context, serverCtx *server.
 }
 
 func checkTofnd(ctx context.Context, _ client.Context, serverCtx *server.Context) error {
-	valdCfg := config.DefaultValdConfig()
-	if err := serverCtx.Viper.Unmarshal(&valdCfg); err != nil {
-		panic(err)
+	valdCfg, err := loadValdConfig(serverCtx)
+	if err != nil {
+		return fmt.Errorf("failed to load vald config: %w", err)
 	}
 
 	conn, err := tss.Connect(valdCfg.TssConfig.Host, valdCfg.TssConfig.Port, valdCfg.TssConfig.DialTimeout)
@@ -128,6 +128,15 @@ func checkTofnd(ctx context.Context, _ client.Context, serverCtx *server.Context
 	}
 
 	return nil
+}
+
+func loadValdConfig(serverCtx *server.Context) (config.ValdConfig, error) {
+	valdCfg := config.DefaultValdConfig()
+	if err := serverCtx.Viper.Unmarshal(&valdCfg, config.AddDecodeHooks); err != nil {
+		return config.ValdConfig{}, err
+	}
+
+	return valdCfg, nil
 }
 
 func checkBroadcaster(ctx context.Context, clientCtx client.Context, serverCtx *server.Context) error {

--- a/vald/healthcheck_test.go
+++ b/vald/healthcheck_test.go
@@ -1,0 +1,33 @@
+package vald
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axelarnetwork/axelar-core/vald/evm/rpc"
+)
+
+func TestLoadValdConfigUsesDecodeHooks(t *testing.T) {
+	v := viper.New()
+	v.Set("tss.tofnd-host", "configured-host")
+	v.Set("tss.tofnd-port", "50052")
+	v.Set("tss.tofnd-dial-timeout", "7s")
+	v.Set("axelar_bridge_evm", []map[string]any{
+		{
+			"name":              "linea",
+			"finality_override": "confirmation",
+		},
+	})
+
+	cfg, err := loadValdConfig(&server.Context{Viper: v})
+	require.NoError(t, err)
+	require.Equal(t, "configured-host", cfg.TssConfig.Host)
+	require.Equal(t, "50052", cfg.TssConfig.Port)
+	require.Equal(t, 7*time.Second, cfg.TssConfig.DialTimeout)
+	require.Len(t, cfg.EVMConfig, 1)
+	require.Equal(t, rpc.Confirmation, cfg.EVMConfig[0].FinalityOverride)
+}


### PR DESCRIPTION
## Description

Use the existing vald decode hooks when `axelard health-check` loads
`ValdConfig`.

`vald-start` already applies `config.AddDecodeHooks`, but the health-check path
did not. As a result, a valid EVM configuration such as
`finality_override = "confirmation"` could fail to decode and panic before the
tofnd check ran.

This change uses the same decode path as `vald-start` and returns a normal
health-check error instead of panicking if configuration decoding fails.

## Todos

- [x] Unit tests
- [x] Manual tests
- [x] Documentation — not required; no CLI contract changes
- [x] Connect epics/issues — standalone health-check bug fix
- [x] Tag type of change — fix
- [x] Upgrade handler — not required

## Steps to Test

```bash
go test -count=1 ./vald
go test -count=1 -race ./vald
go test ./... -race
go vet ./...
```

The regression test loads a vald configuration containing:

```toml
[[axelar_bridge_evm]]
name = "linea"
finality_override = "confirmation"
```

## Expected Behaviour

- Valid finality override strings are decoded through the same hooks used by
  `vald-start`.
- The health check proceeds to the tofnd connection check.
- A genuine configuration decoding error is returned as a normal failed
  health check instead of causing a panic.

## Other Notes

This patch does not change consensus, broadcaster, operator, restart, or
recovery behaviour.

