### PR TITLE
fix(vote): run HandleFailedPoll when a completed poll can't be processed

### DIFF
--- a/x/vote/abci.go
+++ b/x/vote/abci.go
@@ -68,6 +68,12 @@ func handlePollsAtExpiry(ctx sdk.Context, k types.Voter) error {
 
 		if !handled {
 			logger.Error("failed to handle poll at expiry, dropping poll")
+
+			if poll.GetState() == exported.Completed {
+				_ = utils.RunCached(ctx, k, func(cachedCtx sdk.Context) (struct{}, error) {
+					return struct{}{}, k.GetVoteRouter().GetHandler(poll.GetModule()).HandleFailedPoll(cachedCtx, poll)
+				})
+			}
 		}
 
 		k.DeletePoll(ctx, pollID)

--- a/x/vote/abci_test.go
+++ b/x/vote/abci_test.go
@@ -178,7 +178,7 @@ func TestHandlePollsAtExpiry(t *testing.T) {
 				return fmt.Errorf("handler failed")
 			}
 		}).
-		Then("should roll back the handler, delete the poll and not halt", func(t *testing.T) {
+		Then("should roll back the handler, notify failure, delete the poll and not halt", func(t *testing.T) {
 			storeKey := store.NewKVStoreKey("cache")
 			handledKey := []byte("handled")
 			deletedKey := []byte("deleted")
@@ -186,6 +186,7 @@ func TestHandlePollsAtExpiry(t *testing.T) {
 				ctx.MultiStore().GetKVStore(storeKey).Set(handledKey, []byte{})
 				return fmt.Errorf("handler failed")
 			}
+			voteHandler.HandleFailedPollFunc = func(sdk.Context, exported.Poll) error { return nil }
 			keeper.DeletePollFunc = func(ctx sdk.Context, _ exported.PollID) {
 				ctx.MultiStore().GetKVStore(storeKey).Set(deletedKey, []byte{})
 			}
@@ -196,6 +197,7 @@ func TestHandlePollsAtExpiry(t *testing.T) {
 			assert.False(t, ctx.MultiStore().GetKVStore(storeKey).Has(handledKey))
 			assert.True(t, ctx.MultiStore().GetKVStore(storeKey).Has(deletedKey))
 			assert.Len(t, keeper.DeletePollCalls(), 1)
+			assert.Len(t, voteHandler.HandleFailedPollCalls(), 1)
 		}).
 		Run(t, repeats)
 


### PR DESCRIPTION
## Description

Split out of #2366, which hardens the EndBlockers so one failing item can no longer abort `FinalizeBlock`.

This PR is part of a stack; it is based on `fix/endblocker-04-axelarnet-transfer-relock`. Review only the top commit.
Previous PR in the stack: https://github.com/axelarnetwork/axelar-core/pull/2396

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [x] Connect epics/issues
- [x] Tag type of change
- [ ] Upgrade handler (not needed: no state-schema change)

## Steps to Test

```
go test ./utils/... ./x/multisig/... ./x/vote/... ./x/axelarnet/... ./x/nexus/... ./x/reward/...
```

## Expected Behaviour

A failing item is dead-lettered and logged; the rest of the block proceeds.

## Other Notes

Diff of the full stack is byte-identical to #2366.