### PR TITLE
fix(multisig): don't orphan signing sessions on handler failure

### DIFF
--- a/x/multisig/abci.go
+++ b/x/multisig/abci.go
@@ -50,28 +50,30 @@ func handleSignings(ctx sdk.Context, k types.Keeper, rewarder types.Rewarder) {
 	// we handle sessions that'll expire on the next block,
 	// to avoid waiting for an additional block
 	for _, signing := range k.GetSigningSessionsByExpiry(ctx, ctx.BlockHeight()+1) {
-		_ = utils.RunCached(ctx, k, func(cachedCtx sdk.Context) ([]abci.ValidatorUpdate, error) {
-			k.DeleteSigningSession(cachedCtx, signing.GetID())
-			module := signing.GetModule()
+		k.DeleteSigningSession(ctx, signing.GetID())
+		module := signing.GetModule()
 
-			pool := rewarder.GetPool(cachedCtx, types.ModuleName)
-			slices.ForEach(signing.GetMissingParticipants(), pool.ClearRewards)
+		pool := rewarder.GetPool(ctx, types.ModuleName)
+		slices.ForEach(signing.GetMissingParticipants(), pool.ClearRewards)
 
-			if signing.State != exported.Completed {
-				events.Emit(cachedCtx, types.NewSigningExpired(signing.GetID()))
-				k.Logger(cachedCtx).Info("signing session expired",
-					"sig_id", signing.GetID(),
-				)
+		if signing.State != exported.Completed {
+			events.Emit(ctx, types.NewSigningExpired(signing.GetID()))
+			k.Logger(ctx).Info("signing session expired",
+				"sig_id", signing.GetID(),
+			)
 
-				funcs.MustNoErr(k.GetSigRouter().GetHandler(module).HandleFailed(cachedCtx, signing.GetMetadata()))
-				return nil, nil
-			}
+			abortSigning(ctx, k, signing)
+			continue
+		}
 
+		completed := utils.RunCached(ctx, k, func(cachedCtx sdk.Context) (bool, error) {
 			sig := funcs.Must(signing.Result())
 
-			slices.ForEach(sig.GetParticipants(), func(p sdk.ValAddress) { funcs.MustNoErr(pool.ReleaseRewards(p)) })
+			cachedPool := rewarder.GetPool(cachedCtx, types.ModuleName)
+			slices.ForEach(sig.GetParticipants(), func(p sdk.ValAddress) { funcs.MustNoErr(cachedPool.ReleaseRewards(p)) })
+
 			if err := k.GetSigRouter().GetHandler(module).HandleCompleted(cachedCtx, &sig, signing.GetMetadata()); err != nil {
-				return nil, errors.Wrap(err, "failed to handle completed signature")
+				return false, errors.Wrap(err, "failed to handle completed signature")
 			}
 
 			events.Emit(cachedCtx, types.NewSigningCompleted(signing.GetID()))
@@ -81,7 +83,21 @@ func handleSignings(ctx sdk.Context, k types.Keeper, rewarder types.Rewarder) {
 				"module", module,
 			)
 
-			return nil, nil
+			return true, nil
 		})
+
+		if !completed {
+			k.Logger(ctx).Error("failed to handle completed signing session, aborting signing",
+				"sig_id", signing.GetID(),
+				"module", module,
+			)
+			abortSigning(ctx, k, signing)
+		}
 	}
+}
+
+func abortSigning(ctx sdk.Context, k types.Keeper, signing types.SigningSession) {
+	_ = utils.RunCached(ctx, k, func(cachedCtx sdk.Context) (struct{}, error) {
+		return struct{}{}, k.GetSigRouter().GetHandler(signing.GetModule()).HandleFailed(cachedCtx, signing.GetMetadata())
+	})
 }

--- a/x/multisig/abci_test.go
+++ b/x/multisig/abci_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gogoproto "github.com/cosmos/gogoproto/proto"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/exp/maps"
 
@@ -311,26 +312,124 @@ func TestEndBlocker(t *testing.T) {
 						sigHandler.HandleCompletedFunc = func(sdk.Context, utils.ValidatedProtoMarshaler, codec.ProtoMarshaler) error {
 							return fmt.Errorf("some error")
 						}
+						sigHandler.HandleFailedFunc = func(sdk.Context, codec.ProtoMarshaler) error { return nil }
 					}).
-					Then("recover and roll back state", func(t *testing.T) {
+					Then("keep session cleanup and abort the signing", func(t *testing.T) {
+						storeKey := store.NewKVStoreKey("cache")
+						deletedKey := []byte("deleted")
+						clearedKey := []byte("rewards-cleared")
+						// the pool writes through the ctx it was requested with, so a
+						// ClearRewards call on a rolled-back cached ctx leaves no trace
+						rewarder.GetPoolFunc = func(c sdk.Context, _ string) reward.RewardPool {
+							return &rewardmock.RewardPoolMock{
+								ClearRewardsFunc:   func(sdk.ValAddress) { c.MultiStore().GetKVStore(storeKey).Set(clearedKey, []byte{}) },
+								ReleaseRewardsFunc: func(sdk.ValAddress) error { return nil },
+							}
+						}
+						k.DeleteSigningSessionFunc = func(ctx sdk.Context, _ uint64) {
+							ctx.MultiStore().GetKVStore(storeKey).Set(deletedKey, []byte{})
+						}
+						_, err := multisig.EndBlocker(ctx, k, rewarder)
+						assert.NoError(t, err)
+						assert.True(t, ctx.MultiStore().GetKVStore(storeKey).Has(deletedKey))
+						assert.True(t, ctx.MultiStore().GetKVStore(storeKey).Has(clearedKey))
+						assert.Equal(t, len(k.DeleteSigningSessionCalls()), len(k.GetSigningSessionsByExpiry(ctx, ctx.BlockHeight()+1)))
+						assert.Equal(t, len(sigHandler.HandleFailedCalls()), len(k.GetSigningSessionsByExpiry(ctx, ctx.BlockHeight()+1)))
+					}),
+
+				When("multiple completed signing sessions are triggered", func() {
+					k.GetSigningSessionsByExpiryFunc = func(_ sdk.Context, expiry int64) []types.SigningSession {
+						if expiry != ctx.BlockHeight()+1 {
+							return nil
+						}
+						return []types.SigningSession{
+							newSigningSession(module),
+							newSigningSession(module),
+						}
+					}
+				}).
+					When("sigHandler panics", func() {
+						sigHandler.HandleCompletedFunc = func(sdk.Context, utils.ValidatedProtoMarshaler, codec.ProtoMarshaler) error {
+							panic("panic in sig handler")
+						}
+						sigHandler.HandleFailedFunc = func(sdk.Context, codec.ProtoMarshaler) error { return nil }
+					}).
+					Then("recover, keep session cleanup and abort the signing", func(t *testing.T) {
 						pool := rewardmock.RewardPoolMock{
 							ClearRewardsFunc:   func(sdk.ValAddress) {},
 							ReleaseRewardsFunc: func(sdk.ValAddress) error { return nil },
 						}
 						rewarder.GetPoolFunc = func(sdk.Context, string) reward.RewardPool { return &pool }
 						storeKey := store.NewKVStoreKey("cache")
-						rolledBackKey := []byte("ephemeral")
+						deletedKey := []byte("deleted")
 						k.DeleteSigningSessionFunc = func(ctx sdk.Context, _ uint64) {
-							ctx.MultiStore().GetKVStore(storeKey).Set(rolledBackKey, []byte{})
+							ctx.MultiStore().GetKVStore(storeKey).Set(deletedKey, []byte{})
 						}
-						_, err := multisig.EndBlocker(ctx, k, rewarder)
-						assert.NoError(t, err)
-						assert.False(t, ctx.MultiStore().GetKVStore(storeKey).Has(rolledBackKey))
-						assert.Equal(t, len(k.DeleteSigningSessionCalls()), len(k.GetSigningSessionsByExpiry(ctx, ctx.BlockHeight()+1)))
+
+						assert.NotPanics(t, func() {
+							_, err := multisig.EndBlocker(ctx, k, rewarder)
+							assert.NoError(t, err)
+						})
+						assert.True(t, ctx.MultiStore().GetKVStore(storeKey).Has(deletedKey))
+						assert.Len(t, k.DeleteSigningSessionCalls(), 2)
+						assert.Len(t, sigHandler.HandleFailedCalls(), 2)
+					}),
+
+				When("a pending signing session expiry equal to the block height", func() {
+					k.GetSigningSessionsByExpiryFunc = func(_ sdk.Context, expiry int64) []types.SigningSession {
+						if expiry != ctx.BlockHeight()+1 {
+							return nil
+						}
+
+						return []types.SigningSession{{
+							ID:     uint64(rand.PosI64()),
+							Module: module,
+							Key:    typestestutils.Key(),
+							State:  exported.Pending,
+						}}
+					}
+				}).
+					When("HandleFailed panics", func() {
+						sigHandler.HandleFailedFunc = func(sdk.Context, codec.ProtoMarshaler) error {
+							panic("panic in HandleFailed")
+						}
+					}).
+					Then("recover, keep session cleanup, forfeited rewards and expiry event", func(t *testing.T) {
+						storeKey := store.NewKVStoreKey("cache")
+						deletedKey := []byte("deleted")
+						clearedKey := []byte("rewards-cleared")
+						rewarder.GetPoolFunc = func(c sdk.Context, _ string) reward.RewardPool {
+							return &rewardmock.RewardPoolMock{
+								ClearRewardsFunc: func(sdk.ValAddress) { c.MultiStore().GetKVStore(storeKey).Set(clearedKey, []byte{}) },
+							}
+						}
+						k.DeleteSigningSessionFunc = func(ctx sdk.Context, _ uint64) {
+							ctx.MultiStore().GetKVStore(storeKey).Set(deletedKey, []byte{})
+						}
+
+						assert.NotPanics(t, func() {
+							_, err := multisig.EndBlocker(ctx, k, rewarder)
+							assert.NoError(t, err)
+						})
+						assert.True(t, ctx.MultiStore().GetKVStore(storeKey).Has(deletedKey))
+						assert.True(t, ctx.MultiStore().GetKVStore(storeKey).Has(clearedKey))
+						assert.True(t, hasEvent(ctx, &types.SigningExpired{}))
+						assert.Len(t, k.DeleteSigningSessionCalls(), 1)
 					}),
 			).
 			Run(t, 20)
 	})
