### PR TITLE
ci: harden workflow inputs before shell use

### DIFF
--- a/.github/workflows/ci-binaries-r2.yaml
+++ b/.github/workflows/ci-binaries-r2.yaml
@@ -25,11 +25,14 @@ jobs:
         steps:
             - name: Determine checkout ref
               id: get-checkout-ref
+              env:
+                EVENT_NAME: ${{ github.event_name }}
+                BRANCH: ${{ inputs.branch }}
               run: |
-                if [ "${{ github.event_name }}" == "push" ]; then
+                if [ "$EVENT_NAME" == "push" ]; then
                   ref="main"
                 else
-                  ref="${{ inputs.branch }}"
+                  ref="$BRANCH"
                 fi
                 echo "ref=$ref" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci-docker-ecr.yaml
+++ b/.github/workflows/ci-docker-ecr.yaml
@@ -58,11 +58,13 @@ jobs:
         env:
           WASM: "true"
           IBC_WASM_HOOKS: "false"
+          WASM_INPUT: ${{ github.event.inputs.wasm }}
+          IBC_WASM_HOOKS_INPUT: ${{ github.event.inputs.ibc-wasm-hooks }}
         run: |
-          if [ "${{ github.event.inputs.wasm }}" == "false" ]; then
+          if [ "$WASM_INPUT" == "false" ]; then
             export WASM="false"
           fi
-          if [ "${{ github.event.inputs.ibc-wasm-hooks }}" == "true" ]; then
+          if [ "$IBC_WASM_HOOKS_INPUT" == "true" ]; then
             export IBC_WASM_HOOKS="true"
           fi
           make docker-image
@@ -80,12 +82,14 @@ jobs:
         env:
           WASM: "true"
           IBC_WASM_HOOKS: "false"
+          WASM_INPUT: ${{ github.event.inputs.wasm }}
+          IBC_WASM_HOOKS_INPUT: ${{ github.event.inputs.ibc-wasm-hooks }}
         if: github.event.inputs.buildDebug != 'false'
         run: |
-          if [ "${{ github.event.inputs.wasm }}" == "false" ]; then
+          if [ "$WASM_INPUT" == "false" ]; then
             export WASM="false"
           fi
-          if [ "${{ github.event.inputs.ibc-wasm-hooks }}" == "true" ]; then
+          if [ "$IBC_WASM_HOOKS_INPUT" == "true" ]; then
             export IBC_WASM_HOOKS="true"
           fi
           make docker-image-debug

--- a/.github/workflows/ops-take-testnet-snapshot.yaml
+++ b/.github/workflows/ops-take-testnet-snapshot.yaml
@@ -28,7 +28,7 @@ jobs:
           SEMVER: ${{ github.event.inputs.axelard_version }}
         run: |
           if [[ $SEMVER =~ v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]]; then echo "Tag is okay" && exit 0; else echo "invalid tag" && exit 1; fi
-          aws s3 ls s3://axelar-testnet-snapshots/axelartestnet-${{ github.event.inputs.axelard_version }}.tar.lz4 && echo "tag already exists, use a new one" && exit 1
+          aws s3 ls "s3://axelar-testnet-snapshots/axelartestnet-${SEMVER}.tar.lz4" && echo "tag already exists, use a new one" && exit 1
 
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
@@ -36,7 +36,9 @@ jobs:
           fetch-depth: '0'
           submodules: recursive
 
-      - name: Copy snapshot to s3://axelar-testnet-snapshots/axelartestnet-${{ github.event.inputs.axelard_version }}.tar.lz4
+      - name: Copy snapshot to S3
+        env:
+          SEMVER: ${{ github.event.inputs.axelard_version }}
         run: |
           URL=`curl https://quicksync.io/axelar.json|jq -r '.[] |select(.file=="axelartestnet-lisbon-3-pruned")|.url'`
-          curl "$URL" | aws s3 cp - s3://axelar-testnet-snapshots/axelartestnet-${{ github.event.inputs.axelard_version }}.tar.lz4
+          curl "$URL" | aws s3 cp - "s3://axelar-testnet-snapshots/axelartestnet-${SEMVER}.tar.lz4"

--- a/.github/workflows/release-create-tag.yaml
+++ b/.github/workflows/release-create-tag.yaml
@@ -44,22 +44,28 @@ jobs:
           input_string: ${{ steps.release.outputs.tag }}
 
       - name: Generate release
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          BUMP_TYPE: ${{ github.event.inputs.bumpType }}
+          PARSED_MAJOR: ${{ steps.parsed-release.outputs.major }}
+          PARSED_MINOR: ${{ steps.parsed-release.outputs.minor }}
+          NEW_TAG: ${{ steps.release.outputs.new_tag }}
         run: |
           new_release_branch=""
 
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            if [ "${{ github.event.inputs.bumpType }}" = "major" ]; then
-              let new_major=${{ steps.parsed-release.outputs.major }}+1
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            if [ "$BUMP_TYPE" = "major" ]; then
+              let new_major=$PARSED_MAJOR+1
               new_release_branch="releases/$new_major.0.x"
-            elif [ "${{ github.event.inputs.bumpType }}" = "minor" ]; then
-              let new_minor=${{ steps.parsed-release.outputs.minor }}+1
-              new_release_branch="releases/${{ steps.parsed-release.outputs.major }}.$new_minor.x"
+            elif [ "$BUMP_TYPE" = "minor" ]; then
+              let new_minor=$PARSED_MINOR+1
+              new_release_branch="releases/${PARSED_MAJOR}.$new_minor.x"
             else
               echo "cannot make patch release from main branch"
               exit 1
             fi
-          elif [[ "${{ github.ref }}" = refs/heads/releases/* ]]; then
-            if [ "${{ github.event.inputs.bumpType }}" != "patch" ]; then
+          elif [[ "$GITHUB_REF" = refs/heads/releases/* ]]; then
+            if [ "$BUMP_TYPE" != "patch" ]; then
               echo "cannot make major/minor release from release branch"
               exit 1
             fi
@@ -71,7 +77,7 @@ jobs:
           git config --global user.email "cicd@interoplabs.io"
           git config --global user.name "axelar-cicd-bot"
 
-          git commit --allow-empty -m "${{ steps.release.outputs.new_tag }}"
+          git commit --allow-empty -m "$NEW_TAG"
           git push
 
           if [ -n "$new_release_branch" ]; then


### PR DESCRIPTION
## Summary
- CI hygiene for `ci-binaries-r2`, `ci-docker-ecr`, `ops-take-testnet-snapshot`, and `release-create-tag`.
- Bind free-string `workflow_dispatch` inputs under `env:` before `run:` script use (quoted env vars).
- `with:` / `ref:` / `if:` expressions left as-is (not shell script text).
- `ops-take-testnet-snapshot` already bound `SEMVER` for validation; remaining shell uses now go through `$SEMVER`.
- Defense-in-depth for Actions workflows — not framed as a vulnerability ticket.

## Test plan
- [ ] Workflow YAML review
- [ ] Manual `workflow_dispatch` of binaries/ECR paths with normal inputs still behaves the same
- [ ] Snapshot / release-tag dispatch paths still accept prior semver / bump values

Made with [Cursor](https://cursor.com)