### PR TITLE
fix(utils): skip dangling queue entries instead of blocking the queue

### DIFF
--- a/utils/queuer.go
+++ b/utils/queuer.go
@@ -92,7 +92,10 @@ func (q GeneralKVQueue) dequeue(value codec.ProtoMarshaler, iter db.Iterator, fi
 		q.store.cdc.MustUnmarshalLengthPrefixed(iter.Value(), &key)
 
 		if ok := q.store.Get(KeyFromBz(key.Value), value); !ok {
-			return false
+			q.logger.Error(fmt.Sprintf("dropping dangling queue entry pointing to %s", string(key.Value)))
+			q.store.Delete(KeyFromBz(iter.Key()))
+
+			continue
 		}
 
 		isQualified := filter(value)

--- a/utils/queuer_test.go
+++ b/utils/queuer_test.go
@@ -342,3 +342,31 @@ func TestNewSequenceKVQueue(t *testing.T) {
 	}).Repeat(repeats))
 
 }
+
+func TestGeneralKVQueueDanglingEntry(t *testing.T) {
+	ctx, cdc := setup(t)
+	ns := NewNormalizedStore(ctx.KVStore(store.NewKVStoreKey("dangling")), cdc)
+
+	kvQueue := NewGeneralKVQueue("test-queue", ns, log.NewTestLogger(t), func(value codec.ProtoMarshaler) Key {
+		v := value.(*gogoprototypes.UInt64Value)
+		bz := make([]byte, 8)
+		binary.BigEndian.PutUint64(bz, v.Value)
+
+		return KeyFromBz(bz)
+	})
+
+	first := gogoprototypes.UInt64Value{Value: 1}
+	second := gogoprototypes.UInt64Value{Value: 2}
+	kvQueue.Enqueue(KeyFromStr("first"), &first)
+	kvQueue.Enqueue(KeyFromStr("second"), &second)
+
+	// simulate a broken invariant: the first item's data record is gone
+	ns.Delete(KeyFromStr("first"))
+
+	var actual gogoprototypes.UInt64Value
+	assert.True(t, kvQueue.Dequeue(&actual))
+	assert.Equal(t, second, actual)
+
+	// the dangling entry must not keep blocking the head of the queue
+	assert.True(t, kvQueue.IsEmpty())
+}

--- a/x/vote/abci_test.go
+++ b/x/vote/abci_test.go
@@ -157,19 +157,6 @@ func TestHandlePollsAtExpiry(t *testing.T) {
 		Run(t)
 
 	givenPollQueue.
-		When2(withPoll(true, exported.Pending)).
-		When("the poll does not exist", func() {
-			keeper.GetPollFunc = func(sdk.Context, exported.PollID) (exported.Poll, bool) { return nil, false }
-		}).
-		Then("should skip the poll without halting", func(t *testing.T) {
-			assert.NotPanics(t, func() {
-				assert.NoError(t, handlePollsAtExpiry(ctx, keeper))
-			})
-			assert.Len(t, keeper.DeletePollCalls(), 0)
-		}).
-		Run(t, repeats)
-
-	givenPollQueue.
 		When2(withPoll(true, exported.Completed)).
 		When("the vote handler fails", func() {
 			poll.GetResultFunc = func() codec.ProtoMarshaler { return &gogoprototypes.StringValue{} }


### PR DESCRIPTION
## Description

Split out of #2366, which hardens the EndBlockers so one failing item can no longer abort `FinalizeBlock`.

This PR is part of a stack; it is based on `fix/endblocker-05-vote-handle-failed-poll`. Review only the top commit.
Previous PR in the stack: https://github.com/axelarnetwork/axelar-core/pull/2397

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [x] Connect epics/issues
- [x] Tag type of change
- [ ] Upgrade handler (not needed: no state-schema change)

## Steps to Test

```
go test ./utils/... ./x/multisig/... ./x/vote/... ./x/axelarnet/... ./x/nexus/... ./x/reward/...
```

## Expected Behaviour

A failing item is dead-lettered and logged; the rest of the block proceeds.

## Other Notes

Diff of the full stack is byte-identical to #2366.