### PR TITLE
chore(test): fix one-eighth helper name

### DIFF
--- a/testutils/rand/rand_test.go
+++ b/testutils/rand/rand_test.go
@@ -17,7 +17,7 @@ func TestIntGen(t *testing.T) {
 
 func TestRandBoolGen(t *testing.T) {
 	t.Run("return given number of elements", boolTake13)
-	t.Run("correct ratio", ratioConvergesToOneEigth)
+	t.Run("correct ratio", ratioConvergesToOneEighth)
 }
 
 func TestUintGen(t *testing.T) {
@@ -84,7 +84,7 @@ func boolTake13(t *testing.T) {
 }
 
 // this test is testing distribution sampling, so in very rare cases the test can fail (outlier sampling)
-func ratioConvergesToOneEigth(t *testing.T) {
+func ratioConvergesToOneEighth(t *testing.T) {
 	expectedRatio := 1.0 / 8
 	g := Bools(expectedRatio)
 


### PR DESCRIPTION
## Description

Rename the private test helper `ratioConvergesToOneEigth` to `ratioConvergesToOneEighth` and update its call site. The test calculation and assertion are unchanged.

## Todos

- [x] Unit tests
- [x] Manual tests: not applicable
- [x] Documentation: not applicable
- [x] Connect epics/issues: not applicable
- [x] Tag type of change: test
- [x] Upgrade handler: not applicable

## Steps to Test

Run `go test ./testutils/rand`.

## Expected Behaviour

The package tests pass exactly as before with the corrected helper name.

## Other Notes

No production code changes.