### PR TITLE
fix: only interpose ibc-hooks middleware when hooks are enabled

### DIFF
--- a/.changeset/no-ibc-hooks-middleware-when-hooks-disabled.md
+++ b/.changeset/no-ibc-hooks-middleware-when-hooks-disabled.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-core': patch
+---
+
+Interpose the ibc-hooks IBC middleware on received packets only when ibc wasm hooks are enabled.

--- a/app/app.go
+++ b/app/app.go
@@ -287,7 +287,7 @@ func NewAxelarApp(
 
 	// set routers
 	GetKeeper[nexusKeeper.Keeper](keepers).SetMessageRouter(initMessageRouter(keepers))
-	GetKeeper[ibckeeper.Keeper](keepers).SetRouter(initIBCRouter(keepers, initIBCMiddleware(keepers, ics4Wrapper)))
+	GetKeeper[ibckeeper.Keeper](keepers).SetRouter(initIBCRouter(keepers, initIBCMiddleware(keepers, ics4Wrapper, wasmHooks)))
 
 	// light clients are no longer implicit in ibc-go v10; they must be registered
 	// as modular routes on the client keeper
@@ -402,7 +402,7 @@ func InitICS4Wrapper(keepers *KeeperCache, wasmHooks *ibchooks.WasmHooks) ibchoo
 	}
 }
 
-func initIBCMiddleware(keepers *KeeperCache, ics4Middleware ibchooks.ICS4Middleware) ibchooks.IBCMiddleware {
+func initIBCMiddleware(keepers *KeeperCache, ics4Middleware ibchooks.ICS4Middleware, wasmHooks *ibchooks.WasmHooks) porttypes.IBCModule {
 	// IBCModule deals with received IBC packets.
 	ibcModule := axelarnet.NewAxelarnetIBCModule(
 		transfer.NewIBCModule(*GetKeeper[ibctransferkeeper.Keeper](keepers)),
@@ -410,6 +410,10 @@ func initIBCMiddleware(keepers *KeeperCache, ics4Middleware ibchooks.ICS4Middlew
 		GetKeeper[nexusKeeper.Keeper](keepers),
 		axelarbankkeeper.NewBankKeeper(GetKeeper[bankkeeper.BaseKeeper](keepers)),
 	)
+
+	if wasmHooks == nil {
+		return ibcModule
+	}
 
 	// By merging the middlewares the receiving IBC Module has access to all registered hooks in the ICS4Middleware
 	return ibchooks.NewIBCMiddleware(ibcModule, &ics4Middleware)

--- a/app/wasm_test.go
+++ b/app/wasm_test.go
@@ -15,7 +15,10 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	ibchooks "github.com/cosmos/ibc-apps/modules/ibc-hooks/v10"
+	ibctransfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
 	ibcclient "github.com/cosmos/ibc-go/v10/modules/core/02-client/types"
+	ibckeeper "github.com/cosmos/ibc-go/v10/modules/core/keeper"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/axelarnetwork/axelar-core/app"
@@ -23,6 +26,7 @@ import (
 	"github.com/axelarnetwork/axelar-core/cmd/axelard/cmd"
 	"github.com/axelarnetwork/axelar-core/testutils/fake"
 	"github.com/axelarnetwork/axelar-core/testutils/rand"
+	"github.com/axelarnetwork/axelar-core/x/axelarnet"
 	nexus "github.com/axelarnetwork/axelar-core/x/nexus/exported"
 	nexusmock "github.com/axelarnetwork/axelar-core/x/nexus/types/mock"
 	"github.com/axelarnetwork/utils/funcs"
@@ -289,6 +293,14 @@ func TestICSMiddleWare(t *testing.T) {
 			// this is the focus of the test, we need to ensure that the hooks and wrapper are correctly set up for each valid wasm/hooks flag combination
 			wasmHooks := app.InitWasmHooks(keys)
 			ics4Wrapper := app.InitICS4Wrapper(axelarApp.Keepers, wasmHooks)
+
+			transferRoute, hasRoute := app.GetKeeper[ibckeeper.Keeper](axelarApp.Keepers).PortKeeper.Router.Route(ibctransfertypes.ModuleName)
+			assert.True(t, hasRoute)
+			if testCase.hooks == "true" {
+				assert.IsType(t, ibchooks.IBCMiddleware{}, transferRoute)
+			} else {
+				assert.IsType(t, axelarnet.AxelarnetIBCModule{}, transferRoute)
+			}
 
 			ctx := sdk.NewContext(fake.NewMultiStore(), tmproto.Header{}, false, log.NewTestLogger(t))
 			packet := &mock.PacketIMock{


### PR DESCRIPTION
Fixes CPI-527

## Summary
`initIBCMiddleware` now takes the `*ibchooks.WasmHooks` built by `InitWasmHooks` and only
wraps the axelarnet module in `ibchooks.NewIBCMiddleware` when it's non-nil. With hooks
disabled it returns the bare `AxelarnetIBCModule`, so the transfer port route no longer goes
through ibc-hooks. The return type widens to `porttypes.IBCModule`, which `initIBCRouter`
already accepted. `InitICS4Wrapper` is unchanged.
