### PR TITLE
fix(axelarnet): isolate failed-transfer re-locking in EndBlocker

### DIFF
--- a/x/axelarnet/abci.go
+++ b/x/axelarnet/abci.go
@@ -10,7 +10,6 @@ import (
 	"github.com/axelarnetwork/axelar-core/utils/events"
 	"github.com/axelarnetwork/axelar-core/x/axelarnet/keeper"
 	"github.com/axelarnetwork/axelar-core/x/axelarnet/types"
-	"github.com/axelarnetwork/utils/funcs"
 )
 
 // EndBlocker called every block, process inflation, update validator set.
@@ -56,19 +55,34 @@ func EndBlocker(ctx sdk.Context, bk types.BaseKeeper, ibcKeeper keeper.IBCKeeper
 
 	// re-lock tokens to escrow and set transfer as failed
 	for _, f := range failed {
-		lockableAsset, err := n.NewLockableAsset(ctx, ibcKeeper, bank, f.Token)
-		funcs.MustNoErr(err)
-		funcs.MustNoErr(lockableAsset.LockFrom(ctx, types.AxelarIBCAccount))
+		relocked := utils.RunCached(ctx, bk, func(cachedCtx sdk.Context) (bool, error) {
+			lockableAsset, err := n.NewLockableAsset(cachedCtx, ibcKeeper, bank, f.Token)
+			if err != nil {
+				return false, err
+			}
 
-		funcs.MustNoErr(bk.SetTransferFailed(ctx, f.ID))
+			if err := lockableAsset.LockFrom(cachedCtx, types.AxelarIBCAccount); err != nil {
+				return false, err
+			}
 
-		events.Emit(ctx,
-			&types.IBCTransferFailed{
-				ID:        f.ID,
-				Sequence:  f.Sequence,
-				PortID:    f.PortID,
-				ChannelID: f.ChannelID,
-			})
+			if err := bk.SetTransferFailed(cachedCtx, f.ID); err != nil {
+				return false, err
+			}
+
+			events.Emit(cachedCtx,
+				&types.IBCTransferFailed{
+					ID:        f.ID,
+					Sequence:  f.Sequence,
+					PortID:    f.PortID,
+					ChannelID: f.ChannelID,
+				})
+
+			return true, nil
+		})
+
+		if !relocked {
+			bk.Logger(ctx).Error(fmt.Sprintf("failed to re-lock tokens for failed IBC transfer %s with id %s to %s", f.Token, f.ID.String(), f.Receiver))
+		}
 	}
 
 	return nil, nil

--- a/x/axelarnet/abci_test.go
+++ b/x/axelarnet/abci_test.go
@@ -237,6 +237,35 @@ func TestEndBlocker(t *testing.T) {
 			assert.Equal(t, ibcTransferErrors, len(bk.SetTransferFailedCalls()))
 		}).
 		Run(t, repeats)
+
+	lockFromCalls := 0
+	givenTransferQueue.
+		When("all ibc transfers fail and re-locking the first one fails", func() {
+			queueSize = int(rand.I64Between(3, 10))
+			ibcTransferErrors = queueSize
+			lockFromCalls = 0
+
+			nexusK.NewLockableAssetFunc = func(ctx sdk.Context, ibc nexustypes.IBCKeeper, bank nexustypes.BankKeeper, coin sdk.Coin) (nexus.LockableAsset, error) {
+				return &nexusmock.LockableAssetMock{
+					LockFromFunc: func(ctx sdk.Context, fromAddr sdk.AccAddress) error {
+						lockFromCalls++
+						if lockFromCalls == 1 {
+							return fmt.Errorf("lock failed")
+						}
+						return nil
+					},
+				}, nil
+			}
+		}).
+		Then("should not halt and still re-lock the remaining failed transfers", func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				_, err := EndBlocker(ctx, bk, ibcK, nexusK, bankK)
+				assert.NoError(t, err)
+			})
+			assert.Equal(t, queueSize, lockFromCalls)
+			assert.Equal(t, queueSize-1, len(bk.SetTransferFailedCalls()))
+		}).
+		Run(t, repeats)
 }
 
 // TestEndBlocker_RelocksTokensOnFailure verifies that EndBlocker calls LockFrom


### PR DESCRIPTION
## Description

Split out of #2366, which hardens the EndBlockers so one failing item can no longer abort `FinalizeBlock`.

This PR is part of a stack; it is based on `fix/endblocker-03-vote-poll-isolation`. Review only the top commit.
Previous PR in the stack: https://github.com/axelarnetwork/axelar-core/pull/2407

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [x] Connect epics/issues
- [x] Tag type of change
- [ ] Upgrade handler (not needed: no state-schema change)

## Steps to Test

```
go test ./utils/... ./x/multisig/... ./x/vote/... ./x/axelarnet/... ./x/nexus/... ./x/reward/...
```

## Expected Behaviour

A failing item is dead-lettered and logged; the rest of the block proceeds.

## Other Notes

Diff of the full stack is byte-identical to #2366.