### PR TITLE
fix(evm): resolve the chain from poll metadata in HandleResult (#2388, private: #84)

### DIFF
--- a/.changeset/resolve-handle-result-chain-from-poll.md
+++ b/.changeset/resolve-handle-result-chain-from-poll.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Resolve the source chain in the EVM vote handler's `HandleResult` from the poll metadata instead of the voter-supplied result, and reject a result whose chain doesn't match the poll's. `vote.VoteHandler.HandleResult` now takes the poll rather than the result.

--- a/.changeset/resolve-handle-result-chain-from-poll.md
+++ b/.changeset/resolve-handle-result-chain-from-poll.md
@@ -1,5 +1,0 @@
----
-'@axelar-network/axelar-core': patch
----
-
-Resolve the source chain in the EVM vote handler's `HandleResult` from the poll metadata instead of the voter-supplied result, and reject a result whose chain doesn't match the poll's. `vote.VoteHandler.HandleResult` now takes the poll rather than the result.

--- a/x/evm/keeper/vote_handler.go
+++ b/x/evm/keeper/vote_handler.go
@@ -159,21 +159,31 @@ func (v voteHandler) HandleCompletedPoll(ctx sdk.Context, poll vote.Poll) error 
 	return nil
 }
 
-func (v voteHandler) HandleResult(ctx sdk.Context, result codec.ProtoMarshaler) error {
+func (v voteHandler) HandleResult(ctx sdk.Context, poll vote.Poll) error {
+	result := poll.GetResult()
 	voteEvents := result.(*types.VoteEvents)
 
 	if v.IsFalsyResult(result) {
 		return nil
 	}
 
-	chain, ok := v.nexus.GetChain(ctx, voteEvents.Chain)
+	md := mustGetMetadata(poll)
+
+	// the poll's chain is fixed when the poll is created, the result's chain is voter-supplied,
+	// so a mismatch means the voters tried to confirm events for a chain they were not polled on
+	if voteEvents.Chain != md.Chain {
+		return fmt.Errorf("vote result chain %s does not match poll %s chain %s", voteEvents.Chain, poll.GetID().String(), md.Chain)
+	}
+
+	// resolve the chain from poll metadata, not the voter-supplied result
+	chain, ok := v.nexus.GetChain(ctx, md.Chain)
 	if !ok {
-		return fmt.Errorf("%s is not a registered chain", voteEvents.Chain)
+		return fmt.Errorf("%s is not a registered chain", md.Chain)
 	}
 
 	ck, err := v.keeper.ForChain(ctx, chain.Name)
 	if err != nil {
-		return fmt.Errorf("%s is not an evm chain", voteEvents.Chain)
+		return fmt.Errorf("%s is not an evm chain", chain.Name)
 	}
 
 	for _, event := range voteEvents.Events {

--- a/x/evm/keeper/vote_handler_test.go
+++ b/x/evm/keeper/vote_handler_test.go
@@ -228,13 +228,22 @@ func TestHandleExpiredPoll(t *testing.T) {
 
 func TestHandleResult(t *testing.T) {
 	var (
-		ctx     sdk.Context
-		basek   *mock.BaseKeeperMock
-		chaink  *mock.ChainKeeperMock
-		nexusK  *mock.NexusMock
-		result  codec.ProtoMarshaler
-		handler vote.VoteHandler
+		ctx       sdk.Context
+		basek     *mock.BaseKeeperMock
+		chaink    *mock.ChainKeeperMock
+		nexusK    *mock.NexusMock
+		result    codec.ProtoMarshaler
+		poll      *votemock.PollMock
+		pollChain nexus.ChainName
+		handler   vote.VoteHandler
 	)
+
+	// setResult sets the voter-supplied result and, by default, a poll whose metadata
+	// chain agrees with it
+	setResult := func(voteEvents *types.VoteEvents) {
+		result = voteEvents
+		pollChain = voteEvents.Chain
+	}
 
 	setup := func() {
 		multiStore := fakemock.MultiStoreMock{}
@@ -248,6 +257,11 @@ func TestHandleResult(t *testing.T) {
 			LoggerFunc: func(ctx sdk.Context) log.Logger { return log.NewTestLogger(t) },
 		}
 		nexusK = &mock.NexusMock{}
+		poll = &votemock.PollMock{
+			GetIDFunc:       func() vote.PollID { return vote.PollID(rand.I64Between(10, 100)) },
+			GetResultFunc:   func() codec.ProtoMarshaler { return result },
+			GetMetaDataFunc: func() (codec.ProtoMarshaler, bool) { return &types.PollMetadata{Chain: pollChain}, true },
+		}
 
 		handler = keeper.NewVoteHandler(params.MakeEncodingConfig().Codec, basek, nexusK, &mock.RewarderMock{})
 	}
@@ -257,38 +271,58 @@ func TestHandleResult(t *testing.T) {
 	givenHandler.
 		When("result is falsy", func() {
 			chain := nexus.ChainName(rand.Str(5))
-			result = &types.VoteEvents{
+			setResult(&types.VoteEvents{
 				Chain:  chain,
 				Events: nil,
-			}
+			})
 		}).
 		Then("should return nil and do nothing", func(t *testing.T) {
-			assert.NoError(t, handler.HandleResult(ctx, result))
+			assert.NoError(t, handler.HandleResult(ctx, poll))
+		}).
+		Run(t)
+
+	givenHandler.
+		When("the result chain does not match the poll chain", func() {
+			setResult(&types.VoteEvents{
+				Chain:  exported.Ethereum.Name,
+				Events: randTokenDeployedEvents(exported.Ethereum.Name, rand.I64Between(5, 10)),
+			})
+			pollChain = nexus.ChainName(rand.Str(5))
+
+			nexusK.GetChainFunc = func(_ sdk.Context, _ nexus.ChainName) (nexus.Chain, bool) { return exported.Ethereum, true }
+			basek.ForChainFunc = func(_ sdk.Context, _ nexus.ChainName) (types.ChainKeeper, error) { return chaink, nil }
+			chaink.SetConfirmedEventFunc = func(_ sdk.Context, _ types.Event) error { return nil }
+			chaink.EnqueueConfirmedEventFunc = func(_ sdk.Context, _ types.EventID) error { return nil }
+		}).
+		Then("should return error and confirm nothing", func(t *testing.T) {
+			assert.ErrorContains(t, handler.HandleResult(ctx, poll), "does not match poll")
+			assert.Empty(t, chaink.SetConfirmedEventCalls())
+			assert.Empty(t, chaink.EnqueueConfirmedEventCalls())
 		}).
 		Run(t)
 
 	givenHandler.
 		When("source chain is not registered", func() {
 			chain := nexus.ChainName(rand.Str(5))
-			result = &types.VoteEvents{
+			setResult(&types.VoteEvents{
 				Chain:  chain,
 				Events: randTokenDeployedEvents(chain, rand.I64Between(5, 10)),
-			}
+			})
 
 			nexusK.GetChainFunc = func(_ sdk.Context, _ nexus.ChainName) (nexus.Chain, bool) { return nexus.Chain{}, false }
 		}).
 		Then("should return error", func(t *testing.T) {
-			assert.ErrorContains(t, handler.HandleResult(ctx, result), "is not a registered chain")
+			assert.ErrorContains(t, handler.HandleResult(ctx, poll), "is not a registered chain")
 		}).
 		Run(t)
 
 	givenHandler.
 		When("source chain is not an evm chain", func() {
 			chain := nexus.ChainName(rand.Str(5))
-			result = &types.VoteEvents{
+			setResult(&types.VoteEvents{
 				Chain:  chain,
 				Events: randTokenDeployedEvents(chain, rand.I64Between(5, 10)),
-			}
+			})
 
 			nexusK.GetChainFunc = func(_ sdk.Context, _ nexus.ChainName) (nexus.Chain, bool) { return nexus.Chain{}, true }
 			basek.ForChainFunc = func(_ sdk.Context, _ nexus.ChainName) (types.ChainKeeper, error) {
@@ -296,15 +330,15 @@ func TestHandleResult(t *testing.T) {
 			}
 		}).
 		Then("should return error", func(t *testing.T) {
-			assert.ErrorContains(t, handler.HandleResult(ctx, result), "is not an evm chain")
+			assert.ErrorContains(t, handler.HandleResult(ctx, poll), "is not an evm chain")
 		}).
 		Run(t)
 
 	givenHandler.
 		When("source chain is an evm chain", func() {
-			result = &types.VoteEvents{
+			setResult(&types.VoteEvents{
 				Chain: exported.Ethereum.Name,
-			}
+			})
 
 			nexusK.GetChainFunc = func(_ sdk.Context, chainName nexus.ChainName) (nexus.Chain, bool) {
 				switch chainName {
@@ -327,7 +361,7 @@ func TestHandleResult(t *testing.T) {
 				chaink.SetConfirmedEventFunc = func(_ sdk.Context, _ types.Event) error { return fmt.Errorf("failed to set confirmed event") }
 			}).
 				Then("should return error", func(t *testing.T) {
-					assert.ErrorContains(t, handler.HandleResult(ctx, result), "failed to set confirmed event")
+					assert.ErrorContains(t, handler.HandleResult(ctx, poll), "failed to set confirmed event")
 				}),
 
 			When("event is not contract call", func() {
@@ -339,7 +373,7 @@ func TestHandleResult(t *testing.T) {
 				Then("should enqueue the confirmed event", func(t *testing.T) {
 					chaink.EnqueueConfirmedEventFunc = func(_ sdk.Context, _ types.EventID) error { return nil }
 
-					assert.NoError(t, handler.HandleResult(ctx, result))
+					assert.NoError(t, handler.HandleResult(ctx, poll))
 					assert.Len(t, chaink.EnqueueConfirmedEventCalls(), 5)
 				}),
 
@@ -354,7 +388,7 @@ func TestHandleResult(t *testing.T) {
 				Then("should enqueue the confirmed event", func(t *testing.T) {
 					chaink.EnqueueConfirmedEventFunc = func(_ sdk.Context, _ types.EventID) error { return nil }
 
-					assert.NoError(t, handler.HandleResult(ctx, result))
+					assert.NoError(t, handler.HandleResult(ctx, poll))
 					assert.Len(t, chaink.EnqueueConfirmedEventCalls(), 5)
 				}),
 		).

--- a/x/vote/exported/mock/types.go
+++ b/x/vote/exported/mock/types.go
@@ -454,7 +454,7 @@ var _ exported.VoteHandler = &VoteHandlerMock{}
 //			HandleFailedPollFunc: func(ctx github_com_cosmos_cosmos_sdk_types.Context, poll exported.Poll) error {
 //				panic("mock out the HandleFailedPoll method")
 //			},
-//			HandleResultFunc: func(ctx github_com_cosmos_cosmos_sdk_types.Context, result codec.ProtoMarshaler) error {
+//			HandleResultFunc: func(ctx github_com_cosmos_cosmos_sdk_types.Context, poll exported.Poll) error {
 //				panic("mock out the HandleResult method")
 //			},
 //			IsFalsyResultFunc: func(result codec.ProtoMarshaler) bool {
@@ -477,7 +477,7 @@ type VoteHandlerMock struct {
 	HandleFailedPollFunc func(ctx github_com_cosmos_cosmos_sdk_types.Context, poll exported.Poll) error
 
 	// HandleResultFunc mocks the HandleResult method.
-	HandleResultFunc func(ctx github_com_cosmos_cosmos_sdk_types.Context, result codec.ProtoMarshaler) error
+	HandleResultFunc func(ctx github_com_cosmos_cosmos_sdk_types.Context, poll exported.Poll) error
 
 	// IsFalsyResultFunc mocks the IsFalsyResult method.
 	IsFalsyResultFunc func(result codec.ProtoMarshaler) bool
@@ -509,8 +509,8 @@ type VoteHandlerMock struct {
 		HandleResult []struct {
 			// Ctx is the ctx argument value.
 			Ctx github_com_cosmos_cosmos_sdk_types.Context
-			// Result is the result argument value.
-			Result codec.ProtoMarshaler
+			// Poll is the poll argument value.
+			Poll exported.Poll
 		}
 		// IsFalsyResult holds details about calls to the IsFalsyResult method.
 		IsFalsyResult []struct {
@@ -634,21 +634,21 @@ func (mock *VoteHandlerMock) HandleFailedPollCalls() []struct {
 }
 
 // HandleResult calls HandleResultFunc.
-func (mock *VoteHandlerMock) HandleResult(ctx github_com_cosmos_cosmos_sdk_types.Context, result codec.ProtoMarshaler) error {
+func (mock *VoteHandlerMock) HandleResult(ctx github_com_cosmos_cosmos_sdk_types.Context, poll exported.Poll) error {
 	if mock.HandleResultFunc == nil {
 		panic("VoteHandlerMock.HandleResultFunc: method is nil but VoteHandler.HandleResult was just called")
 	}
 	callInfo := struct {
-		Ctx    github_com_cosmos_cosmos_sdk_types.Context
-		Result codec.ProtoMarshaler
+		Ctx  github_com_cosmos_cosmos_sdk_types.Context
+		Poll exported.Poll
 	}{
-		Ctx:    ctx,
-		Result: result,
+		Ctx:  ctx,
+		Poll: poll,
 	}
 	mock.lockHandleResult.Lock()
 	mock.calls.HandleResult = append(mock.calls.HandleResult, callInfo)
 	mock.lockHandleResult.Unlock()
-	return mock.HandleResultFunc(ctx, result)
+	return mock.HandleResultFunc(ctx, poll)
 }
 
 // HandleResultCalls gets all the calls that were made to HandleResult.
@@ -656,12 +656,12 @@ func (mock *VoteHandlerMock) HandleResult(ctx github_com_cosmos_cosmos_sdk_types
 //
 //	len(mockedVoteHandler.HandleResultCalls())
 func (mock *VoteHandlerMock) HandleResultCalls() []struct {
-	Ctx    github_com_cosmos_cosmos_sdk_types.Context
-	Result codec.ProtoMarshaler
+	Ctx  github_com_cosmos_cosmos_sdk_types.Context
+	Poll exported.Poll
 } {
 	var calls []struct {
-		Ctx    github_com_cosmos_cosmos_sdk_types.Context
-		Result codec.ProtoMarshaler
+		Ctx  github_com_cosmos_cosmos_sdk_types.Context
+		Poll exported.Poll
 	}
 	mock.lockHandleResult.RLock()
 	calls = mock.calls.HandleResult

--- a/x/vote/exported/types.go
+++ b/x/vote/exported/types.go
@@ -37,7 +37,7 @@ type VoteHandler interface {
 	HandleExpiredPoll(ctx sdk.Context, poll Poll) error
 	HandleFailedPoll(ctx sdk.Context, poll Poll) error
 	HandleCompletedPoll(ctx sdk.Context, poll Poll) error
-	HandleResult(ctx sdk.Context, result codec.ProtoMarshaler) error
+	HandleResult(ctx sdk.Context, poll Poll) error
 }
 
 // PollID represents ID of polls

--- a/x/vote/keeper/msg_server.go
+++ b/x/vote/keeper/msg_server.go
@@ -67,7 +67,7 @@ func (s msgServer) Vote(c context.Context, req *types.VoteRequest) (*types.VoteR
 	case vote.Completed:
 		if voteResult == vote.VoteInTime {
 			voteHandler := s.GetVoteRouter().GetHandler(poll.GetModule())
-			if err := voteHandler.HandleResult(ctx, poll.GetResult()); err != nil {
+			if err := voteHandler.HandleResult(ctx, poll); err != nil {
 				return &types.VoteResponse{Log: fmt.Sprintf("vote handler failed %s", err.Error())}, nil
 			}
 		}

--- a/x/vote/keeper/msg_server_test.go
+++ b/x/vote/keeper/msg_server_test.go
@@ -72,7 +72,7 @@ func TestMsgServer_VoteGracePeriod(t *testing.T) {
 	// Register a mock vote handler for test-module
 	voteHandler := &exportedMock.VoteHandlerMock{
 		IsFalsyResultFunc:       func(codec.ProtoMarshaler) bool { return false },
-		HandleResultFunc:        func(sdk.Context, codec.ProtoMarshaler) error { return nil },
+		HandleResultFunc:        func(sdk.Context, exported.Poll) error { return nil },
 		HandleExpiredPollFunc:   func(sdk.Context, exported.Poll) error { return nil },
 		HandleFailedPollFunc:    func(sdk.Context, exported.Poll) error { return nil },
 		HandleCompletedPollFunc: func(sdk.Context, exported.Poll) error { return nil },
@@ -151,7 +151,7 @@ func TestMsgServer_VoteFailedPoll(t *testing.T) {
 
 	voteHandler := &exportedMock.VoteHandlerMock{
 		IsFalsyResultFunc:       func(codec.ProtoMarshaler) bool { return false },
-		HandleResultFunc:        func(sdk.Context, codec.ProtoMarshaler) error { return nil },
+		HandleResultFunc:        func(sdk.Context, exported.Poll) error { return nil },
 		HandleExpiredPollFunc:   func(sdk.Context, exported.Poll) error { return nil },
 		HandleFailedPollFunc:    func(sdk.Context, exported.Poll) error { return nil },
 		HandleCompletedPollFunc: func(sdk.Context, exported.Poll) error { return nil },

--- a/x/vote/types/vote_router.go
+++ b/x/vote/types/vote_router.go
@@ -77,8 +77,8 @@ func (w handlerWrapper) IsFalsyResult(result codec.ProtoMarshaler) bool {
 	return w.handler.IsFalsyResult(result)
 }
 
-func (w handlerWrapper) HandleResult(ctx sdk.Context, result codec.ProtoMarshaler) error {
-	return cache(w.handler.HandleResult)(ctx, result)
+func (w handlerWrapper) HandleResult(ctx sdk.Context, poll exported.Poll) error {
+	return cache(w.handler.HandleResult)(ctx, poll)
 }
 
 func (w handlerWrapper) HandleFailedPoll(ctx sdk.Context, poll exported.Poll) error {

--- a/x/vote/types/vote_router_test.go
+++ b/x/vote/types/vote_router_test.go
@@ -7,7 +7,6 @@ import (
 	"cosmossdk.io/log"
 	store "cosmossdk.io/store/types"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
-	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 
@@ -42,7 +41,7 @@ func TestVoteRouter(t *testing.T) {
 	}).Run(t)
 
 	withRegisteredHandler.When("handler changes state and emits event", func() {
-		handler.HandleResultFunc = func(ctx sdk.Context, _ codec.ProtoMarshaler) error {
+		handler.HandleResultFunc = func(ctx sdk.Context, _ exported.Poll) error {
 			ctx.KVStore(storeKey).Set([]byte("key1"), []byte("value"))
 
 			events.Emit(ctx, &Voted{})
@@ -84,7 +83,7 @@ func TestVoteRouter(t *testing.T) {
 		}).Run(t)
 
 	withRegisteredHandler.When("handler returns error", func() {
-		handler.HandleResultFunc = func(ctx sdk.Context, _ codec.ProtoMarshaler) error {
+		handler.HandleResultFunc = func(ctx sdk.Context, _ exported.Poll) error {
 			ctx.KVStore(storeKey).Set([]byte("key1"), []byte("value"))
 
 			events.Emit(ctx, &Voted{})


### PR DESCRIPTION
Summary

HandleResult in the EVM vote handler now takes the poll instead of just the tallied
result, checks that VoteEvents.Chain matches the poll's PollMetadata.Chain, and
resolves the chain keeper from the metadata. A result whose chain disagrees with the
poll's is rejected with an error and nothing gets confirmed. The vote.VoteHandler
interface changes accordingly, and x/vote's msg_server passes poll where it used
to pass poll.GetResult().
Why

HandleResult resolved ck from voteEvents.Chain, which is voter-supplied data
inside the result, and then called SetConfirmedEvent and EnqueueConfirmedEvent on
it. A threshold of one chain's maintainer set could vote on a poll opened for their own
chain while naming a different chain in the result, and have forged confirmed events
land in that chain's event queue. VoteEvents.ValidateBasic only checks that each
event agrees with m.Chain, so an internally consistent forgery passes.
