### PR TITLE
chore: add changeset for EndBlocker per-item failure isolation

### DIFF
--- a/.changeset/isolate-endblocker-per-item-failures.md
+++ b/.changeset/isolate-endblocker-per-item-failures.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Isolate per-item work in the EndBlockers so a single failing item is dead-lettered and logged instead of aborting FinalizeBlock and halting the chain.


### PR DESCRIPTION
## Description

Release note for the EndBlocker hardening split out of #2366, which makes the EndBlockers dead-letter a failing item instead of aborting `FinalizeBlock`.

This is the base of a stack of PRs; it adds only the changeset, no code. The code lands in the PRs stacked on top of this one.

## Todos

- [ ] Unit tests (n/a: no code change)
- [ ] Manual tests
- [ ] Documentation
- [x] Connect epics/issues
- [x] Tag type of change
- [ ] Upgrade handler (not needed: no state-schema change)

## Steps to Test

n/a

## Expected Behaviour

The note is swept into CHANGELOG.md by the next release PR.

## Other Notes

Please merge alongside or after #2366's split code PRs, so the note does not ship in a tag ahead of the code.