### PR TITLE
fix: verify the IBC channel exists before registering a cosmos chain

### DIFF
--- a/.changeset/verify-channel-before-registering-ibc-path.md
+++ b/.changeset/verify-channel-before-registering-ibc-path.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Require the IBC path passed to AddCosmosBasedChain to point at a channel that already exists and is open.

--- a/x/axelarnet/keeper/msg_server.go
+++ b/x/axelarnet/keeper/msg_server.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
 
 	"github.com/axelarnetwork/axelar-core/utils"
 	"github.com/axelarnetwork/axelar-core/utils/events"
@@ -127,6 +128,10 @@ func (s msgServer) AddCosmosBasedChain(c context.Context, req *types.AddCosmosBa
 		return nil, fmt.Errorf("ibc path %s is already registered for chain %s", req.IBCPath, chain)
 	}
 
+	if err := s.validateIBCPathIsBound(ctx, req.IBCPath); err != nil {
+		return nil, err
+	}
+
 	chain := nexus.Chain{
 		Name:                  req.CosmosChain,
 		KeyType:               tss.None,
@@ -155,6 +160,27 @@ func (s msgServer) AddCosmosBasedChain(c context.Context, req *types.AddCosmosBa
 	}
 
 	return &types.AddCosmosBasedChainResponse{}, nil
+}
+
+// validateIBCPathIsBound checks that the given IBC path points at a channel that already exists and
+// is open.
+func (s msgServer) validateIBCPathIsBound(ctx sdk.Context, ibcPath string) error {
+	pathSplit := strings.SplitN(ibcPath, "/", 2)
+	if len(pathSplit) != 2 {
+		return fmt.Errorf("invalid IBC path %s", ibcPath)
+	}
+	portID, channelID := pathSplit[0], pathSplit[1]
+
+	channel, found := s.GetChannel(ctx, portID, channelID)
+	if !found {
+		return fmt.Errorf("channel %s on port %s does not exist", channelID, portID)
+	}
+
+	if channel.State != channeltypes.OPEN {
+		return fmt.Errorf("channel %s on port %s is in state %s, expected %s", channelID, portID, channel.State, channeltypes.OPEN)
+	}
+
+	return nil
 }
 
 // RegisterAsset handles register an asset to a cosmos based chain

--- a/x/axelarnet/keeper/msg_server_test.go
+++ b/x/axelarnet/keeper/msg_server_test.go
@@ -12,6 +12,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	ibctypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
 	ibcclient "github.com/cosmos/ibc-go/v10/modules/core/exported"
 	"github.com/stretchr/testify/assert"
 
@@ -405,17 +406,21 @@ func TestRetryIBCTransfer(t *testing.T) {
 
 func TestAddCosmosBasedChain(t *testing.T) {
 	var (
-		server types.MsgServiceServer
-		k      keeper.Keeper
-		nexusK *mock.NexusMock
-		ctx    sdk.Context
-		req    *types.AddCosmosBasedChainRequest
+		server   types.MsgServiceServer
+		k        keeper.Keeper
+		nexusK   *mock.NexusMock
+		channelK *mock.ChannelKeeperMock
+		ctx      sdk.Context
+		req      *types.AddCosmosBasedChainRequest
 	)
 	repeats := 20
 
 	givenMsgServer := Given("an axelarnet msg server", func() {
-		ctx, k, _, _ = setup(t)
+		ctx, k, channelK, _ = setup(t)
 		k.InitGenesis(ctx, types.DefaultGenesisState())
+		channelK.GetChannelFunc = func(sdk.Context, string, string) (channeltypes.Channel, bool) {
+			return channeltypes.Channel{State: channeltypes.OPEN}, true
+		}
 		nexusK = &mock.NexusMock{
 			GetChainFunc:              func(ctx sdk.Context, chain nexus.ChainName) (nexus.Chain, bool) { return nexus.Chain{}, false },
 			GetChainByNativeAssetFunc: func(ctx sdk.Context, asset string) (nexus.Chain, bool) { return nexus.Chain{}, false },
@@ -508,6 +513,20 @@ func TestAddCosmosBasedChain(t *testing.T) {
 				}
 			}).
 				Then2(requestFails("asset already registered")),
+
+			When("the channel does not exist yet", func() {
+				channelK.GetChannelFunc = func(sdk.Context, string, string) (channeltypes.Channel, bool) {
+					return channeltypes.Channel{}, false
+				}
+			}).
+				Then2(requestFails("does not exist")),
+
+			When("the channel is not open", func() {
+				channelK.GetChannelFunc = func(sdk.Context, string, string) (channeltypes.Channel, bool) {
+					return channeltypes.Channel{State: channeltypes.INIT}, true
+				}
+			}).
+				Then2(requestFails("expected STATE_OPEN")),
 		).
 		Run(t, repeats)
 


### PR DESCRIPTION
## Summary

`AddCosmosBasedChain` now validates the IBC path before it writes anything. The channel
has to already exist and be `STATE_OPEN`, otherwise the request fails. The check runs
ahead of `SetChain`, so a rejected request leaves no partial state behind.

## Why

Channel ids come off a counter that `ChanOpenInit` increments for any funded account,
with no ACL. Whoever opens the id first owns the channel we then route that chain's
transfers over.

CPI-520