+}
+
+func hasEvent(ctx sdk.Context, event gogoproto.Message) bool {
+	eventType := gogoproto.MessageName(event)
+	for _, e := range ctx.EventManager().Events() {
+		if e.Type == eventType {
+			return true
+		}
+	}
+
+	return false
 }
 
 func newSigningSession(module string) types.SigningSession {

--- a/x/multisig/keeper/genesis_test.go
+++ b/x/multisig/keeper/genesis_test.go
@@ -187,7 +187,10 @@ func TestInitExportGenesis(t *testing.T) {
 				assert.Error(t, k.AssignKey(ctx, chain.Name, keyID))
 				assert.NoError(t, k.RotateKey(ctx, chain.Name))
 				assert.NoError(t, k.Sign(ctx, keyID, rand.Bytes(exported.HashLength), chain.Module))
-				assert.Len(t, k.ExportGenesis(ctx).SigningSessions, 2)
+				// the session started by whenSigningSessionExists expired during the
+				// EndBlocker loop of the second whenKeyExists, so only the session
+				// started right above is left
+				assert.Len(t, k.ExportGenesis(ctx).SigningSessions, 1)
 			}).
 			Run(t)
 


### PR DESCRIPTION
## Description

Split out of #2366, which hardens the EndBlockers so one failing item can no longer abort `FinalizeBlock`.

This PR is part of a stack; it is based on `fix/endblocker-00-changeset`. Review only the top commit.
Previous PR in the stack: https://github.com/axelarnetwork/axelar-core/pull/2392

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [x] Connect epics/issues
- [x] Tag type of change
- [ ] Upgrade handler (not needed: no state-schema change)

## Steps to Test

```
go test ./utils/... ./x/multisig/... ./x/vote/... ./x/axelarnet/... ./x/nexus/... ./x/reward/...
```

## Expected Behaviour

A failing item is dead-lettered and logged; the rest of the block proceeds.

## Other Notes

Diff of the full stack is byte-identical to #2366.