### PR TITLE
fix(reward): isolate inflation handling in EndBlocker

### DIFF
--- a/x/reward/abci.go
+++ b/x/reward/abci.go
@@ -7,6 +7,7 @@ import (
 	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
+	"github.com/axelarnetwork/axelar-core/utils"
 	multisigTypes "github.com/axelarnetwork/axelar-core/x/multisig/types"
 	"github.com/axelarnetwork/axelar-core/x/reward/exported"
 	"github.com/axelarnetwork/axelar-core/x/reward/types"
@@ -17,10 +18,16 @@ import (
 
 // EndBlocker is called at the end of every block, process external chain voting inflation
 func EndBlocker(ctx sdk.Context, k types.Rewarder, n types.Nexus, m mintkeeper.Keeper, s types.Staker, slasher types.Slasher, msig types.MultiSig, ss types.Snapshotter) ([]abci.ValidatorUpdate, error) {
-	handleExternalChainVotingInflation(ctx, k, n, m, s, slasher, ss)
-	err := handleKeyMgmtInflation(ctx, k, m, s, slasher, msig, ss)
+	_ = utils.RunCached(ctx, k, func(cachedCtx sdk.Context) (struct{}, error) {
+		handleExternalChainVotingInflation(cachedCtx, k, n, m, s, slasher, ss)
+		return struct{}{}, nil
+	})
 
-	return nil, err
+	_ = utils.RunCached(ctx, k, func(cachedCtx sdk.Context) (struct{}, error) {
+		return struct{}{}, handleKeyMgmtInflation(cachedCtx, k, m, s, slasher, msig, ss)
+	})
+
+	return nil, nil
 }
 
 func addRewardsByConsensusPower(ctx sdk.Context, s types.Staker, rewardPool exported.RewardPool, validators []snapshot.ValidatorI, totalReward sdk.DecCoin) {

--- a/x/reward/abci_test.go
+++ b/x/reward/abci_test.go
@@ -182,3 +182,15 @@ func (s *endBlockerTestSetup) runEndBlocker() error {
 	_, err := reward.EndBlocker(s.ctx, s.rewarder, s.nexusKeeper, s.mintK, s.staker, s.slasher, s.msig, s.snapshotter)
 	return err
 }
+
+func TestEndBlocker_DoesNotHaltOnInflationFailure(t *testing.T) {
+	s := newEndBlockerTestSetup(t)
+	s.rewarder.LoggerFunc = func(sdk.Context) log.Logger { return log.NewTestLogger(t) }
+	s.staker.IterateBondedValidatorsByPowerFunc = func(ctx context.Context, fn func(index int64, validator stakingtypes.ValidatorI) (stop bool)) error {
+		return errors.New("staking iteration failed")
+	}
+
+	assert.NotPanics(t, func() {
+		assert.NoError(t, s.runEndBlocker())
+	})
+}


### PR DESCRIPTION
## Description

Split out of #2366, which hardens the EndBlockers so one failing item can no longer abort `FinalizeBlock`.

This PR is part of a stack; it is based on `fix/endblocker-08-nexus-maintainer-dereg`. Review only the top commit.
Previous PR in the stack: https://github.com/axelarnetwork/axelar-core/pull/2412

## Todos

- [x] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [x] Connect epics/issues
- [x] Tag type of change
- [ ] Upgrade handler (not needed: no state-schema change)

## Steps to Test

```
go test ./utils/... ./x/multisig/... ./x/vote/... ./x/axelarnet/... ./x/nexus/... ./x/reward/...
```

## Expected Behaviour

A failing item is dead-lettered and logged; the rest of the block proceeds.

## Other Notes

Diff of the full stack is byte-identical to #2366.