### PR TITLE
fix(nexus): isolate chain-maintainer deregistration in EndBlocker

### DIFF
--- a/x/nexus/abci.go
+++ b/x/nexus/abci.go
@@ -12,9 +12,7 @@ import (
 
 // EndBlocker called every block
 func EndBlocker(ctx sdk.Context, n types.Nexus, r types.RewardKeeper, s types.Snapshotter) ([]abci.ValidatorUpdate, error) {
-	if err := checkChainMaintainers(ctx, n, r, s); err != nil {
-		return nil, err
-	}
+	checkChainMaintainers(ctx, n, r, s)
 
 	routeQueuedMessages(ctx, n)
 
@@ -25,13 +23,12 @@ func EndBlocker(ctx sdk.Context, n types.Nexus, r types.RewardKeeper, s types.Sn
 // - if a chain maintainer has missed voting for too many polls, then it will be de-registered
 // - if a chain maintainer has voted incorrectly for too many polls, then it will be de-registered
 // - if a chain maintainer does not active proxy set, then it will be de-registered
-func checkChainMaintainers(ctx sdk.Context, n types.Nexus, r types.RewardKeeper, s types.Snapshotter) error {
+func checkChainMaintainers(ctx sdk.Context, n types.Nexus, r types.RewardKeeper, s types.Snapshotter) {
 	for _, chain := range n.GetChains(ctx) {
 		if !n.IsChainActivated(ctx, chain) {
 			continue
 		}
 
-		rewardPool := r.GetPool(ctx, chain.Name.String())
 		params := n.GetParams(ctx)
 		window := int(params.ChainMaintainerCheckWindow)
 
@@ -46,26 +43,34 @@ func checkChainMaintainers(ctx sdk.Context, n types.Nexus, r types.RewardKeeper,
 				continue
 			}
 
-			rewardPool.ClearRewards(maintainerState.GetAddress())
-			if err := n.RemoveChainMaintainer(ctx, chain, maintainerState.GetAddress()); err != nil {
-				return err
-			}
+			deregistered := utils.RunCached(ctx, n, func(cachedCtx sdk.Context) (bool, error) {
+				r.GetPool(cachedCtx, chain.Name.String()).ClearRewards(maintainerState.GetAddress())
 
-			ctx.EventManager().EmitEvent(
-				sdk.NewEvent(
-					types.EventTypeChainMaintainer,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-					sdk.NewAttribute(sdk.AttributeKeyAction, types.AttributeValueDeregister),
-					sdk.NewAttribute(types.AttributeKeyChain, chain.Name.String()),
-					sdk.NewAttribute(types.AttributeKeyChainMaintainerAddress, maintainerState.GetAddress().String()),
-				),
-			)
+				if err := n.RemoveChainMaintainer(cachedCtx, chain, maintainerState.GetAddress()); err != nil {
+					return false, err
+				}
+
+				cachedCtx.EventManager().EmitEvent(
+					sdk.NewEvent(
+						types.EventTypeChainMaintainer,
+						sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
+						sdk.NewAttribute(sdk.AttributeKeyAction, types.AttributeValueDeregister),
+						sdk.NewAttribute(types.AttributeKeyChain, chain.Name.String()),
+						sdk.NewAttribute(types.AttributeKeyChainMaintainerAddress, maintainerState.GetAddress().String()),
+					),
+				)
+
+				return true, nil
+			})
+
+			if !deregistered {
+				n.Logger(ctx).Error(fmt.Sprintf("failed to deregister validator %s as maintainer for chain %s", maintainerState.GetAddress().String(), chain.Name))
+				continue
+			}
 
 			n.Logger(ctx).Info(fmt.Sprintf("deregistered validator %s as maintainer for chain %s", maintainerState.GetAddress().String(), chain.Name))
 		}
 	}
-
-	return nil
 }
 
 func routeQueuedMessages(ctx sdk.Context, n types.Nexus) {

--- a/x/nexus/abci_test.go
+++ b/x/nexus/abci_test.go
@@ -13,8 +13,11 @@ import (
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
 	"github.com/axelarnetwork/axelar-core/x/nexus"
 	"github.com/axelarnetwork/axelar-core/x/nexus/exported"
+	exportedmock "github.com/axelarnetwork/axelar-core/x/nexus/exported/mock"
 	"github.com/axelarnetwork/axelar-core/x/nexus/types"
 	"github.com/axelarnetwork/axelar-core/x/nexus/types/mock"
+	rewardexported "github.com/axelarnetwork/axelar-core/x/reward/exported"
+	rewardmock "github.com/axelarnetwork/axelar-core/x/reward/exported/mock"
 	. "github.com/axelarnetwork/utils/test"
 )
 
@@ -112,6 +115,64 @@ func TestRouteQueuedMessages(t *testing.T) {
 			for i, call := range n.RouteMessageCalls() {
 				assert.Equal(t, msgs[i].ID, call.ID)
 			}
+		}).
+		Run(t)
+}
+
+func TestCheckChainMaintainers(t *testing.T) {
+	var (
+		ctx      sdk.Context
+		n        *mock.NexusMock
+		reward   *mock.RewardKeeperMock
+		snapshot *mock.SnapshotterMock
+	)
+
+	givenDeregisterableMaintainer := Given("a chain with a maintainer that must be deregistered", func() {
+		ctx = sdk.NewContext(fake.NewMultiStore(), tmproto.Header{}, false, log.NewTestLogger(t))
+		chain := exported.Chain{Name: exported.ChainName("ethereum")}
+		maintainer := rand.ValAddr()
+
+		maintainerState := &exportedmock.MaintainerStateMock{
+			GetAddressFunc:          func() sdk.ValAddress { return maintainer },
+			CountMissingVotesFunc:   func(int) uint64 { return 0 },
+			CountIncorrectVotesFunc: func(int) uint64 { return 0 },
+		}
+
+		n = &mock.NexusMock{
+			LoggerFunc:           func(_ sdk.Context) log.Logger { return log.NewTestLogger(t) },
+			GetChainsFunc:        func(sdk.Context) []exported.Chain { return []exported.Chain{chain} },
+			IsChainActivatedFunc: func(sdk.Context, exported.Chain) bool { return true },
+			GetParamsFunc:        func(sdk.Context) types.Params { return types.DefaultParams() },
+			GetChainMaintainerStatesFunc: func(sdk.Context, exported.Chain) []exported.MaintainerState {
+				return []exported.MaintainerState{maintainerState}
+			},
+			DequeueRouteMessageFunc: func(sdk.Context) (exported.GeneralMessage, bool) {
+				return exported.GeneralMessage{}, false
+			},
+		}
+		reward = &mock.RewardKeeperMock{
+			GetPoolFunc: func(sdk.Context, string) rewardexported.RewardPool {
+				return &rewardmock.RewardPoolMock{ClearRewardsFunc: func(sdk.ValAddress) {}}
+			},
+		}
+		// no active proxy => the maintainer must be deregistered
+		snapshot = &mock.SnapshotterMock{
+			GetProxyFunc: func(sdk.Context, sdk.ValAddress) (sdk.AccAddress, bool) { return nil, false },
+		}
+	})
+
+	givenDeregisterableMaintainer.
+		When("removing the maintainer fails", func() {
+			n.RemoveChainMaintainerFunc = func(sdk.Context, exported.Chain, sdk.ValAddress) error {
+				return fmt.Errorf("remove failed")
+			}
+		}).
+		Then("the end blocker recovers and does not halt", func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				_, err := nexus.EndBlocker(ctx, n, reward, snapshot)
+				assert.NoError(t, err)
+			})
+			assert.Len(t, n.RemoveChainMaintainerCalls(), 1)
 		}).
 		Run(t)
 }


### PR DESCRIPTION
## Description

Split out of #2366, which hardens the EndBlockers so one failing item can no longer abort `FinalizeBlock`.

This PR is part of a stack; it is based on `fix/endblocker-07-utils-log-level`. Review only the top commit.
Previous PR in the stack: https://github.com/axelarnetwork/axelar-core/pull/2399

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [x] Connect epics/issues
- [x] Tag type of change
- [ ] Upgrade handler (not needed: no state-schema change)

## Steps to Test

```
go test ./utils/... ./x/multisig/... ./x/vote/... ./x/axelarnet/... ./x/nexus/... ./x/reward/...
```

## Expected Behaviour

A failing item is dead-lettered and logged; the rest of the block proceeds.

## Other Notes

Diff of the full stack is byte-identical to #2366.