### PR TITLE
feat: speed up SubmitPubKey (#2389, private: #82)

### DIFF
--- a/.changeset/speed-up-submit-pub-key.md
+++ b/.changeset/speed-up-submit-pub-key.md
@@ -1,5 +1,0 @@
----
-'@axelar-network/axelar-core': patch
----
-
-Speed up SubmitPubKey by verifying the proof of ownership in the message handler (after the cheaper checks) and caching GetPermissionRole.

--- a/.changeset/speed-up-submit-pub-key.md
+++ b/.changeset/speed-up-submit-pub-key.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Speed up SubmitPubKey by verifying the proof of ownership in the message handler (after the cheaper checks) and caching GetPermissionRole.

--- a/x/multisig/keeper/genesis_test.go
+++ b/x/multisig/keeper/genesis_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"crypto/sha256"
 	"testing"
 
 	"cosmossdk.io/math"
@@ -92,8 +93,10 @@ func TestInitExportGenesis(t *testing.T) {
 		for _, v := range validators {
 			snapshotter.GetOperatorFunc = func(sdk.Context, sdk.AccAddress) sdk.ValAddress { return v.Address }
 
+			sender := rand.AccAddr()
 			sk := funcs.Must(btcec.NewPrivateKey())
-			msgServer.SubmitPubKey(sdk.WrapSDKContext(ctx), types.NewSubmitPubKeyRequest(rand.AccAddr(), keyID, sk.PubKey().SerializeCompressed(), ecdsa.Sign(sk, []byte(keyID)).Serialize()))
+			hash := sha256.Sum256([]byte(sender.String()))
+			msgServer.SubmitPubKey(sdk.WrapSDKContext(ctx), types.NewSubmitPubKeyRequest(sender, keyID, sk.PubKey().SerializeCompressed(), ecdsa.Sign(sk, hash[:]).Serialize()))
 		}
 
 		// Call EndBlocker for every block until timeout

--- a/x/multisig/keeper/msg_server.go
+++ b/x/multisig/keeper/msg_server.go
@@ -66,6 +66,15 @@ func (s msgServer) SubmitPubKey(c context.Context, req *types.SubmitPubKeyReques
 		return nil, fmt.Errorf("sender %s is not a registered proxy", req.Sender)
 	}
 
+	if err := keygenSession.CanAddKey(ctx.BlockHeight(), participant, req.PubKey); err != nil {
+		return nil, errorsmod.Wrap(err, "unable to add public key for keygen")
+	}
+
+	ctx.GasMeter().ConsumeGas(types.PubKeyOwnershipVerifyCost, "verify pub key ownership")
+	if err := req.VerifyPubKeyOwnership(); err != nil {
+		return nil, err
+	}
+
 	err = keygenSession.AddKey(ctx.BlockHeight(), participant, req.PubKey)
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "unable to add public key for keygen")

--- a/x/multisig/keeper/msg_server_test.go
+++ b/x/multisig/keeper/msg_server_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"crypto/sha256"
 	"errors"
 	"testing"
 
@@ -75,8 +76,10 @@ func TestMsgServer(t *testing.T) {
 		assert.Len(t, k.GetKeygenSessionsByExpiry(ctx, ctx.BlockHeight()+5), 0) // KeygenGracePeriod from custom params
 	})
 	requestIsMade := When("a request is made", func() {
+		sender := rand2.AccAddr()
 		sk := funcs.Must(btcec.NewPrivateKey())
-		req = types.NewSubmitPubKeyRequest(rand2.AccAddr(), keyID, sk.PubKey().SerializeCompressed(), ecdsa.Sign(sk, []byte(keyID)).Serialize())
+		hash := sha256.Sum256([]byte(sender.String()))
+		req = types.NewSubmitPubKeyRequest(sender, keyID, sk.PubKey().SerializeCompressed(), ecdsa.Sign(sk, hash[:]).Serialize())
 	})
 	pubKeyFails := Then("submit pubkey fails", func(t *testing.T) {
 		_, err := msgServer.SubmitPubKey(sdk.WrapSDKContext(ctx), req)
@@ -116,6 +119,40 @@ func TestMsgServer(t *testing.T) {
 					When2(keySessionExists).
 					When2(requestIsMade).
 					Then2(pubKeyFails),
+
+				whenSenderIsProxy.
+					When2(keySessionExists).
+					When("a request with a mismatched proof of ownership is made", func() {
+						sender := rand2.AccAddr()
+						sk := funcs.Must(btcec.NewPrivateKey())
+						hash := sha256.Sum256([]byte("not the sender"))
+
+						req = types.NewSubmitPubKeyRequest(sender, keyID, sk.PubKey().SerializeCompressed(), ecdsa.Sign(sk, hash[:]).Serialize())
+						assert.NoError(t, req.ValidateBasic())
+					}).
+					Then("submit pubkey fails and the verification is still charged for", func(t *testing.T) {
+						before := ctx.GasMeter().GasConsumed()
+						_, err := msgServer.SubmitPubKey(sdk.WrapSDKContext(ctx), req)
+
+						assert.Error(t, err)
+						assert.GreaterOrEqual(t, ctx.GasMeter().GasConsumed()-before, uint64(types.PubKeyOwnershipVerifyCost))
+					}),
+
+				When("the sender is a proxy of a non-participant", func() {
+					snapshotter.GetOperatorFunc = func(sdk.Context, sdk.AccAddress) sdk.ValAddress { return rand2.ValAddr() }
+				}).
+					When2(keySessionExists).
+					When("a request with a mismatched proof of ownership is made", func() {
+						sender := rand2.AccAddr()
+						sk := funcs.Must(btcec.NewPrivateKey())
+						hash := sha256.Sum256([]byte("not the sender"))
+
+						req = types.NewSubmitPubKeyRequest(sender, keyID, sk.PubKey().SerializeCompressed(), ecdsa.Sign(sk, hash[:]).Serialize())
+					}).
+					Then("submit pubkey fails before the proof of ownership is verified", func(t *testing.T) {
+						_, err := msgServer.SubmitPubKey(sdk.WrapSDKContext(ctx), req)
+						assert.ErrorContains(t, err, "not a participant")
+					}),
 
 				whenSenderIsProxy.
 					When2(keySessionExists).
@@ -164,8 +201,10 @@ func TestMsgServer(t *testing.T) {
 						for _, v := range validators {
 							snapshotter.GetOperatorFunc = func(sdk.Context, sdk.AccAddress) sdk.ValAddress { return v.Address }
 
+							sender := rand2.AccAddr()
 							sk := funcs.Must(btcec.NewPrivateKey())
-							req = types.NewSubmitPubKeyRequest(rand2.AccAddr(), keyID, sk.PubKey().SerializeCompressed(), ecdsa.Sign(sk, []byte(keyID)).Serialize())
+							hash := sha256.Sum256([]byte(sender.String()))
+							req = types.NewSubmitPubKeyRequest(sender, keyID, sk.PubKey().SerializeCompressed(), ecdsa.Sign(sk, hash[:]).Serialize())
 
 							_, err := msgServer.SubmitPubKey(sdk.WrapSDKContext(ctx), req)
 							assert.NoError(t, err)
@@ -207,8 +246,10 @@ func TestMsgServer(t *testing.T) {
 						for _, v := range validators {
 							snapshotter.GetOperatorFunc = func(sdk.Context, sdk.AccAddress) sdk.ValAddress { return v.Address }
 
+							sender := rand2.AccAddr()
 							sk := funcs.Must(btcec.NewPrivateKey())
-							req = types.NewSubmitPubKeyRequest(rand2.AccAddr(), keyID, sk.PubKey().SerializeCompressed(), ecdsa.Sign(sk, []byte(keyID)).Serialize())
+							hash := sha256.Sum256([]byte(sender.String()))
+							req = types.NewSubmitPubKeyRequest(sender, keyID, sk.PubKey().SerializeCompressed(), ecdsa.Sign(sk, hash[:]).Serialize())
 
 							_, err := msgServer.SubmitPubKey(sdk.WrapSDKContext(ctx), req)
 							assert.NoError(t, err)

--- a/x/multisig/types/keygen.go
+++ b/x/multisig/types/keygen.go
@@ -77,13 +77,8 @@ func (m KeygenSession) GetKeyID() exported.KeyID {
 	return m.Key.ID
 }
 
-// AddKey adds a new public key for the given participant into the keygen session
-func (m *KeygenSession) AddKey(blockHeight int64, participant sdk.ValAddress, pubKey exported.PublicKey) error {
-	if m.Key.PubKeys == nil {
-		m.Key.PubKeys = make(map[string]exported.PublicKey)
-		m.IsPubKeyReceived = make(map[string]bool)
-	}
-
+// CanAddKey returns an error if the given public key cannot be added to the keygen session.
+func (m KeygenSession) CanAddKey(blockHeight int64, participant sdk.ValAddress, pubKey exported.PublicKey) error {
 	if m.isExpired(blockHeight) {
 		return fmt.Errorf("keygen session %s has expired", m.GetKeyID())
 	}
@@ -102,6 +97,20 @@ func (m *KeygenSession) AddKey(blockHeight int64, participant sdk.ValAddress, pu
 
 	if m.State == exported.Completed && !m.isWithinGracePeriod(blockHeight) {
 		return fmt.Errorf("keygen session %s has closed", m.GetKeyID())
+	}
+
+	return nil
+}
+
+// AddKey adds a new public key for the given participant into the keygen session
+func (m *KeygenSession) AddKey(blockHeight int64, participant sdk.ValAddress, pubKey exported.PublicKey) error {
+	if err := m.CanAddKey(blockHeight, participant, pubKey); err != nil {
+		return err
+	}
+
+	if m.Key.PubKeys == nil {
+		m.Key.PubKeys = make(map[string]exported.PublicKey)
+		m.IsPubKeyReceived = make(map[string]bool)
 	}
 
 	m.addKey(participant, pubKey)

--- a/x/multisig/types/msg_submit_pub_key.go
+++ b/x/multisig/types/msg_submit_pub_key.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 
 	errorsmod "cosmossdk.io/errors"
+	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
@@ -11,6 +12,9 @@ import (
 )
 
 var _ sdk.Msg = &SubmitPubKeyRequest{}
+
+// The gas charged for VerifyPubKeyOwnership.
+const PubKeyOwnershipVerifyCost = storetypes.Gas(200_000)
 
 // NewSubmitPubKeyRequest constructor for SubmitPubKeyRequest
 func NewSubmitPubKeyRequest(sender sdk.AccAddress, keyID exported.KeyID, pubKey exported.PublicKey, signature Signature) *SubmitPubKeyRequest {
@@ -40,6 +44,10 @@ func (m SubmitPubKeyRequest) ValidateBasic() error {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 	}
 
+	return nil
+}
+
+func (m SubmitPubKeyRequest) VerifyPubKeyOwnership() error {
 	hash := sha256.Sum256([]byte(m.Sender))
 	if !m.Signature.Verify(hash[:], m.PubKey) {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "signature does not match the public key")

--- a/x/multisig/types/msg_submit_pub_key_test.go
+++ b/x/multisig/types/msg_submit_pub_key_test.go
@@ -1,0 +1,40 @@
+package types_test
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/axelarnetwork/axelar-core/testutils/rand"
+	"github.com/axelarnetwork/axelar-core/x/multisig/exported"
+	"github.com/axelarnetwork/axelar-core/x/multisig/types"
+	"github.com/axelarnetwork/utils/funcs"
+)
+
+func TestSubmitPubKeyRequest_VerifyPubKeyOwnership(t *testing.T) {
+	keyID := exported.KeyID(rand.HexStr(5))
+	newRequest := func(sender []byte, signedMessage string) *types.SubmitPubKeyRequest {
+		sk := funcs.Must(btcec.NewPrivateKey())
+		hash := sha256.Sum256([]byte(signedMessage))
+
+		return types.NewSubmitPubKeyRequest(sender, keyID, sk.PubKey().SerializeCompressed(), ecdsa.Sign(sk, hash[:]).Serialize())
+	}
+
+	t.Run("should accept a proof that matches the sender", func(t *testing.T) {
+		sender := rand.AccAddr()
+		req := newRequest(sender, sender.String())
+
+		assert.NoError(t, req.VerifyPubKeyOwnership())
+	})
+
+	t.Run("should reject a proof that does not match the sender, but only outside ValidateBasic", func(t *testing.T) {
+		sender := rand.AccAddr()
+		req := newRequest(sender, "not the sender")
+
+		assert.NoError(t, req.ValidateBasic())
+		assert.ErrorContains(t, req.VerifyPubKeyOwnership(), "signature does not match the public key")
+	})
+}

--- a/x/permission/exported/proto.go
+++ b/x/permission/exported/proto.go
@@ -1,12 +1,30 @@
 package exported
 
 import (
+	"reflect"
+	"sync"
+
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/cosmos/gogoproto/protoc-gen-gogo/descriptor"
 )
 
+// roleCache memoizes the permission role per concrete message type.
+var roleCache sync.Map // reflect.Type -> Role
+
 // GetPermissionRole returns the role that is defined for the given message. Returns ROLE_UNSPECIFIED if none is set.
 func GetPermissionRole(message descriptor.Message) Role {
+	key := reflect.TypeOf(message)
+	if cached, ok := roleCache.Load(key); ok {
+		return cached.(Role)
+	}
+
+	role := resolvePermissionRole(message)
+	roleCache.Store(key, role)
+
+	return role
+}
+
+func resolvePermissionRole(message descriptor.Message) Role {
 	_, d := descriptor.ForMessage(message)
 	v, err := proto.GetExtension(d.GetOptions(), E_PermissionRole)
 	if err != nil {


### PR DESCRIPTION
CPI-468

## Description

Two independent reductions in the cost of processing a `SubmitPubKeyRequest`.

**1. Cache the permission role per message type** (`x/permission/exported/proto.go`)

`GetPermissionRole` resolved the role through `descriptor.ForMessage`, which gunzips and unmarshals the message's entire compiled proto file descriptor on every call. The role is a compile-time property of the message type, so the result is now memoized in a `sync.Map` keyed by concrete Go type.

**2. Verify the proof of ownership in the handler** (`x/multisig/types/msg_submit_pub_key.go`, `x/multisig/keeper/msg_server.go`)

The proof of ownership check is an ECDSA verification, the most expensive step in handling the message by a wide margin, and it ran in `ValidateBasic` alongside the cheap encoding checks. It moves to the `SubmitPubKey` handler, after the keygen session lookup and the proxy lookup, so it runs only for a registered validator proxy submitting to an existing keygen session.

Fixes CPI-405
