### PR TITLE
feat(vald): warn when the tofnd signing channel is exposed beyond loopback

### DIFF
--- a/.changeset/warn-remote-tofnd-insecure.md
+++ b/.changeset/warn-remote-tofnd-insecure.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Warn at vald startup when the tofnd signing channel is configured with a non-loopback host: the connection is plaintext and unauthenticated, so exposing it beyond loopback lets anyone who can reach the port request signatures with the validator's keys

--- a/vald/tofnd_grpc/client.go
+++ b/vald/tofnd_grpc/client.go
@@ -3,6 +3,8 @@ package grpc
 import (
 	"context"
 	"fmt"
+	"net"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc"
@@ -15,8 +17,31 @@ func Connect(host string, port string, timeout time.Duration) (*grpc.ClientConn,
 	serverAddr := fmt.Sprintf("%s:%s", host, port)
 	log.Infof("initiate connection to tofnd gRPC server: %s", serverAddr)
 
+	// The channel is plaintext and unauthenticated: any caller that can
+	// reach the port can request signatures for any key the tofnd daemon
+	// holds. That is safe for the default loopback deployment, but if the
+	// daemon is split onto another host or container network, anything on
+	// that network gains the same power. Warn loudly so the exposure is a
+	// deliberate operator choice rather than a silent default.
+	if !isLoopbackHost(host) {
+		log.Errorf("tofnd connection to %s is plaintext and unauthenticated; "+
+			"any party that can reach this address can request signatures with the validator's keys. "+
+			"Restrict network access to this port.", serverAddr)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	return grpc.DialContext(ctx, serverAddr, grpc.WithInsecure(), grpc.WithBlock())
+}
+
+func isLoopbackHost(host string) bool {
+	h := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if h == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(strings.Trim(h, "[]")); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }

--- a/vald/tofnd_grpc/client_test.go
+++ b/vald/tofnd_grpc/client_test.go
@@ -1,0 +1,19 @@
+package grpc
+
+import "testing"
+
+func TestIsLoopbackHost(t *testing.T) {
+	loopback := []string{"localhost", "LOCALHOST", "localhost.", "127.0.0.1", "127.1.2.3", "::1", "[::1]", " 127.0.0.1 "}
+	for _, h := range loopback {
+		if !isLoopbackHost(h) {
+			t.Errorf("expected %q to be recognized as loopback", h)
+		}
+	}
+
+	remote := []string{"tofnd", "10.0.0.5", "192.168.1.10", "tofnd.svc.cluster.local", "0.0.0.0", ""}
+	for _, h := range remote {
+		if isLoopbackHost(h) {
+			t.Errorf("expected %q to NOT be recognized as loopback", h)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`vald` connects to the `tofnd` signing daemon over plaintext, unauthenticated gRPC:

```go
return grpc.DialContext(ctx, serverAddr, grpc.WithInsecure(), grpc.WithBlock())
```

Any caller that can reach the port can request a signature for any key the daemon holds. That is the intended trust model for the default loopback deployment (`--tofnd-host localhost`), and nothing in this PR changes it. But when an operator points the flag at another host or a container network (a pattern used to isolate the signer), the exposure is silent: vald starts cleanly and the signing endpoint sits unauthenticated on that network.

This PR makes the exposure a deliberate choice rather than an accident: `Connect` logs a prominent warning whenever the configured host does not resolve to loopback.

## Changes

- `vald/tofnd_grpc/client.go`: loopback classification (`localhost` incl. trailing dot/case, `127.0.0.0/8`, `::1` incl. bracketed form, surrounding whitespace) and a connect-time warning for non-loopback hosts. Note: `utils/log` exposes no `Warnf`, so the warning uses `Errorf` to be unmissable in log scans; happy to switch if a different level is preferred.
- `vald/tofnd_grpc/client_test.go`: table-driven coverage for the classifier (loopback forms and negatives incl. `0.0.0.0` and empty).

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./vald/tofnd_grpc/...` passes (new table test)
- [x] No change on the default path (`localhost`) beyond an unchanged info log

Made with Cursor

Made with [Cursor](https://cursor.com)