### PR TITLE
fix(vote): isolate poll handling in EndBlocker

### DIFF
--- a/x/vote/abci.go
+++ b/x/vote/abci.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/axelarnetwork/axelar-core/utils"
 	"github.com/axelarnetwork/axelar-core/x/vote/exported"
 	"github.com/axelarnetwork/axelar-core/x/vote/types"
 )
@@ -24,38 +25,49 @@ func handlePollsAtExpiry(ctx sdk.Context, k types.Voter) error {
 		handledPolls++
 
 		pollID := pollMetadata.ID
-		poll, ok := k.GetPoll(ctx, pollID)
-		if !ok {
-			panic(fmt.Errorf("poll %s not found", pollID))
-		}
-
 		logger := k.Logger(ctx).With("poll", pollID.String())
 
-		voteHandler := k.GetVoteRouter().GetHandler(poll.GetModule())
-		switch poll.GetState() {
-		case exported.Pending:
-			logger.Debug("poll expired")
-			if err := voteHandler.HandleExpiredPoll(ctx, poll); err != nil {
-				return err
+		poll, ok := k.GetPoll(ctx, pollID)
+		if !ok {
+			logger.Error("poll not found")
+			continue
+		}
+
+		handled := utils.RunCached(ctx, k, func(cachedCtx sdk.Context) (bool, error) {
+			voteHandler := k.GetVoteRouter().GetHandler(poll.GetModule())
+
+			switch poll.GetState() {
+			case exported.Pending:
+				logger.Debug("poll expired")
+				if err := voteHandler.HandleExpiredPoll(cachedCtx, poll); err != nil {
+					return false, err
+				}
+
+			case exported.Failed:
+				logger.Debug("poll failed")
+				if err := voteHandler.HandleFailedPoll(cachedCtx, poll); err != nil {
+					return false, err
+				}
+
+			case exported.Completed:
+				if voteHandler.IsFalsyResult(poll.GetResult()) {
+					logger.Debug("poll completed with falsy result")
+				} else {
+					logger.Debug("poll completed with final result")
+				}
+				if err := voteHandler.HandleCompletedPoll(cachedCtx, poll); err != nil {
+					return false, err
+				}
+
+			default:
+				return false, fmt.Errorf("unexpected poll state %s", poll.GetState().String())
 			}
 
-		case exported.Failed:
-			logger.Debug("poll failed")
-			if err := voteHandler.HandleFailedPoll(ctx, poll); err != nil {
-				return err
-			}
+			return true, nil
+		})
 
-		case exported.Completed:
-			if voteHandler.IsFalsyResult(poll.GetResult()) {
-				logger.Debug("poll completed with falsy result")
-			} else {
-				logger.Debug("poll completed with final result")
-			}
-			if err := voteHandler.HandleCompletedPoll(ctx, poll); err != nil {
-				return err
-			}
-		default:
-			panic(fmt.Errorf("unexpected poll state %s", poll.GetState().String()))
+		if !handled {
+			logger.Error("failed to handle poll at expiry, dropping poll")
 		}
 
 		k.DeletePoll(ctx, pollID)

--- a/x/vote/abci_test.go
+++ b/x/vote/abci_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"cosmossdk.io/log"
+	store "cosmossdk.io/store/types"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -155,4 +156,128 @@ func TestHandlePollsAtExpiry(t *testing.T) {
 		}).
 		Run(t)
 
+	givenPollQueue.
+		When2(withPoll(true, exported.Pending)).
+		When("the poll does not exist", func() {
+			keeper.GetPollFunc = func(sdk.Context, exported.PollID) (exported.Poll, bool) { return nil, false }
+		}).
+		Then("should skip the poll without halting", func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				assert.NoError(t, handlePollsAtExpiry(ctx, keeper))
+			})
+			assert.Len(t, keeper.DeletePollCalls(), 0)
+		}).
+		Run(t, repeats)
+
+	givenPollQueue.
+		When2(withPoll(true, exported.Completed)).
+		When("the vote handler fails", func() {
+			poll.GetResultFunc = func() codec.ProtoMarshaler { return &gogoprototypes.StringValue{} }
+			voteHandler.IsFalsyResultFunc = func(codec.ProtoMarshaler) bool { return false }
+			voteHandler.HandleCompletedPollFunc = func(ctx sdk.Context, poll exported.Poll) error {
+				return fmt.Errorf("handler failed")
+			}
+		}).
+		Then("should roll back the handler, delete the poll and not halt", func(t *testing.T) {
+			storeKey := store.NewKVStoreKey("cache")
+			handledKey := []byte("handled")
+			deletedKey := []byte("deleted")
+			voteHandler.HandleCompletedPollFunc = func(ctx sdk.Context, poll exported.Poll) error {
+				ctx.MultiStore().GetKVStore(storeKey).Set(handledKey, []byte{})
+				return fmt.Errorf("handler failed")
+			}
+			keeper.DeletePollFunc = func(ctx sdk.Context, _ exported.PollID) {
+				ctx.MultiStore().GetKVStore(storeKey).Set(deletedKey, []byte{})
+			}
+
+			assert.NotPanics(t, func() {
+				assert.NoError(t, handlePollsAtExpiry(ctx, keeper))
+			})
+			assert.False(t, ctx.MultiStore().GetKVStore(storeKey).Has(handledKey))
+			assert.True(t, ctx.MultiStore().GetKVStore(storeKey).Has(deletedKey))
+			assert.Len(t, keeper.DeletePollCalls(), 1)
+		}).
+		Run(t, repeats)
+
+	givenPollQueue.
+		When2(withPoll(true, exported.Pending)).
+		When("the vote handler panics", func() {
+			voteHandler.HandleExpiredPollFunc = func(ctx sdk.Context, poll exported.Poll) error {
+				panic("panic in vote handler")
+			}
+		}).
+		Then("should recover, delete the poll and not halt", func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				assert.NoError(t, handlePollsAtExpiry(ctx, keeper))
+			})
+			assert.Len(t, keeper.DeletePollCalls(), 1)
+		}).
+		Run(t, repeats)
+
+	givenPollQueue.
+		When2(withPoll(true, exported.NonExistent)).
+		Then("should delete the poll and not halt on unexpected state", func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				assert.NoError(t, handlePollsAtExpiry(ctx, keeper))
+			})
+			assert.Len(t, keeper.DeletePollCalls(), 1)
+		}).
+		Run(t, repeats)
+
+	givenPollQueue.
+		When("two expired completed polls where the first handler fails", func() {
+			failingPoll := &exportedMock.PollMock{
+				GetIDFunc:     func() exported.PollID { return exported.PollID(1) },
+				GetModuleFunc: func() string { return evmtypes.ModuleName },
+				GetStateFunc:  func() exported.PollState { return exported.Completed },
+				GetResultFunc: func() codec.ProtoMarshaler { return &gogoprototypes.StringValue{} },
+			}
+			healthyPoll := &exportedMock.PollMock{
+				GetIDFunc:     func() exported.PollID { return exported.PollID(2) },
+				GetModuleFunc: func() string { return evmtypes.ModuleName },
+				GetStateFunc:  func() exported.PollState { return exported.Completed },
+				GetResultFunc: func() codec.ProtoMarshaler { return &gogoprototypes.StringValue{} },
+			}
+
+			dequeued := 0
+			pollQueue.DequeueIfFunc = func(value codec.ProtoMarshaler, filter func(value codec.ProtoMarshaler) bool) bool {
+				if dequeued >= 2 {
+					return false
+				}
+				dequeued++
+
+				pollMetadata := exported.PollMetadata{
+					ID:        exported.PollID(dequeued),
+					State:     exported.Completed,
+					ExpiresAt: ctx.BlockHeight(),
+				}
+				bz, _ := pollMetadata.Marshal()
+				if err := value.Unmarshal(bz); err != nil {
+					panic(err)
+				}
+
+				return true
+			}
+			keeper.GetPollFunc = func(_ sdk.Context, id exported.PollID) (exported.Poll, bool) {
+				if id == exported.PollID(1) {
+					return failingPoll, true
+				}
+				return healthyPoll, true
+			}
+			voteHandler.IsFalsyResultFunc = func(codec.ProtoMarshaler) bool { return false }
+			voteHandler.HandleCompletedPollFunc = func(_ sdk.Context, p exported.Poll) error {
+				if p.GetID() == exported.PollID(1) {
+					return fmt.Errorf("handler failed")
+				}
+				return nil
+			}
+		}).
+		Then("should still handle the second poll", func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				assert.NoError(t, handlePollsAtExpiry(ctx, keeper))
+			})
+			assert.Len(t, voteHandler.HandleCompletedPollCalls(), 2)
+			assert.Len(t, keeper.DeletePollCalls(), 2)
+		}).
+		Run(t, repeats)
 }


### PR DESCRIPTION
## Description

Split out of #2366, which hardens the EndBlockers so one failing item can no longer abort `FinalizeBlock`.

This PR is part of a stack; it is based on `fix/endblocker-02-multisig-keygen`. Review only the top commit.
Previous PR in the stack: https://github.com/axelarnetwork/axelar-core/pull/2406

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [x] Connect epics/issues
- [x] Tag type of change
- [ ] Upgrade handler (not needed: no state-schema change)

## Steps to Test

```
go test ./utils/... ./x/multisig/... ./x/vote/... ./x/axelarnet/... ./x/nexus/... ./x/reward/...
```

## Expected Behaviour

A failing item is dead-lettered and logged; the rest of the block proceeds.

## Other Notes

Diff of the full stack is byte-identical to #2366.